### PR TITLE
Remove a dependecy on Pioasm to fix building with ninja

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -19,7 +19,7 @@ function(pico_generate_pio_header TARGET PIO)
     get_filename_component(HEADER_GEN_TARGET ${PIO} NAME_WE)
     set(HEADER_GEN_TARGET "${TARGET}_${HEADER_GEN_TARGET}_pio_h")
 
-    add_custom_target(${HEADER_GEN_TARGET} DEPENDS ${HEADER} Pioasm)
+    add_custom_target(${HEADER_GEN_TARGET} DEPENDS ${HEADER})
 
     add_custom_command(OUTPUT ${HEADER}
             DEPENDS ${PIO}


### PR DESCRIPTION
This fixes the "'pioasm/pioasm', needed by '...', missing and no known rule to make it" error with ninja. I think the `add_custom_command` below adds the necessary dependency on the pioasm build.

I've successfully done a `ninja` and `make -j24` build on the examples with this (and a similar change to a couple of the examples).

(Clean build each time, 24-thread CPU)