### PR TITLE
fix compilation for non github users

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -26,7 +26,7 @@ if(PICO_BUILD_DOCS)
         add_custom_target(doc-pico-examples)
     else()
         ExternalProject_Add(doc-pico-examples
-                GIT_REPOSITORY    git@github.com:raspberrypi/pico-examples.git
+                GIT_REPOSITORY    https://github.com/raspberrypi/pico-examples
                 GIT_TAG           master
                 CONFIGURE_COMMAND ""
                 BUILD_COMMAND ""


### PR DESCRIPTION
ssh git cloning requires ssh key. Allow non github users to compile the
code