### PR TITLE
Add 'hardware/structs/sio.h' header to the 'pico/multicore.h' header

### DIFF
--- a/src/rp2_common/pico_multicore/include/pico/multicore.h
+++ b/src/rp2_common/pico_multicore/include/pico/multicore.h
@@ -9,6 +9,7 @@
 
 #include "pico/types.h"
 #include "pico/sync.h"
+#include "hardware/structs/sio.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The `pico/multicore.h` header uses the `sio_hw` struct, but does not include the header that defines it. This normally is not a problem since other headers include the structure as well, but since this structure is used in the header, we should not rely on other headers bringing it in and instead include it directly