### PR TITLE
Fix missing timer registers in DMA header

### DIFF
--- a/src/rp2040/hardware_regs/include/hardware/regs/dma.h
+++ b/src/rp2040/hardware_regs/include/hardware/regs/dma.h
@@ -4826,6 +4826,62 @@
 #define DMA_TIMER1_Y_LSB    0
 #define DMA_TIMER1_Y_ACCESS "RW"
 // =============================================================================
+// Register    : DMA_TIMER2
+// Description : Pacing (X/Y) Fractional Timer
+//               The pacing timer produces TREQ assertions at a rate set by
+//               ((X/Y) * sys_clk). This equation is evaluated every sys_clk
+//               cycles and therefore can only generate TREQs at a rate of 1 per
+//               sys_clk (i.e. permanent TREQ) or less.
+#define DMA_TIMER2_OFFSET 0x00000428
+#define DMA_TIMER2_BITS   0xffffffff
+#define DMA_TIMER2_RESET  0x00000000
+// -----------------------------------------------------------------------------
+// Field       : DMA_TIMER2_X
+// Description : Pacing Timer Dividend. Specifies the X value for the (X/Y)
+//               fractional timer.
+#define DMA_TIMER2_X_RESET  0x0000
+#define DMA_TIMER2_X_BITS   0xffff0000
+#define DMA_TIMER2_X_MSB    31
+#define DMA_TIMER2_X_LSB    16
+#define DMA_TIMER2_X_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : DMA_TIMER2_Y
+// Description : Pacing Timer Divisor. Specifies the Y value for the (X/Y)
+//               fractional timer.
+#define DMA_TIMER2_Y_RESET  0x0000
+#define DMA_TIMER2_Y_BITS   0x0000ffff
+#define DMA_TIMER2_Y_MSB    15
+#define DMA_TIMER2_Y_LSB    0
+#define DMA_TIMER2_Y_ACCESS "RW"
+// =============================================================================
+// Register    : DMA_TIMER3
+// Description : Pacing (X/Y) Fractional Timer
+//               The pacing timer produces TREQ assertions at a rate set by
+//               ((X/Y) * sys_clk). This equation is evaluated every sys_clk
+//               cycles and therefore can only generate TREQs at a rate of 1 per
+//               sys_clk (i.e. permanent TREQ) or less.
+#define DMA_TIMER3_OFFSET 0x0000042c
+#define DMA_TIMER3_BITS   0xffffffff
+#define DMA_TIMER3_RESET  0x00000000
+// -----------------------------------------------------------------------------
+// Field       : DMA_TIMER3_X
+// Description : Pacing Timer Dividend. Specifies the X value for the (X/Y)
+//               fractional timer.
+#define DMA_TIMER3_X_RESET  0x0000
+#define DMA_TIMER3_X_BITS   0xffff0000
+#define DMA_TIMER3_X_MSB    31
+#define DMA_TIMER3_X_LSB    16
+#define DMA_TIMER3_X_ACCESS "RW"
+// -----------------------------------------------------------------------------
+// Field       : DMA_TIMER3_Y
+// Description : Pacing Timer Divisor. Specifies the Y value for the (X/Y)
+//               fractional timer.
+#define DMA_TIMER3_Y_RESET  0x0000
+#define DMA_TIMER3_Y_BITS   0x0000ffff
+#define DMA_TIMER3_Y_MSB    15
+#define DMA_TIMER3_Y_LSB    0
+#define DMA_TIMER3_Y_ACCESS "RW"
+// =============================================================================
 // Register    : DMA_MULTI_CHAN_TRIGGER
 // Description : Trigger one or more channels simultaneously
 //               Each bit in this register corresponds to a DMA channel. Writing

--- a/src/rp2040/hardware_regs/rp2040.svd
+++ b/src/rp2040/hardware_regs/rp2040.svd
@@ -32852,6 +32852,48 @@
           <resetValue>0x00000000</resetValue>
         </register>
         <register>
+          <addressOffset>0x0428</addressOffset>
+          <description>Pacing (X/Y) Fractional Timer\n
+            The pacing timer produces TREQ assertions at a rate set by ((X/Y) * sys_clk). This equation is evaluated every sys_clk cycles and therefore can only generate TREQs at a rate of 1 per sys_clk (i.e. permanent TREQ) or less.</description>
+          <fields>
+            <field>
+              <access>read-write</access>
+              <bitRange>[31:16]</bitRange>
+              <description>Pacing Timer Dividend. Specifies the X value for the (X/Y) fractional timer.</description>
+              <name>X</name>
+            </field>
+            <field>
+              <access>read-write</access>
+              <bitRange>[15:0]</bitRange>
+              <description>Pacing Timer Divisor. Specifies the Y value for the (X/Y) fractional timer.</description>
+              <name>Y</name>
+            </field>
+          </fields>
+          <name>TIMER2</name>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <addressOffset>0x042c</addressOffset>
+          <description>Pacing (X/Y) Fractional Timer\n
+            The pacing timer produces TREQ assertions at a rate set by ((X/Y) * sys_clk). This equation is evaluated every sys_clk cycles and therefore can only generate TREQs at a rate of 1 per sys_clk (i.e. permanent TREQ) or less.</description>
+          <fields>
+            <field>
+              <access>read-write</access>
+              <bitRange>[31:16]</bitRange>
+              <description>Pacing Timer Dividend. Specifies the X value for the (X/Y) fractional timer.</description>
+              <name>X</name>
+            </field>
+            <field>
+              <access>read-write</access>
+              <bitRange>[15:0]</bitRange>
+              <description>Pacing Timer Divisor. Specifies the Y value for the (X/Y) fractional timer.</description>
+              <name>Y</name>
+            </field>
+          </fields>
+          <name>TIMER3</name>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
           <addressOffset>0x0430</addressOffset>
           <description>Trigger one or more channels simultaneously</description>
           <fields>

--- a/src/rp2040/hardware_structs/include/hardware/structs/dma.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/dma.h
@@ -48,12 +48,11 @@ typedef struct {
     io_rw_32 inte1;
     io_rw_32 intf1;
     io_rw_32 ints1;
-    io_rw_32 timer[2];
-    uint32_t _pad2[2];
+    io_rw_32 timer[4];
     io_wo_32 multi_channel_trigger;
     io_rw_32 sniff_ctrl;
     io_rw_32 sniff_data;
-    uint32_t _pad3[1];
+    uint32_t _pad2[1];
     io_ro_32 fifo_levels;
     io_wo_32 abort;
 } dma_hw_t;


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-feedback/issues/22

Datasheet main text matched hardware, but DMA header and register listing generation was incorrectly parameterised (no single-source generation for DMA unlike other regblocks). The register listing is fixed in upstream datasheet, need to add the missing timers to the register headers too.