### PR TITLE
systick cvr register is RW not RO

### DIFF
--- a/src/rp2040/hardware_structs/include/hardware/structs/systick.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/systick.h
@@ -13,7 +13,7 @@
 typedef struct {
     io_rw_32 csr;
     io_rw_32 rvr;
-    io_ro_32 cvr;
+    io_rw_32 cvr;
     io_ro_32 calib;
 } systick_hw_t;
 


### PR DESCRIPTION
As specified in the RP2040 datasheet the SYST_CVR register is RW. Writes are required to clear the current count value.