### PR TITLE
Push/Pull PIO Disassembly Incorrectly Concatenates Operands

### DIFF
--- a/tools/pioasm/pio_disassembler.cpp
+++ b/tools/pioasm/pio_disassembler.cpp
@@ -86,10 +86,10 @@ std::string disassemble(uint16_t inst, uint sideset_bits_including_opt, bool sid
                 std::string guts = "";
                 if (arg1 & 4u) {
                     op("pull");
-                    if (arg1 & 2u) guts = "ifempty";
+                    if (arg1 & 2u) guts = "ifempty ";
                 } else {
                     op("push");
-                    if (arg1 & 2u) guts = "iffull";
+                    if (arg1 & 2u) guts = "iffull ";
                 }
                 guts += (arg1 & 0x1u) ? "block" : "noblock";
                 op_guts(guts);


### PR DESCRIPTION
This bug leaves you with a disassembly that cannot be reassembled without manual editing, as push/pull concatenates operands when iffull/ifempty are emitted.

With this bug:

```    0x8060, //  3: push   iffullblock                ```

After this patch:

```    0x8060, //  3: push   iffull block               ```

This fix adds a space to the iffull/ifempty strings as the disassembler will always print block/noblock, and thus a space is always required when iffull/ifempty are emitted by the disassembler.