### PR TITLE
Missing comma in pioasm python wait output

### DIFF
--- a/tools/pioasm/python_output.cpp
+++ b/tools/pioasm/python_output.cpp
@@ -203,7 +203,7 @@ struct python_output : public output_format {
                         break;
                 }
                 if (!invalid) {
-                    guts = ((arg1 & 4u) ? "1 " : "0 ") + guts;
+                    guts = ((arg1 & 4u) ? "1, " : "0, ") + guts;
                     op("wait");
                     op_guts(guts);
                 }


### PR DESCRIPTION
Point fix for something I noticed in passing