### PR TITLE
Add header when needed

### DIFF
--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -22,6 +22,10 @@
 #include "pico/time.h"
 #include "pico/printf.h"
 
+#if PICO_ENTER_USB_BOOT_ON_EXIT
+#include "pico/bootrom.h"
+#endif
+
 #ifndef PICO_NO_RAM_VECTOR_TABLE
 #define PICO_NO_RAM_VECTOR_TABLE 0
 #endif


### PR DESCRIPTION
This header is needed when 'Enter USB flashing mode on exit' is selected by adding the define PICO_ENTER_USB_BOOT_ON_EXIT to the users project CMake configuration.

This avoids the user having to additionally include the header themselves.