### PR TITLE
Fix incorrect type in systick struct header vs machine-generated register header

### DIFF
--- a/src/rp2040/hardware_structs/include/hardware/structs/systick.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/systick.h
@@ -13,7 +13,7 @@
 typedef struct {
     io_rw_32 csr;
     io_rw_32 rvr;
-    io_ro_32 cvr;
+    io_rw_32 cvr;
     io_ro_32 calib;
 } systick_hw_t;
 


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-sdk/issues/46