### PR TITLE
fix the representation of at_the_end_of_time

### DIFF
--- a/src/common/pico_base/include/pico.h
+++ b/src/common/pico_base/include/pico.h
@@ -17,7 +17,6 @@
 #include "pico/version.h"
 #include "pico/config.h"
 #include "pico/platform.h"
-#include "pico/assert.h"
 #include "pico/error.h"
 
 #endif

--- a/src/common/pico_base/include/pico/assert.h
+++ b/src/common/pico_base/include/pico/assert.h
@@ -7,7 +7,7 @@
 #ifndef _PICO_ASSERT_H
 #define _PICO_ASSERT_H
 
-#include "pico/types.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 

--- a/src/common/pico_base/include/pico/types.h
+++ b/src/common/pico_base/include/pico/types.h
@@ -27,8 +27,8 @@ typedef uint64_t absolute_time_t;
 
 /*! fn to_us_since_boot
  * \brief convert an absolute_time_t into a number of microseconds since boot.
- * \param t the number of microseconds since boot
- * \return an absolute_time_t value equivalent to t
+ * \param t the absolute time to convert
+ * \return a number of microseconds since boot, equivalent to t
  */
 static inline uint64_t to_us_since_boot(absolute_time_t t) {
     return t;
@@ -52,8 +52,8 @@ typedef struct {
 
 /*! fn to_us_since_boot
  * \brief convert an absolute_time_t into a number of microseconds since boot.
- * \param t the number of microseconds since boot
- * \return an absolute_time_t value equivalent to t
+ * \param t the absolute time to convert
+ * \return a number of microseconds since boot, equivalent to t
  */
 static inline uint64_t to_us_since_boot(absolute_time_t t) {
     return t._private_us_since_boot;

--- a/src/common/pico_base/include/pico/types.h
+++ b/src/common/pico_base/include/pico/types.h
@@ -7,13 +7,14 @@
 #ifndef _PICO_TYPES_H
 #define _PICO_TYPES_H
 
+#include "pico/assert.h"
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
 
 typedef unsigned int uint;
 
-#ifdef NDEBUG
 /*! \typedef absolute_time_t
     \brief An opaque 64 bit timestamp in microseconds
 
@@ -23,32 +24,13 @@ typedef unsigned int uint;
     \see to_us_since_boot
     \see update_us_since_boot
 */
+#ifndef NDEBUG
 typedef uint64_t absolute_time_t;
-
-/*! fn to_us_since_boot
- * \brief convert an absolute_time_t into a number of microseconds since boot.
- * \param t the absolute time to convert
- * \return a number of microseconds since boot, equivalent to t
- */
-static inline uint64_t to_us_since_boot(absolute_time_t t) {
-    return t;
-}
-
-/*! fn update_us_since_boot
- * \brief update an absolute_time_t value to represent a given number of microseconds since boot
- * \param t the absolute time value to update
- * \param us_since_boot the number of microseconds since boot to represent. Note this should be representable
- *                      as a signed 64 bit integer
- */
-static inline void update_us_since_boot(absolute_time_t *t, uint64_t us_since_boot) {
-    *t = us_since_boot;
-}
-
-#define ABSOLUTE_TIME_INITIALIZED_VAR(name, value) name = value
 #else
 typedef struct {
     uint64_t _private_us_since_boot;
 } absolute_time_t;
+#endif
 
 /*! fn to_us_since_boot
  * \brief convert an absolute_time_t into a number of microseconds since boot.
@@ -56,7 +38,11 @@ typedef struct {
  * \return a number of microseconds since boot, equivalent to t
  */
 static inline uint64_t to_us_since_boot(absolute_time_t t) {
+#ifndef NDEBUG
+    return t;
+#else
     return t._private_us_since_boot;
+#endif
 }
 
 /*! fn update_us_since_boot
@@ -66,9 +52,17 @@ static inline uint64_t to_us_since_boot(absolute_time_t t) {
  *                      as a signed 64 bit integer
  */
 static inline void update_us_since_boot(absolute_time_t *t, uint64_t us_since_boot) {
+#ifndef NDEBUG
+    *t = us_since_boot;
+#else
     assert(us_since_boot <= INT64_MAX);
     t->_private_us_since_boot = us_since_boot;
+#endif
 }
+
+#ifndef NDEBUG
+#define ABSOLUTE_TIME_INITIALIZED_VAR(name, value) name = value
+#else
 #define ABSOLUTE_TIME_INITIALIZED_VAR(name, value) name = {value}
 #endif
 

--- a/src/common/pico_base/include/pico/types.h
+++ b/src/common/pico_base/include/pico/types.h
@@ -37,7 +37,8 @@ static inline uint64_t to_us_since_boot(absolute_time_t t) {
 /*! fn update_us_since_boot
  * \brief update an absolute_time_t value to represent a given number of microseconds since boot
  * \param t the absolute time value to update
- * \param us_since_boot the number of microseconds since boot to represent
+ * \param us_since_boot the number of microseconds since boot to represent. Note this should be representable
+ *                      as a signed 64 bit integer
  */
 static inline void update_us_since_boot(absolute_time_t *t, uint64_t us_since_boot) {
     *t = us_since_boot;
@@ -49,11 +50,23 @@ typedef struct {
     uint64_t _private_us_since_boot;
 } absolute_time_t;
 
+/*! fn to_us_since_boot
+ * \brief convert an absolute_time_t into a number of microseconds since boot.
+ * \param t the number of microseconds since boot
+ * \return an absolute_time_t value equivalent to t
+ */
 static inline uint64_t to_us_since_boot(absolute_time_t t) {
     return t._private_us_since_boot;
 }
 
+/*! fn update_us_since_boot
+ * \brief update an absolute_time_t value to represent a given number of microseconds since boot
+ * \param t the absolute time value to update
+ * \param us_since_boot the number of microseconds since boot to represent. Note this should be representable
+ *                      as a signed 64 bit integer
+ */
 static inline void update_us_since_boot(absolute_time_t *t, uint64_t us_since_boot) {
+    assert(us_since_boot <= INT64_MAX);
     t->_private_us_since_boot = us_since_boot;
 }
 #define ABSOLUTE_TIME_INITIALIZED_VAR(name, value) name = {value}

--- a/src/common/pico_time/include/pico/time.h
+++ b/src/common/pico_time/include/pico/time.h
@@ -155,7 +155,9 @@ static inline int64_t absolute_time_diff_us(absolute_time_t from, absolute_time_
     return to_us_since_boot(to) - to_us_since_boot(from);
 }
 
-/*! \brief The timestamp representing the end of time; no timestamp is after this
+/*! \brief The timestamp representing the end of time; this is actually not the maximum possible
+ * timestamp, but is set to 0x7fffffff_ffffffff microseconds to avoid sign overflows with time
+ * arithmetic. This is still over 7 million years, so should be sufficient.
  * \ingroup timestamp
  */
 extern const absolute_time_t at_the_end_of_time;

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -11,10 +11,9 @@
 #include "pico/time.h"
 #include "pico/util/pheap.h"
 #include "hardware/sync.h"
-#include "hardware/gpio.h"
 
 const absolute_time_t ABSOLUTE_TIME_INITIALIZED_VAR(nil_time, 0);
-const absolute_time_t ABSOLUTE_TIME_INITIALIZED_VAR(at_the_end_of_time, ULONG_MAX);
+const absolute_time_t ABSOLUTE_TIME_INITIALIZED_VAR(at_the_end_of_time, INT64_MAX);
 
 typedef struct alarm_pool_entry {
     absolute_time_t target;

--- a/src/host/hardware_timer/timer.c
+++ b/src/host/hardware_timer/timer.c
@@ -51,7 +51,6 @@ uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(timer_us_32)() {
 PICO_WEAK_FUNCTION_DEF(time_reached)
 bool PICO_WEAK_FUNCTION_IMPL_NAME(time_reached)(absolute_time_t t) {
     uint64_t target = to_us_since_boot(t);
-    if (target > 0xffffffffu) return false;
     return time_us_64() >= target;
 }
 

--- a/test/pico_time_test/pico_time_test.c
+++ b/test/pico_time_test/pico_time_test.c
@@ -206,6 +206,15 @@ int main() {
 
     PICOTEST_END_SECTION();
 
+    PICOTEST_START_SECTION("end of time");
+    PICOTEST_CHECK(absolute_time_diff_us(at_the_end_of_time, get_absolute_time()) < 0, "now should be before the end of time")
+    PICOTEST_CHECK(absolute_time_diff_us(get_absolute_time(), at_the_end_of_time) > 0, "the end of time should be after now")
+    PICOTEST_CHECK(absolute_time_diff_us(at_the_end_of_time, at_the_end_of_time) == 0, "the end of time should equal itself")
+    absolute_time_t near_the_end_of_time;
+    update_us_since_boot(&near_the_end_of_time, 0x7ffffeffffffffff);
+    PICOTEST_CHECK(absolute_time_diff_us(near_the_end_of_time, at_the_end_of_time) > 0, "near the end of time should be before the end of time")
+    PICOTEST_END_SECTION();
+
     PICOTEST_END_TEST();
 }
 


### PR DESCRIPTION
at_the_end_of_time was erroneously ULONG_MAX which is only 32 bits; changed to INT64_MAX which is sufficiently far in the future, but allows for signed 64 bit arithmetic.