### PR TITLE
Add PICO_NO_FPGA_CHECK define to remove FPGA check and save some bytes

### DIFF
--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -63,7 +63,17 @@ void __attribute__((noreturn)) panic_unsupported();
 
 void __attribute__((noreturn)) panic(const char *fmt, ...);
 
+// PICO_CONFIG: PICO_NO_FPGA_CHECK, Remove the FPGA platform check for small code size reduction, type=bool, default=0, advanced=true, group=pico_runtime
+#ifndef PICO_NO_FPGA_CHECK
+#define PICO_NO_FPGA_CHECK 0
+#endif
+
+#if PICO_NO_FPGA_CHECK
+static inline bool running_on_fpga() {return false;}
+#else
 bool running_on_fpga();
+#endif
+
 uint8_t rp2040_chip_version();
 
 static inline uint8_t rp2040_rom_version() {

--- a/src/rp2_common/pico_platform/platform.c
+++ b/src/rp2_common/pico_platform/platform.c
@@ -9,9 +9,19 @@
 #include "hardware/regs/tbman.h"
 #include "hardware/regs/sysinfo.h"
 
+// Note we leave the FPGA check in by default so that we can run bug repro
+// binaries coming in from the wild on the FPGA platform. It takes up around
+// 48 bytes if you include all the calls, so you can pass PICO_NO_FPGA_CHECK=1
+// to remove it. The FPGA check is used to skip initialisation of hardware
+// (mainly clock generators and oscillators) that aren't present on FPGA.
+
+#if !PICO_NO_FPGA_CHECK
+// Inline stub provided in header if this code is unused (so folding can be
+// done in each TU instead of relying on LTO)
 bool running_on_fpga() {
     return !!((*(io_ro_32 *)TBMAN_BASE) & TBMAN_PLATFORM_FPGA_BITS);
 }
+#endif
 
 #define MANUFACTURER_RPI 0x927
 #define PART_RP2 0x2


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-sdk/issues/72

We want to leave this check in by default, but it is called (outline call) in 3 places, so adds a total of 48 bytes to the binary. This commit adds a PICO_NO_FPGA_CHECK config to replace the code with an inline stub, so that the calls get folded away.

I added the config to the `pico_runtime` group as that is what it affects. Noticed that `platform.h` is also a bit light on doxygen, so @kilograham  I can add some doxygen there as part of this PR, and add this config to a new `pico_platform` doxygen group. Lmk