### PR TITLE
fix incorrect name of systick struct

### DIFF
--- a/src/rp2040/hardware_structs/include/hardware/structs/systick.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/systick.h
@@ -17,6 +17,6 @@ typedef struct {
     io_ro_32 calib;
 } systick_hw_t;
 
-#define mpu_hw ((systick_hw_t *const)(PPB_BASE + M0PLUS_SYST_CSR_OFFSET))
+#define systick_hw ((systick_hw_t *const)(PPB_BASE + M0PLUS_SYST_CSR_OFFSET))
 
 #endif


### PR DESCRIPTION
It looks like systick.h was derived from mpu.h, but not all the relevant changes happened.
