### PR TITLE
i2c: add "memory" functions

### DIFF
--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -155,6 +155,26 @@ static inline i2c_hw_t *i2c_get_hw(i2c_inst_t *i2c) {
  */
 int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop, absolute_time_t until);
 
+/*! \brief Attempt to write specified number of bytes to address, blocking until the specified absolute time is reached.
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr Address of device to write to
+ * \param memaddr Memory address
+ * \param len_memaddr Length of memory address (either 1 or 2 bytes)
+ * \param src Pointer to data to send
+ * \param len Length of data in bytes to send
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param until The absolute time that the block will wait until the entire transaction is complete. Note, an individual timeout of
+ *           this value divided by the length of data is applied for each byte transfer, so if the first or subsequent
+ *           bytes fails to transfer within that sub timeout, the function will return with an error.
+ *
+ * \return Number of bytes written, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+int i2c_write_mem_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, const uint8_t *src, size_t len, bool nostop, absolute_time_t until);
+
+
 /*! \brief  Attempt to read specified number of bytes from address, blocking until the specified absolute time is reached.
  *  \ingroup hardware_i2c
  *
@@ -168,6 +188,23 @@ int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, 
  * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
  */
 int i2c_read_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until);
+
+/*! \brief  Attempt to read specified number of bytes from address, blocking until the specified absolute time is reached.
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr Address of device to read from
+ * \param memaddr Memory address
+ * \param len_memaddr Length of memory address (either 1 or 2 bytes)
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param until The absolute time that the block will wait until the entire transaction is complete.
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+int i2c_read_mem_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until);
+
 
 /*! \brief Attempt to write specified number of bytes to address, with timeout
  *  \ingroup hardware_i2c
@@ -189,7 +226,31 @@ static inline int i2c_write_timeout_us(i2c_inst_t *i2c, uint8_t addr, const uint
     return i2c_write_blocking_until(i2c, addr, src, len, nostop, t);
 }
 
+/*! \brief Attempt to write specified number of bytes to address, with timeout
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr Address of device to write to
+ * \param memaddr Memory address
+ * \param len_memaddr Length of memory address (either 1 or 2 bytes)
+ * \param src Pointer to data to send
+ * \param len Length of data in bytes to send
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param timeout_us The time that the function will wait for the entire transaction to complete. Note, an individual timeout of
+ *           this value divided by the length of data is applied for each byte transfer, so if the first or subsequent
+ *           bytes fails to transfer within that sub timeout, the function will return with an error.
+ *
+ * \return Number of bytes written, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+static inline int i2c_write_mem_timeout_us(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, const uint8_t *src, size_t len, bool nostop, uint timeout_us) {
+    absolute_time_t t = make_timeout_time_us(timeout_us);
+    return i2c_write_mem_blocking_until(i2c, addr, memaddr, len_memaddr, src, len, nostop, t);
+}
+
 int i2c_write_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop, uint timeout_per_char_us);
+int i2c_write_mem_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, const uint8_t *src, size_t len, bool nostop, uint timeout_per_char_us);
+
 
 /*! \brief  Attempt to read specified number of bytes from address, with timeout
  *  \ingroup hardware_i2c
@@ -207,8 +268,27 @@ static inline int i2c_read_timeout_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *ds
     absolute_time_t t = make_timeout_time_us(timeout_us);
     return i2c_read_blocking_until(i2c, addr, dst, len, nostop, t);
 }
+/*! \brief  Attempt to read specified number of bytes from address, with timeout
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr Address of device to read from
+ * \param memaddr Memory address
+ * \param len_memaddr Length of memory address (either 1 or 2 bytes)
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param timeout_us The time that the function will wait for the entire transaction to complete
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+static inline int i2c_read_mem_timeout_us(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, uint8_t *dst, size_t len, bool nostop, uint timeout_us) {
+    absolute_time_t t = make_timeout_time_us(timeout_us);
+    return i2c_read_blocking_until(i2c, addr, dst, len, nostop, t);
+}
 
 int i2c_read_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop, uint timeout_per_char_us);
+int i2c_read_mem_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, uint8_t *dst, size_t len, bool nostop, uint timeout_per_char_us);
 
 /*! \brief Attempt to write specified number of bytes to address, blocking
  *  \ingroup hardware_i2c
@@ -223,6 +303,21 @@ int i2c_read_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, si
  */
 int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop);
 
