### PR TITLE
Pioasm Incorrectly Assembles Irq 'rel' Flag

### DIFF
--- a/tools/pioasm/pio_assembler.cpp
+++ b/tools/pioasm/pio_assembler.cpp
@@ -304,7 +304,7 @@ raw_encoding instr_wait::raw_encode(const program &program) {
 raw_encoding instr_irq::raw_encode(const program &program) {
     uint arg2 = num->resolve(program);
     if (arg2 > 7) throw syntax_error(num->location, "irq number must be must be >= 0 and <= 7");
-    if (relative) arg2 |= 0x20u;
+    if (relative) arg2 |= 0x10u;
     return {inst_type::irq, (uint)modifiers, arg2};
 }
 


### PR DESCRIPTION
By setting 5 instead of bit 4, pioasm sets the wait flag instead of the rel flag.

With this bug

```irq 0 rel```

is assembled to

```    0xc020, //  0: irq    wait 0```

After this patch, it is instead assembled to

```    0xc010, //  0: irq    nowait 0 rel```