### PR TITLE
move PLL reset code from clocks driver to pll driver

### DIFF
--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -7,7 +7,6 @@
 #include "pico.h"
 #include "hardware/regs/clocks.h"
 #include "hardware/platform_defs.h"
-#include "hardware/resets.h"
 #include "hardware/clocks.h"
 #include "hardware/watchdog.h"
 #include "hardware/pll.h"
@@ -148,9 +147,6 @@ void clocks_init(void) {
     // PLL SYS: 12 / 1 = 12MHz * 125 = 1500MHZ / 6 / 2 = 125MHz
     // PLL USB: 12 / 1 = 12MHz * 40  = 480 MHz / 5 / 2 =  48MHz
     /// \end::pll_settings[]
-
-    reset_block(RESETS_RESET_PLL_SYS_BITS | RESETS_RESET_PLL_USB_BITS);
-    unreset_block_wait(RESETS_RESET_PLL_SYS_BITS | RESETS_RESET_PLL_USB_BITS);
 
     /// \tag::pll_init[]
     pll_init(pll_sys, 1, 1500 * MHZ, 6, 2);

--- a/src/rp2_common/hardware_pll/pll.c
+++ b/src/rp2_common/hardware_pll/pll.c
@@ -50,13 +50,8 @@ void pll_init(PLL pll, uint refdiv, uint vco_freq, uint post_div1, uint post_div
     reset_block(pll_reset);
     unreset_block_wait(pll_reset);
 
-    // Turn off PLL in case it is already running
-    pll->pwr = 0xffffffff;
-    pll->fbdiv_int = 0;
-
+    // Load VCO-related dividers before starting VCO
     pll->cs = refdiv;
-
-    // Put calculated value into feedback divider
     pll->fbdiv_int = fbdiv;
 
     // Turn on PLL

--- a/src/rp2_common/hardware_pll/pll.c
+++ b/src/rp2_common/hardware_pll/pll.c
@@ -7,15 +7,11 @@
 // For MHZ definitions etc
 #include "hardware/clocks.h"
 #include "hardware/pll.h"
+#include "hardware/resets.h"
 
 /// \tag::pll_init_calculations[]
 void pll_init(PLL pll, uint refdiv, uint vco_freq, uint post_div1, uint post_div2) {
-    // Turn off PLL in case it is already running
-    pll->pwr = 0xffffffff;
-    pll->fbdiv_int = 0;
-
     uint32_t ref_mhz = XOSC_MHZ / refdiv;
-    pll->cs = refdiv;
 
     // What are we multiplying the reference clock by to get the vco freq
     // (The regs are called div, because you divide the vco output and compare it to the refclk)
@@ -34,9 +30,31 @@ void pll_init(PLL pll, uint refdiv, uint vco_freq, uint post_div1, uint post_div
     // than postdiv2
     assert(post_div2 <= post_div1);
 
-/// \tag::pll_init_finish[]
     // Check that reference frequency is no greater than vco / 16
     assert(ref_mhz <= (vco_freq / 16));
+
+    // div1 feeds into div2 so if div1 is 5 and div2 is 2 then you get a divide by 10
+    uint32_t pdiv = (post_div1 << PLL_PRIM_POSTDIV1_LSB) |
+                    (post_div2 << PLL_PRIM_POSTDIV2_LSB);
+
+/// \tag::pll_init_finish[]
+    if ((pll->cs & PLL_CS_LOCK_BITS) &&
+        (refdiv == (pll->cs & PLL_CS_REFDIV_BITS)) &&
+        (fbdiv  == (pll->fbdiv_int & PLL_FBDIV_INT_BITS)) &&
+        (pdiv   == (pll->prim & (PLL_PRIM_POSTDIV1_BITS & PLL_PRIM_POSTDIV2_BITS)))) {
+        // do not disrupt PLL that is already correctly configured and operating
+        return;
+    }
+
+    uint32_t pll_reset = (pll_usb_hw == pll) ? RESETS_RESET_PLL_USB_BITS : RESETS_RESET_PLL_SYS_BITS;
+    reset_block(pll_reset);
+    unreset_block_wait(pll_reset);
+
+    // Turn off PLL in case it is already running
+    pll->pwr = 0xffffffff;
+    pll->fbdiv_int = 0;
+
+    pll->cs = refdiv;
 
     // Put calculated value into feedback divider
     pll->fbdiv_int = fbdiv;
@@ -50,9 +68,7 @@ void pll_init(PLL pll, uint refdiv, uint vco_freq, uint post_div1, uint post_div
     // Wait for PLL to lock
     while (!(pll->cs & PLL_CS_LOCK_BITS)) tight_loop_contents();
 
-    // Set up post dividers - div1 feeds into div2 so if div1 is 5 and div2 is 2 then you get a divide by 10
-    uint32_t pdiv = (post_div1 << PLL_PRIM_POSTDIV1_LSB) |
-                    (post_div2 << PLL_PRIM_POSTDIV2_LSB);
+    // Set up post dividers
     pll->prim = pdiv;
 
     // Turn on post divider

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -67,6 +67,8 @@ void runtime_init(void) {
             RESETS_RESET_IO_QSPI_BITS |
             RESETS_RESET_PADS_QSPI_BITS |
             RESETS_RESET_PLL_USB_BITS |
+            RESETS_RESET_USBCTRL_BITS |
+            RESETS_RESET_SYSCFG_BITS |
             RESETS_RESET_PLL_SYS_BITS
     ));
 

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -63,6 +63,7 @@ void runtime_init(void) {
     // Reset all peripherals to put system into a known state,
     // - except for QSPI pads and the XIP IO bank, as this is fatal if running from flash
     // - and the PLLs, as this is fatal if clock muxing has not been reset on this boot
+    // - and USB, syscfg, as this disturbs USB-to-SWD on core 1
     reset_block(~(
             RESETS_RESET_IO_QSPI_BITS |
             RESETS_RESET_PADS_QSPI_BITS |


### PR DESCRIPTION
reset_block() and unreset_block_wait() calls on behalf of pll_init() are moved away from ./src/rp2_common/hardware_clocks/clocks.c and into ./src/rp2_common/hardware_pll/pll.c where they more rightly belong.  This follows the existing conventions already employed in the rtc, spi, uart, i2c, adc driver code.

The assert() calls to verify the validity of parameters are now done before such values are written to the PLL peripheral.

The peripheral state is checked before writing to the peripheral so that a PLL that already matches the provided configuration is not unnecessarily disrupted.
