### PR TITLE
fix #if in hardware/structs/dma.h

### DIFF
--- a/src/rp2040/hardware_structs/include/hardware/structs/dma.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/dma.h
@@ -70,7 +70,7 @@ typedef struct {
 #define dma_debug_hw ((dma_debug_hw_t *const)(DMA_BASE + DMA_CH0_DBG_CTDREQ_OFFSET))
 
 static inline void check_dma_channel_param(uint channel) {
-#if PARAM_ASSERTIONS_ENABLED(DMA)
+#if PARAM_ASSERTIONS_ENABLED_DMA
     // this method is used a lot by inline functions so avoid code bloat by deferring to function
     extern void check_dma_channel_param_impl(uint channel);
     check_dma_channel_param_impl(channel);

--- a/src/rp2040/hardware_structs/include/hardware/structs/dma.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/dma.h
@@ -10,13 +10,6 @@
 #include "hardware/address_mapped.h"
 #include "hardware/platform_defs.h"
 #include "hardware/regs/dma.h"
-#include "pico/assert.h"
-
-
-// PICO_CONFIG: PARAM_ASSERTIONS_ENABLED_DMA, Enable/disable DMA assertions, type=bool, default=0, group=hardware_dma
-#ifndef PARAM_ASSERTIONS_ENABLED_DMA
-#define PARAM_ASSERTIONS_ENABLED_DMA 0
-#endif
 
 typedef struct {
     io_rw_32 read_addr;
@@ -68,18 +61,5 @@ typedef struct {
 
 #define dma_hw ((dma_hw_t *const)DMA_BASE)
 #define dma_debug_hw ((dma_debug_hw_t *const)(DMA_BASE + DMA_CH0_DBG_CTDREQ_OFFSET))
-
-static inline void check_dma_channel_param(uint channel) {
-#if PARAM_ASSERTIONS_ENABLED_DMA
-    // this method is used a lot by inline functions so avoid code bloat by deferring to function
-    extern void check_dma_channel_param_impl(uint channel);
-    check_dma_channel_param_impl(channel);
-#endif
-}
-
-inline static dma_channel_hw_t *dma_channel_hw_addr(uint channel) {
-    check_dma_channel_param(channel);
-    return &dma_hw->ch[channel];
-}
 
 #endif

--- a/src/rp2_common/hardware_dma/include/hardware/dma.h
+++ b/src/rp2_common/hardware_dma/include/hardware/dma.h
@@ -10,6 +10,7 @@
 #include "pico.h"
 #include "hardware/structs/dma.h"
 #include "hardware/regs/dreq.h"
+#include "pico/assert.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,6 +36,24 @@ extern "C" {
 
 // this is not defined in generated dreq.h
 #define DREQ_FORCE  63
+
+// PICO_CONFIG: PARAM_ASSERTIONS_ENABLED_DMA, Enable/disable DMA assertions, type=bool, default=0, group=hardware_dma
+#ifndef PARAM_ASSERTIONS_ENABLED_DMA
+#define PARAM_ASSERTIONS_ENABLED_DMA 0
+#endif
+
+static inline void check_dma_channel_param(uint channel) {
+#if PARAM_ASSERTIONS_ENABLED(DMA)
+    // this method is used a lot by inline functions so avoid code bloat by deferring to function
+    extern void check_dma_channel_param_impl(uint channel);
+    check_dma_channel_param_impl(channel);
+#endif
+}
+
+inline static dma_channel_hw_t *dma_channel_hw_addr(uint channel) {
+    check_dma_channel_param(channel);
+    return &dma_hw->ch[channel];
+}
 
 /*! \brief Mark a dma channel as used
  *  \ingroup hardware_dma


### PR DESCRIPTION
I suspect the user's intent was to use "PARAM_ASSERTIONS_ENABLED_DMA" (default setting generated on lines 17-18).
