### PR TITLE
extract_configs: Do better matching-up of default values (regex was too strict)

### DIFF
--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -44,7 +44,7 @@
 
 #define FLASH_UNIQUE_ID_SIZE_BYTES 8
 
-// PICO_CONFIG: PICO_FLASH_SIZE_BYTES, size of primary flash in bytes, type=int, default=-1, group=hardware_flash
+// PICO_CONFIG: PICO_FLASH_SIZE_BYTES, size of primary flash in bytes, type=int, group=hardware_flash
 #ifndef PICO_FLASH_SIZE_BYTES
 #warning PICO_FLASH_SIZE_BYTES is not set
 #endif


### PR DESCRIPTION
also error if PICO_CONFIG says there's a default but no matching #define is found