### PR TITLE
Replace unavailable flag-preserving instruction

### DIFF
--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -79,7 +79,7 @@ bool clock_configure(enum clock_index clk_index, uint32_t src, uint32_t auxsrc, 
             uint delay_cyc = configured_freq[clk_sys] / configured_freq[clk_index] + 1;
             asm volatile (
                 "1: \n\t"
-                "sub %0, #1 \n\t"
+                "subs %0, #1 \n\t"
                 "bne 1b"
                 : "+r" (delay_cyc)
             );

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -78,6 +78,7 @@ bool clock_configure(enum clock_index clk_index, uint32_t src, uint32_t auxsrc, 
             // necessarily running, nor is timer... so, 3 cycles per loop:
             uint delay_cyc = configured_freq[clk_sys] / configured_freq[clk_index] + 1;
             asm volatile (
+                ".syntax unified \n\t"
                 "1: \n\t"
                 "subs %0, #1 \n\t"
                 "bne 1b"


### PR DESCRIPTION
It seems sub requires thumb2 instructions which are unavailable. This is in line with the rest of the sdk code base which uses subs.