+/*! \brief Attempt to write specified number of bytes to address, blocking
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr Address of device to write to
+ * \param memaddr Memory address
+ * \param len_memaddr Length of memory address (either 1 or 2 bytes)
+ * \param src Pointer to data to send
+ * \param len Length of data in bytes to send
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \return Number of bytes written, or PICO_ERROR_GENERIC if address not acknowledged, no device present.
+ */
+int i2c_write_mem_blocking(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, const uint8_t *src, size_t len, bool nostop);
+
 /*! \brief  Attempt to read specified number of bytes from address, blocking
  *  \ingroup hardware_i2c
  *
@@ -235,6 +330,21 @@ int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t
  * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present.
  */
 int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop);
+
+/*! \brief  Attempt to read specified number of bytes from address, blocking
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr Address of device to read from
+ * \param memaddr Memory address
+ * \param len_memaddr Length of memory address (either 1 or 2 bytes)
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present.
+ */
+int i2c_read_mem_blocking(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size_t len_memaddr, uint8_t *dst, size_t len, bool nostop);
 
 
 /*! \brief Determine non-blocking write space available

--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -155,7 +155,7 @@ static inline i2c_hw_t *i2c_get_hw(i2c_inst_t *i2c) {
  */
 int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop, absolute_time_t until);
 
-/*! \brief Attempt to write specified number of bytes to address, blocking until the specified absolute time is reached.
+/*! \brief Attempt to write specified number of bytes to address addr with memory address memaddr, blocking until the specified absolute time is reached.
  *  \ingroup hardware_i2c
  *
  * \param i2c Either \ref i2c0 or \ref i2c1
@@ -189,7 +189,7 @@ int i2c_write_mem_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr
  */
 int i2c_read_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until);
 
-/*! \brief  Attempt to read specified number of bytes from address, blocking until the specified absolute time is reached.
+/*! \brief  Attempt to read specified number of bytes from address addr with memory address memaddr, blocking until the specified absolute time is reached.
  *  \ingroup hardware_i2c
  *
  * \param i2c Either \ref i2c0 or \ref i2c1
@@ -226,7 +226,7 @@ static inline int i2c_write_timeout_us(i2c_inst_t *i2c, uint8_t addr, const uint
     return i2c_write_blocking_until(i2c, addr, src, len, nostop, t);
 }
 
-/*! \brief Attempt to write specified number of bytes to address, with timeout
+/*! \brief Attempt to write specified number of bytes to address addr with memory address memaddr, with timeout
  *  \ingroup hardware_i2c
  *
  * \param i2c Either \ref i2c0 or \ref i2c1
@@ -268,7 +268,7 @@ static inline int i2c_read_timeout_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *ds
     absolute_time_t t = make_timeout_time_us(timeout_us);
     return i2c_read_blocking_until(i2c, addr, dst, len, nostop, t);
 }
-/*! \brief  Attempt to read specified number of bytes from address, with timeout
+/*! \brief  Attempt to read specified number of bytes from address addr with memory address memaddr, with timeout
  *  \ingroup hardware_i2c
  *
  * \param i2c Either \ref i2c0 or \ref i2c1
@@ -303,7 +303,7 @@ int i2c_read_mem_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint16_t mem
  */
 int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop);
 
-/*! \brief Attempt to write specified number of bytes to address, blocking
+/*! \brief Attempt to write specified number of bytes to address addr with memory address memaddr, blocking
  *  \ingroup hardware_i2c
  *
  * \param i2c Either \ref i2c0 or \ref i2c1
@@ -331,7 +331,7 @@ int i2c_write_mem_blocking(i2c_inst_t *i2c, uint8_t addr, uint16_t memaddr, size
  */
 int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop);
 
