### PR TITLE
Fix -Wsign-compare warnings

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -355,7 +355,7 @@ static inline void sm_config_set_mov_status(pio_sm_config *c, enum pio_mov_statu
  * \return the default state machine configuration which can then be modified.
  */
 static inline pio_sm_config pio_get_default_sm_config(void) {
-    pio_sm_config c = {0, 0, 0};
+    pio_sm_config c = {0, 0, 0, 0};
     sm_config_set_clkdiv_int_frac(&c, 1, 0);
     sm_config_set_wrap(&c, 0, 31);
     sm_config_set_in_shift(&c, true, false, 32);

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -42,8 +42,9 @@ void pio_sm_unclaim(PIO pio, uint sm) {
 }
 
 int pio_claim_unused_sm(PIO pio, bool required) {
-    uint which = pio_get_index(pio);
-    uint base = which * NUM_PIO_STATE_MACHINES;
+    // PIO index is 0 or 1.
+    int which = (int)pio_get_index(pio);
+    int base = which * NUM_PIO_STATE_MACHINES;
     int index = hw_claim_unused_from_range((uint8_t*)&claimed, required, base,
                                       base + NUM_PIO_STATE_MACHINES - 1, "No PIO state machines are available");
     return index >= base ? index - base : -1;
@@ -87,7 +88,7 @@ bool pio_can_add_program(PIO pio, const pio_program_t *program) {
 static bool _pio_can_add_program_at_offset(PIO pio, const pio_program_t *program, uint offset) {
     assert(offset < PIO_INSTRUCTION_COUNT);
     assert(offset + program->length <= PIO_INSTRUCTION_COUNT);
-    if (program->origin >= 0 && program->origin != offset) return false;
+    if (program->origin >= 0 && (uint)program->origin != offset) return false;
     uint32_t used_mask = _used_instruction_space[pio_get_index(pio)];
     uint32_t program_mask = (1u << program->length) - 1;
     return !(used_mask & (program_mask << offset));

--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -151,8 +151,8 @@ void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vect
     } while (seq < count_of(cmd_sequence));
 }
 
-#define LOCKOUT_MAGIC_START 0x73a8831e
-#define LOCKOUT_MAGIC_END (LOCKOUT_MAGIC_START ^ -1)
+#define LOCKOUT_MAGIC_START 0x73a8831eu
+#define LOCKOUT_MAGIC_END (~LOCKOUT_MAGIC_START)
 
 static_assert(SIO_IRQ_PROC1 == SIO_IRQ_PROC0 + 1, "");
 

--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -34,7 +34,7 @@ static stdio_driver_t *filter;
 auto_init_mutex(print_mutex);
 
 bool stdout_serialize_begin(void) {
-    int core_num = get_core_num();
+    uint core_num = get_core_num();
     uint32_t owner;
     if (!mutex_try_enter(&print_mutex, &owner)) {
         if (owner == core_num) {

--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -75,7 +75,7 @@ void stdio_uart_init_full(struct uart_inst *uart, uint baud_rate, int tx_pin, in
 }
 
 static void stdio_uart_out_chars(const char *buf, int length) {
-    for (uint i = 0; i <length; i++) {
+    for (int i = 0; i <length; i++) {
         uart_putc(uart_default, buf[i]);
     }
 }

--- a/test/kitchen_sink/CMakeLists.txt
+++ b/test/kitchen_sink/CMakeLists.txt
@@ -69,7 +69,6 @@ target_compile_options(kitchen_sink_options INTERFACE
         -Wno-shadow
         -Wno-missing-field-initializers
         -Wno-missing-braces
-        -Wno-sign-compare
         -Wno-multichar
 
         # todo useful but fix later


### PR DESCRIPTION
We are clean with -Wall -Wextra except for a short list of disabled warnings. I tried turning these all back on, and they are mostly innocuous (insufficient gymnastics in assert-like macros mostly) but there are a few mixed-signed comparisons that are probably worth fixing.

This commit fixes those warnings and reenables `-Wsign-compare` on kitchen sink regression