### PR TITLE
b0 sincos shim was incorrect, causing crash

### DIFF
--- a/src/rp2_common/pico_double/double_aeabi.S
+++ b/src/rp2_common/pico_double/double_aeabi.S
@@ -677,7 +677,7 @@ double_wrapper_section sincos
     bl sincostan_remainder
     pop {r2}
     mov lr, r2
-    b 1f
+    b 1f // continue with sincos
 
 wrapper_func sincos
     push {r2-r5, lr}
@@ -688,8 +688,7 @@ wrapper_func sincos
     cmp r2, #9
     bge 2b
 1:
-
-    bl 2f
+    bl 2f // call the shim
     pop {r4-r5}
     stmia r4!, {r0, r1}
     stmia r5!, {r2, r3}
@@ -697,16 +696,7 @@ wrapper_func sincos
 
 2:
     shimmable_table_tail_call SF_TABLE_V3_FSINCOS sincos_shim_bootstrap
-#if PICO_DOUBLE_PROPAGATE_NANS
-.align 2
-1:
-    pop {r2, r3}
-    stmia r2!, {r0, r1}
-    mov lr, r3
-    pop {r3}
-    stmia r3!, {r0, r1}
-    bx lr
-#endif
+
 .thumb_func
 sincos_shim_bootstrap:
     push {r2, r3, r4}

--- a/src/rp2_common/pico_double/double_v1_rom_shim.S
+++ b/src/rp2_common/pico_double/double_v1_rom_shim.S
@@ -1630,19 +1630,19 @@ double_section dsin_shim
  pop {r4-r7,r15}
 
 double_section dsincos_shim
+
+ @ Note that this function returns in r0-r3
  regular_func dsincos_shim
+
  push {r4-r7,r14}
  bl push_r8_r11
- push {r2-r3}
  bl dsincos_internal
  mov r12,r0                    @ save ε
  bl dcos_finish
  push {r0,r1}
  mov r0,r12
  bl dsin_finish
- pop {r2,r3,r4,r5}
- stmia r4!, {r0, r1}
- stmia r5!, {r2, r3}
+ pop {r2,r3}
  bl pop_r8_r11
  pop {r4-r7,r15}
 

--- a/test/pico_float_test/pico_double_test.c
+++ b/test/pico_float_test/pico_double_test.c
@@ -288,6 +288,8 @@ double bb = 1;
 int main() {
     setup_default_uart();
 
+    bool fail = false;
+
     printf("%d\n", aa < bb);
     for(double a = -1; a <= 1; a++) {
         for(double b = -1; b <= 1; b++) {
@@ -314,6 +316,10 @@ int main() {
         double s, c;
         sincos(x, &s, &c);
         printf("SINCOS %10.18f %10.18f\n", s, c);
+        if (s != sin(x) || c != cos(x)) {
+            printf("SINCOS mismatch\n");
+            fail = true;
+        }
     }
 
 #if PICO_DOUBLE_PROPAGATE_NANS
@@ -412,23 +418,18 @@ int main() {
         printf("%g %10.18g %10.18g, %10.18g, %10.18g %10.18g\n", x, f, x + 0.37777777777777777777777777777,
                x - 0.377777777777777777777777777777, g, 123456789.0 / x);
     }
-    if (test_cdcmpeq() || test_cdcmple() ||
-        test_dcmpun() || test_cmple_gt() || test_cmplt_ge()) {
+
+    if (fail ||
+        test_cdcmpeq() ||
+        test_cdcmple() ||
+        test_dcmpun() ||
+        test_cmple_gt() ||
+        test_cmplt_ge()) {
         printf("FAILED\n");
         return 1;
     } else {
         printf("PASSED\n");
         return 0;
     }
-
-    if (test_cdcmpeq() || test_cdcmple() ||
-        test_dcmpun() || test_cmple_gt() || test_cmplt_ge()) {
-        printf("FAILED\n");
-        return 1;
-    } else {
-        printf("PASSED\n");
-        return 0;
-    }
-
 #endif
 }


### PR DESCRIPTION
on B0 the sincos shim was written as a regular sincos method (i.e. expecting r2, r3 to be pointers for results) rather than returning values in r0-r3 as it should. This happened to be mostly harmless in the past, but got broken when fixes for out of range inputs were added (which meant shim was called without valid r2-r3)