### PR TITLE
Default PARAM_ASSERTIONS_ENABLED_LOCK_CORE to 0

### DIFF
--- a/src/common/pico_sync/include/pico/lock_core.h
+++ b/src/common/pico_sync/include/pico/lock_core.h
@@ -10,9 +10,9 @@
 #include "pico.h"
 #include "hardware/sync.h"
 
-// PICO_CONFIG: PARAM_ASSERTIONS_ENABLED_LOCK_CORE, Enable/disable assertions in the lock core, type=bool, default=1, group=pico_sync
+// PICO_CONFIG: PARAM_ASSERTIONS_ENABLED_LOCK_CORE, Enable/disable assertions in the lock core, type=bool, default=0, group=pico_sync
 #ifndef PARAM_ASSERTIONS_ENABLED_LOCK_CORE
-#define PARAM_ASSERTIONS_ENABLED_LOCK_CORE 1
+#define PARAM_ASSERTIONS_ENABLED_LOCK_CORE 0
 #endif
 
 /** \file lock_core.h


### PR DESCRIPTION
so that it matches all the other PARAM_ASSERTIONS_* default values