### PR TITLE
Check for (and fix) more compiler warnings

### DIFF
--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -253,8 +253,9 @@ static void alarm_pool_dump_key(pheap_node_id_t id, void *user_data) {
 #endif
 }
 
-static int64_t repeating_timer_callback(alarm_id_t id, void *user_data) {
+static int64_t repeating_timer_callback(__unused alarm_id_t id, __unused void *user_data) {
     repeating_timer_t *rt = (repeating_timer_t *)user_data;
+    assert(rt->alarm_id == id);
     if (rt->callback(rt)) {
         return rt->delay_us;
     } else {
@@ -289,7 +290,7 @@ void alarm_pool_dump(alarm_pool_t *pool) {
 }
 
 #if !PICO_TIME_DEFAULT_ALARM_POOL_DISABLED
-static int64_t sev_callback(alarm_id_t id, void *user_data) {
+static int64_t sev_callback(__unused alarm_id_t id, __unused void *user_data) {
     __sev();
     return 0;
 }

--- a/src/rp2_common/hardware_dma/include/hardware/dma.h
+++ b/src/rp2_common/hardware_dma/include/hardware/dma.h
@@ -42,7 +42,7 @@ extern "C" {
 #define PARAM_ASSERTIONS_ENABLED_DMA 0
 #endif
 
-static inline void check_dma_channel_param(uint channel) {
+static inline void check_dma_channel_param(__unused uint channel) {
 #if PARAM_ASSERTIONS_ENABLED(DMA)
     // this method is used a lot by inline functions so avoid code bloat by deferring to function
     extern void check_dma_channel_param_impl(uint channel);

--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -169,6 +169,7 @@ static_assert(FLASH_UNIQUE_ID_SIZE_BYTES == FLASH_RUID_DATA_BYTES, "");
 
 void flash_get_unique_id(uint8_t *id_out) {
 #if PICO_NO_FLASH
+    __unused uint8_t *ignore = id_out;
     panic_unsupported();
 #else
     uint8_t txbuf[FLASH_RUID_TOTAL_BYTES] = {0};

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -34,7 +34,7 @@ static void set_raw_irq_handler_and_unlock(uint num, irq_handler_t handler, uint
     spin_unlock(spin_lock_instance(PICO_SPINLOCK_ID_IRQ), save);
 }
 
-static inline void check_irq_param(uint num) {
+static inline void check_irq_param(__unused uint num) {
     invalid_params_if(IRQ, num >= NUM_IRQS);
 }
 

--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -104,7 +104,7 @@ typedef struct {
     uint32_t pinctrl;
 } pio_sm_config;
 
-static inline void check_sm_param(uint sm) {
+static inline void check_sm_param(__unused uint sm) {
     valid_params_if(PIO, sm < NUM_PIO_STATE_MACHINES);
 }
 

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -50,13 +50,6 @@ int pio_claim_unused_sm(PIO pio, bool required) {
     return index >= base ? index - base : -1;
 }
 
-void pio_load_program(PIO pio, const uint16_t *prog, uint8_t prog_len, uint8_t load_offset) {
-    // instructions are only 16 bits, but instruction memory locations are spaced 32 bits apart
-    // Adjust the addresses of any jump instructions to respect load offset
-    assert(load_offset + prog_len <= PIO_INSTRUCTION_COUNT);
-
-}
-
 static_assert(PIO_INSTRUCTION_COUNT <= 32, "");
 static uint32_t _used_instruction_space[2];
 

--- a/src/rp2_common/hardware_spi/include/hardware/spi.h
+++ b/src/rp2_common/hardware_spi/include/hardware/spi.h
@@ -136,7 +136,7 @@ static inline spi_hw_t *spi_get_hw(spi_inst_t *spi) {
  * \param cpha SSPCLKOUT phase, applicable to Motorola SPI frame format only
  * \param order Must be SPI_MSB_FIRST, no other values supported on the PL022
  */
-static inline void spi_set_format(spi_inst_t *spi, uint data_bits, spi_cpol_t cpol, spi_cpha_t cpha, spi_order_t order) {
+static inline void spi_set_format(spi_inst_t *spi, uint data_bits, spi_cpol_t cpol, spi_cpha_t cpha, __unused spi_order_t order) {
     invalid_params_if(SPI, data_bits < 4 || data_bits > 16);
     // LSB-first not supported on PL022:
     invalid_params_if(SPI, order != SPI_MSB_FIRST);

--- a/src/rp2_common/hardware_timer/include/hardware/timer.h
+++ b/src/rp2_common/hardware_timer/include/hardware/timer.h
@@ -50,7 +50,7 @@ extern "C" {
 #define PARAM_ASSERTIONS_ENABLED_TIMER 0
 #endif
 
-static inline void check_hardware_alarm_num_param(uint alarm_num) {
+static inline void check_hardware_alarm_num_param(__unused uint alarm_num) {
     invalid_params_if(TIMER, alarm_num >= NUM_TIMERS);
 }
 

--- a/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c
+++ b/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c
@@ -38,7 +38,7 @@ static inline uint8_t hw_line_state(void) {
     return (usb_hw->sie_status & USB_SIE_STATUS_LINE_STATE_BITS) >> USB_SIE_STATUS_LINE_STATE_LSB;
 }
 
-int64_t hw_enumeration_fix_wait_se0_callback(alarm_id_t id, void *user_data) {
+int64_t hw_enumeration_fix_wait_se0_callback(__unused alarm_id_t id, __unused void *user_data) {
     if (hw_line_state() == LS_SE0) {
         // Come back in 1ms and check again
         return 1000;
@@ -71,7 +71,7 @@ static void hw_enumeration_fix_wait_se0(void) {
     hw_enumeration_fix_busy_wait_se0();
 }
 
-int64_t hw_enumeration_fix_force_ls_j_done(alarm_id_t id, void *user_data) {
+int64_t hw_enumeration_fix_force_ls_j_done(__unused alarm_id_t id, __unused void *user_data) {
     hw_enumeration_fix_finish();
     return 0;
 }

--- a/src/rp2_common/pico_malloc/pico_malloc.c
+++ b/src/rp2_common/pico_malloc/pico_malloc.c
@@ -19,7 +19,7 @@ extern void __real_free(void *mem);
 
 extern char __StackLimit; /* Set by linker.  */
 
-static inline void check_alloc(void *mem, uint8_t size) {
+static inline void check_alloc(__unused void *mem, __unused uint8_t size) {
 #if PICO_MALLOC_PANIC
     if (!mem || (((char *)mem) + size) > &__StackLimit) {
         panic("Out of memory");

--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -83,6 +83,8 @@ int core1_wrapper(int (*entry)(void), void *stack_base) {
 #if PICO_USE_STACK_GUARDS
     // install core1 stack guard
     runtime_install_stack_guard(stack_base);
+#else
+    __unused void *ignore = stack_base;
 #endif
     irq_init_priorities();
     return (*entry)();
@@ -126,7 +128,7 @@ void multicore_launch_core1_with_stack(void (*entry)(void), uint32_t *stack_bott
 }
 
 void multicore_launch_core1(void (*entry)(void)) {
-    extern char __StackOneBottom;
+    extern uint32_t __StackOneBottom;
     uint32_t *stack_limit = (uint32_t *) &__StackOneBottom;
     // hack to reference core1_stack although that pointer is wrong.... core1_stack should always be <= stack_limit, if not boom!
     uint32_t *stack = core1_stack <= stack_limit ? stack_limit : (uint32_t *) -1;

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -156,7 +156,7 @@ void runtime_init(void) {
 
 }
 
-void _exit(int status) {
+void _exit(__unused int status) {
 #if PICO_ENTER_USB_BOOT_ON_EXIT
     reset_usb_boot(0,0);
 #else

--- a/src/rp2_common/pico_standard_link/new_delete.cpp
+++ b/src/rp2_common/pico_standard_link/new_delete.cpp
@@ -17,7 +17,7 @@ void *operator new[](std::size_t n) {
     return std::malloc(n);
 }
 
-void operator delete(void *p, std::size_t n) noexcept { std::free(p); }
+void operator delete(void *p, __unused std::size_t n) noexcept { std::free(p); }
 
 void operator delete(void *p) { std::free(p); }
 

--- a/test/kitchen_sink/CMakeLists.txt
+++ b/test/kitchen_sink/CMakeLists.txt
@@ -42,6 +42,11 @@ target_link_libraries(kitchen_sink_libs INTERFACE
     pico_unique_id
     pico_util
 )
+# todo this is full of warnings atm
+#if (TARGET tinyusb_device)
+#    target_include_directories(kitchen_sink_libs INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+#    target_link_libraries(kitchen_sink_libs INTERFACE tinyusb_device)
+#endif()
 
 add_library(kitchen_sink_options INTERFACE)
 
@@ -49,23 +54,27 @@ target_compile_options(kitchen_sink_options INTERFACE
         -Werror
         -Wall
         -Wextra
-        -Wno-unused-parameter
-        -Wno-inline
+        #        -pedantic
+
         -Wnull-dereference
-#        -pedantic
+        -Wuninitialized
+        -Wunused
+        -Wcast-align
         -Wall
         -Wcast-qual
-        -Wno-deprecated-declarations
         -Wfloat-equal
         -Wmissing-format-attribute
-        -Wno-long-long
         $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>
 
+        -Wno-inline
         # todo not sure these are true, but investigate
         #-Wpacked
+        # todo requires unsigned register constants
+        #-Wconversion
 
         # todo we have some of these in usb_device_tiny to try to make it more readable.. perhaps doxygen would help here instead
-        #-Wredundant-decls
+        -Wredundant-decls
+
         -Wno-shadow
         -Wno-missing-field-initializers
         -Wno-missing-braces

--- a/test/kitchen_sink/kitchen_sink.c
+++ b/test/kitchen_sink/kitchen_sink.c
@@ -27,10 +27,6 @@ bi_decl(bi_block_device(
                            BINARY_INFO_BLOCK_DEV_FLAG_READ | BINARY_INFO_BLOCK_DEV_FLAG_WRITE |
                                    BINARY_INFO_BLOCK_DEV_FLAG_PT_UNKNOWN));
 
-void my_timer(uint i) {
-    puts("XXXX timer");
-}
-
 //#pragma GCC push_options
 //#pragma GCC optimize ("O3")
 
@@ -87,7 +83,6 @@ int main(void) {
     dma_channel_configure(0, &config, &dma_to, &dma_from, 1, true);
     dma_channel_set_config(0, &config, false);
 
-//    timer_start_ms(2, 2000, my_timer);
     for (int i = 0; i < 20; i++) {
         puts("sleepy");
         sleep_ms(1000);


### PR DESCRIPTION
Add -Wuninitialized -Wunused -Wcast-align to warnings checked by kitchen_sink (and fixup warnings)