### PR TITLE
Add flash_get_unique_id to hardware_flash

### DIFF
--- a/docs/index.h
+++ b/docs/index.h
@@ -44,6 +44,7 @@
  * \defgroup pico_stdlib pico_stdlib
  * \defgroup pico_sync pico_sync
  * \defgroup pico_time pico_time
+ * \defgroup pico_unique_id pico_unique_id
  * \defgroup pico_util pico_util
  * @}
  *

--- a/src/rp2_common/CMakeLists.txt
+++ b/src/rp2_common/CMakeLists.txt
@@ -37,6 +37,7 @@ if (NOT PICO_BARE_METAL)
     pico_add_subdirectory(boot_stage2)
 
     pico_add_subdirectory(pico_multicore)
+    pico_add_subdirectory(pico_unique_id)
 
     pico_add_subdirectory(pico_bit_ops)
     pico_add_subdirectory(pico_divider)

--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -171,7 +171,7 @@ void flash_get_unique_id(uint8_t *id_out) {
 #else
     uint8_t txbuf[FLASH_RUID_TOTAL_BYTES] = {0};
     uint8_t rxbuf[FLASH_RUID_TOTAL_BYTES] = {0};
-    txbuf[0] = 0x4b;
+    txbuf[0] = FLASH_RUID_CMD;
     flash_do_cmd(txbuf, rxbuf, FLASH_RUID_TOTAL_BYTES);
     for (int i = 0; i < FLASH_RUID_DATA_BYTES; i++)
         id_out[i] = rxbuf[i + 1 + FLASH_RUID_DUMMY_BYTES];

--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -112,6 +112,7 @@ void __no_inline_not_in_flash_func(flash_range_program)(uint32_t flash_offs, con
 //-----------------------------------------------------------------------------
 // Lower-level flash access functions
 
+#if !PICO_NO_FLASH
 // Bitbanging the chip select using IO overrides, in case RAM-resident IRQs
 // are still running, and the FIFO bottoms out. (the bootrom does the same)
 static void flash_cs_force(bool high) {
@@ -159,6 +160,7 @@ static void __no_inline_not_in_flash_func(flash_do_cmd)(const uint8_t *txbuf, ui
     flash_flush_cache();
     flash_enable_xip_via_boot2();
 }
+#endif
 
 // Use standard RUID command to get a unique identifier for the flash (and
 // hence the board)

--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -115,7 +115,7 @@ void __no_inline_not_in_flash_func(flash_range_program)(uint32_t flash_offs, con
 #if !PICO_NO_FLASH
 // Bitbanging the chip select using IO overrides, in case RAM-resident IRQs
 // are still running, and the FIFO bottoms out. (the bootrom does the same)
-static void flash_cs_force(bool high) {
+static void __no_inline_not_in_flash_func(flash_cs_force)(bool high) {
     uint32_t field_val = high ?
         IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_VALUE_HIGH :
         IO_QSPI_GPIO_QSPI_SS_CTRL_OUTOVER_VALUE_LOW;

--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -18,6 +18,8 @@
 #define FLASH_SECTOR_SIZE (1u << 12)
 #define FLASH_BLOCK_SIZE (1u << 16)
 
+#define FLASH_UNIQUE_ID_SIZE_BYTES 8
+
 /** \file flash.h
  *  \defgroup hardware_flash hardware_flash
  *
@@ -27,6 +29,10 @@
  * executing from flash. In this case you must perform your own
  * synchronisation to make sure no XIP accesses take place during flash
  * programming.
+ *
+ * Likewise they are *unsafe* if you have interrupt handlers or an interrupt
+ * vector table in flash, so you must disable interrupts before calling in
+ * this case.
  *
  * If PICO_NO_FLASH=1 is not defined (i.e. if the program is built to run from
  * flash) then these functions will make a static copy of the second stage
@@ -54,6 +60,19 @@ void flash_range_erase(uint32_t flash_offs, size_t count);
  * \param data Pointer to the data to program into flash
  * \param count Number of bytes to program. Must be a multiple of 256 bytes (one page).
  */
+
 void flash_range_program(uint32_t flash_offs, const uint8_t *data, size_t count);
+
+/*! \brief Get flash unique 64 bit identifier
+ *  \ingroup hardware_flash
+ *
+ * Use a standard 4Bh RUID instruction to retrieve the 64 bit unique
+ * identifier from a flash device attached to the QSPI interface. Since there
+ * is a 1:1 association between the MCU and this flash, this also serves as a
+ * unique identifier for the board.
+ *
+ *  \param id_out Pointer to an 8-byte buffer to which the ID will be written
+ */
+void flash_get_unique_id(uint8_t *id_out);
 
 #endif

--- a/src/rp2_common/pico_unique_id/CMakeLists.txt
+++ b/src/rp2_common/pico_unique_id/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(pico_unique_id INTERFACE)
+
+target_sources(pico_unique_id INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/unique_id.c
+)
+
+target_include_directories(pico_unique_id INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+
+target_link_libraries(pico_unique_id INTERFACE hardware_flash)

--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -31,7 +31,19 @@ extern "C" {
  * flash-resident interrupt routines to be disabled when called into.
  */
 
-#define PICO_UNIQUE_ID_SIZE_BYTES 8
+#define PICO_UNIQUE_BOARD_ID_SIZE_BYTES 8
+
+/**
+ * \brief Unique board identifier
+ * \ingroup unique_id
+ *
+ * This struct is suitable for holding the unique identifier of a NOR flash
+ * device on an RP2040-based board. It contains an array of
+ * PICO_UNIQUE_BOARD_ID_SIZE_BYTES identifier bytes.
+ */
+typedef struct {
+	uint8_t id[PICO_UNIQUE_BOARD_ID_SIZE_BYTES];
+} pico_unique_board_id_t;
 
 /*! \brief Get unique ID
  *  \ingroup unique_id
@@ -42,9 +54,9 @@ extern "C" {
  *
  * On PICO_NO_FLASH builds the unique identifier is set to all 0xEE.
  *
- * \param id_out an 8-byte buffer to which the identifer will be written.
+ * \param id_out a pointer to a pico_unique_board_id_t struct, to which the identifier will be written
  */
-void pico_get_unique_id(uint8_t *id_out);
+void pico_get_unique_board_id(pico_unique_board_id_t *id_out);
 
 #ifdef __cplusplus
 }

--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -48,7 +48,6 @@ typedef struct {
 /*! \brief Get unique ID
  *  \ingroup unique_id
  *
-
  * Get the unique 64-bit device identifier which was retrieved from the
  * external NOR flash device at boot.
  *

--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_UNIQUE_ID_H_
+#define _PICO_UNIQUE_ID_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** \file pico/unique_id.h
+ *  \defgroup unique_id unique_id
+ *
+ * Unique device ID access API
+ *
+ * RP2040 does not have an on-board unique identifier (all instances of RP2040
+ * silicon are identical and have no persistent state). However, RP2040 boots
+ * from serial NOR flash devices which have a 64-bit unique ID as a standard
+ * feature, and there is a 1:1 association between RP2040 and flash, so this
+ * is suitable for use as a unique identifier for an RP2040-based board.
+ *
+ * This library injects a call to the flash_get_unique_id function from the
+ * hardware_flash library, to run before main, and stores the result in a
+ * static location which can safely be accessed at any time via
+ * pico_get_unique_id().
+ *
+ * This avoids some pitfalls of the hardware_flash API, which requires any
+ * flash-resident interrupt routines to be disabled when called into.
+ */
+
+#define PICO_UNIQUE_ID_SIZE_BYTES 8
+
+/*! \brief Get unique ID
+ *  \ingroup unique_id
+ *
+
+ * Get the unique 64-bit device identifier which was retrieved from the
+ * external NOR flash device at boot.
+ *
+ * On PICO_NO_FLASH builds the unique identifier is set to all 0xEE.
+ *
+ * \param id_out an 8-byte buffer to which the identifer will be written.
+ */
+void pico_get_unique_id(uint8_t *id_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 /** \file pico/unique_id.h
- *  \defgroup unique_id unique_id
+ *  \defgroup pico_unique_id pico_unique_id
  *
  * Unique device ID access API
  *
@@ -35,7 +35,7 @@ extern "C" {
 
 /**
  * \brief Unique board identifier
- * \ingroup unique_id
+ * \ingroup pico_unique_id
  *
  * This struct is suitable for holding the unique identifier of a NOR flash
  * device on an RP2040-based board. It contains an array of
@@ -46,7 +46,7 @@ typedef struct {
 } pico_unique_board_id_t;
 
 /*! \brief Get unique ID
- *  \ingroup unique_id
+ *  \ingroup pico_unique_id
  *
  * Get the unique 64-bit device identifier which was retrieved from the
  * external NOR flash device at boot.

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -7,7 +7,7 @@
 #include "hardware/flash.h"
 #include "pico/unique_id.h"
 
-static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES == FLASH_UNIQUE_ID_SIZE_BYTES, "Board ID size must match flash ID");
+static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES == FLASH_UNIQUE_ID_SIZE_BYTES, "Board ID size must match flash ID size");
 
 static pico_unique_board_id_t retrieved_id;
 

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -7,23 +7,22 @@
 #include "hardware/flash.h"
 #include "pico/unique_id.h"
 
-static_assert(PICO_UNIQUE_ID_SIZE_BYTES == FLASH_UNIQUE_ID_SIZE_BYTES);
+static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES == FLASH_UNIQUE_ID_SIZE_BYTES);
 
-static uint8_t retrieved_id[PICO_UNIQUE_ID_SIZE_BYTES];
+static pico_unique_board_id_t retrieved_id;
 
 static void __attribute__((constructor)) _retrieve_unique_id_on_boot() {
 #if PICO_NO_FLASH
     // The hardware_flash call will panic() if called directly on a NO_FLASH
     // build. Since this constructor is pre-main it would be annoying to
     // debug, so just produce something well-defined and obviously wrong.
-    for (int i = 0; i < PICO_UNIQUE_ID_SIZE_BYTES; i++)
-        retrieved_id[i] = 0xee;
+    for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; i++)
+        retrieved_id.id[i] = 0xee;
 #else
-    flash_get_unique_id(retrieved_id);
+    flash_get_unique_id(retrieved_id.id);
 #endif
 }
 
-void pico_get_unique_id(uint8_t *id_out) {
-    for (int i = 0; i < PICO_UNIQUE_ID_SIZE_BYTES; i++)
-        id_out[i] = retrieved_id[i];
+void pico_get_unique_board_id(pico_unique_board_id_t *id_out) {
+    *id_out = retrieved_id;
 }

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -7,7 +7,7 @@
 #include "hardware/flash.h"
 #include "pico/unique_id.h"
 
-static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES == FLASH_UNIQUE_ID_SIZE_BYTES);
+static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES == FLASH_UNIQUE_ID_SIZE_BYTES, "Board ID size must match flash ID");
 
 static pico_unique_board_id_t retrieved_id;
 

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "hardware/flash.h"
+#include "pico/unique_id.h"
+
+static_assert(PICO_UNIQUE_ID_SIZE_BYTES == FLASH_UNIQUE_ID_SIZE_BYTES);
+
+static uint8_t retrieved_id[PICO_UNIQUE_ID_SIZE_BYTES];
+
+static void __attribute__((constructor)) _retrieve_unique_id_on_boot() {
+#if PICO_NO_FLASH
+    // The hardware_flash call will panic() if called directly on a NO_FLASH
+    // build. Since this constructor is pre-main it would be annoying to
+    // debug, so just produce something well-defined and obviously wrong.
+    for (int i = 0; i < PICO_UNIQUE_ID_SIZE_BYTES; i++)
+        retrieved_id[i] = 0xee;
+#else
+    flash_get_unique_id(retrieved_id);
+#endif
+}
+
+void pico_get_unique_id(uint8_t *id_out) {
+    for (int i = 0; i < PICO_UNIQUE_ID_SIZE_BYTES; i++)
+        id_out[i] = retrieved_id[i];
+}


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-examples/issues/6

This adds a function `flash_get_unique_id` which retrieves the unique identifier from external NOR flash. This is suitable for use as a unique board ID.

Also adds some lower-level flash functions for sending arbitrary commands to the SSI, but these are kept static.