### PR TITLE
Pioasm static initializer fix

### DIFF
--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -165,7 +165,7 @@ static void __no_inline_not_in_flash_func(flash_do_cmd)(const uint8_t *txbuf, ui
 // Use standard RUID command to get a unique identifier for the flash (and
 // hence the board)
 
-static_assert(FLASH_UNIQUE_ID_SIZE_BYTES == FLASH_RUID_DATA_BYTES);
+static_assert(FLASH_UNIQUE_ID_SIZE_BYTES == FLASH_RUID_DATA_BYTES, "");
 
 void flash_get_unique_id(uint8_t *id_out) {
 #if PICO_NO_FLASH

--- a/tools/pioasm/main.cpp
+++ b/tools/pioasm/main.cpp
@@ -18,7 +18,7 @@ void usage() {
     std::cerr << "\n";
     std::cerr << "options:\n";
     std::cerr << "  -o <output_format>   select output_format (default '" << DEFAULT_OUTPUT_FORMAT << "'); available options are:\n";
-    for(const auto& f : output_format::output_formats) {
+    for(const auto& f : output_format::all()) {
         std::cerr << "                           " << f->name << std::endl;
         std::cerr << "                               " << f->get_description() << std::endl;
     }
@@ -79,11 +79,11 @@ int main(int argc, char *argv[]) {
     }
     std::shared_ptr<output_format> oformat;
     if (!res) {
-        const auto& e = std::find_if(output_format::output_formats.begin(), output_format::output_formats.end(),
+        const auto& e = std::find_if(output_format::all().begin(), output_format::all().end(),
                                      [&](const std::shared_ptr<output_format> &f) {
                                          return f->name == format;
                                      });
-        if (e == output_format::output_formats.end()) {
+        if (e == output_format::all().end()) {
             std::cerr << "error: unknown output format '" << format << "'" << std::endl;
             res = 1;
         } else {

--- a/tools/pioasm/output_format.h
+++ b/tools/pioasm/output_format.h
@@ -77,13 +77,12 @@ struct compiled_source {
 };
 
 struct output_format {
-    static std::vector<std::shared_ptr<output_format>> output_formats;
     static std::string default_name;
 
     std::string name;
 
     static void add(output_format *lang) {
-        output_formats.push_back(std::shared_ptr<output_format>(lang));
+        all().push_back(std::shared_ptr<output_format>(lang));
     }
 
     virtual int output(std::string destination, std::vector<std::string> output_options,
@@ -93,6 +92,11 @@ struct output_format {
 
     FILE *open_single_output(std::string destination);
     virtual ~output_format() = default;
+
+    static std::vector<std::shared_ptr<output_format>>& all() {
+        static std::vector<std::shared_ptr<output_format>> output_formats;
+        return output_formats;
+    }
 protected:
     output_format(std::string name) : name(std::move(name)) {}
 };

--- a/tools/pioasm/pio_assembler.cpp
+++ b/tools/pioasm/pio_assembler.cpp
@@ -15,7 +15,6 @@
 
 using syntax_error = yy::parser::syntax_error;
 
-std::vector<std::shared_ptr<output_format>> output_format::output_formats;
 std::string output_format::default_name = "c-sdk";
 
 pio_assembler::pio_assembler() {
@@ -324,7 +323,7 @@ std::vector<compiled_source::symbol> pio_assembler::public_symbols(program &prog
 
 int pio_assembler::write_output() {
     std::set<std::string> known_output_formats;
-    std::transform(output_format::output_formats.begin(), output_format::output_formats.end(),
+    std::transform(output_format::all().begin(), output_format::all().end(),
                    std::inserter(known_output_formats, known_output_formats.begin()),
                    [&](std::shared_ptr<output_format> &f) {
                        return f->name;


### PR DESCRIPTION
ninja build was broken on windows because mingw64 was being used to compile pioasm and this had a different static initiiazation order. Fixed the code to actually be order agnostic