-/*! \brief  Attempt to read specified number of bytes from address, blocking
+/*! \brief  Attempt to read specified number of bytes from address addr with memory address memaddr, blocking
  *  \ingroup hardware_i2c
  *
  * \param i2c Either \ref i2c0 or \ref i2c1


### PR DESCRIPTION
When dealing with I2C peripherals it is extremely common to have secondary address fields after the main I2C address (for instance when using off-chip memory or peripherals with many registers). 

For this reason the majority of HALs for I2C feature functions which can easily interface with both kinds of I2C peripherals - those with secondary addresses and those without

For example, see the STM32 HAL, which has the following:
```
(#) Blocking mode functions are :
        (++) HAL_I2C_Master_Transmit()
        (++) HAL_I2C_Master_Receive()
        (++) HAL_I2C_Slave_Transmit()
        (++) HAL_I2C_Slave_Receive()
        (++) HAL_I2C_Mem_Write() <------ these functions
        (++) HAL_I2C_Mem_Read() <------
        (++) HAL_I2C_IsDeviceReady()
```
It is possible to emulate this functionality - for instance, I wrote a small test script which uses malloc:
```c
//assume buffer with buff_size is the transmit variable, and 0x40 is the memory address
uint8_t* temp = malloc(buff_size + 1);
temp[0] = 0x40;
for(int i=1; i<buff_size+1; i++) {
    temp[i] = buffer[i-1];
}
i2c_write_blocking(I2C_PORT, I2C_ADDR, temp, buff_size+1, false);
free(d);
```
However the fact remains that prepending variables to arrays in C is pretty awful.

For this reason I add a `_mem` version of all I2C functions in `/rp2_common/hardware_i2c/i2c.c`
* i2c_write_mem_blocking_until()
* i2c_read_mem_blocking_until()
* i2c_write_mem_timeout_us()
* i2c_read_mem_timeout_us()
* i2c_write_mem_timeout_per_char_us()
* i2c_read_mem_timeout_per_char_us()
* i2c_write_mem_blocking()
* i2c_read_mem_blocking()

Thanks to the nice internal organization of the file, *no changes were made to existing external APIs.*

You can test the read_mem and write_mem functions using a cheap AT24 EEPROM if you have one available, e.g.:
```c
bool at24_write_bytes(i2c_inst_t* i2c, uint8_t a2_value, uint16_t address, uint8_t* buf, uint8_t len) {
    uint8_t i2caddr = 0xA << 3 | a2_value << 2 | (address & 0x300) >> 8;
    uint8_t memaddr = address & 0xFF;

    int attempts = 0;
    while(attempts < 50) {
        //AT24 EEPROMs will NACK while they are busy
        //Try this in a loop for a few times to make sure they're actually faulty and not just busy
        int res = i2c_write_mem_blocking(i2c, i2caddr, memaddr, 1, buf, len, false);
        if(res > 0) {
            return false;
        }
    }
    return true;
}

bool at24_read_bytes(i2c_inst_t* i2c, uint8_t a2_value, uint16_t address, uint8_t* buf, uint8_t len) {
    uint8_t i2caddr = 0xA << 3 | a2_value << 2 | (address & 0x300) >> 8;
    uint8_t memaddr = address & 0xFF;

    int attempts = 0;
    while(attempts < 50) {
        //AT24 EEPROMs will NACK while they are busy
        //Try this in a loop for a few times to make sure they're actually faulty and not just busy
        int res = i2c_read_mem_blocking(i2c, i2caddr, memaddr, 1, buf, len, false);
        if(res > 0) {
            return false;
        }
    }
    return true;
}

// .. .. ..

uint8_t txbuf[2] = {0x1, 0x2};
at24_write_bytes(i2c1, 1, 0x0, txbuf, 2);
uint8_t rxbuf[2] = {0, 0};
at24_read_bytes(i2c1, 1, 0x0, rxbuf, 2);
printf("Received: %d %d\n", rxbuf[0], rxbuf[1]);

```

I tried my best to keep the style and documentation the same as the existing codebase. Please let me know if other changes are necessary.
