### PR TITLE
add Adafruit feather, itsybitsy, qtpy board headers

### DIFF
--- a/src/boards/include/boards/adafruit_feather_rp2040.h
+++ b/src/boards/include/boards/adafruit_feather_rp2040.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+#ifndef _BOARDS_ADAFRUIT_FEATHER_RP2040_H
+#define _BOARDS_ADAFRUIT_FEATHER_RP2040_H
+
+// For board detection
+#define ADAFRUIT_FEATHER_RP2040
+
+//------------- UART -------------//
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+//------------- LED -------------//
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 13
+#endif
+
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 16
+#endif
+
+//------------- I2C -------------//
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 2
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 3
+#endif
+
+//------------- SPI -------------//
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+
+#ifndef PICO_DEFAULT_SPI_MOSI_PIN
+#define PICO_DEFAULT_SPI_MOSI_PIN 19
+#endif
+
+#ifndef PICO_DEFAULT_SPI_MISO_PIN
+#define PICO_DEFAULT_SPI_MISO_PIN 20
+#endif
+
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+
+
+//------------- FLASH -------------//
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_FLOAT_SUPPORT_ROM_V1
+#define PICO_FLOAT_SUPPORT_ROM_V1 0
+#endif
+
+#ifndef PICO_DOUBLE_SUPPORT_ROM_V1
+#define PICO_DOUBLE_SUPPORT_ROM_V1 0
+#endif
+
+#endif

--- a/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
+++ b/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+#ifndef _BOARDS_ADAFRUIT_ITSYBITSY_RP2040_H
+#define _BOARDS_ADAFRUIT_ITSYBITSY_RP2040_H
+
+// For board detection
+#define ADAFRUIT_ITSYBITSY_RP2040
+
+//------------- UART -------------//
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+//------------- LED -------------//
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 11
+#endif
+
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 17 // power enable is pin 16
+#endif
+
+//------------- I2C -------------//
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 2
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 3
+#endif
+
+//------------- SPI -------------//
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+
+#ifndef PICO_DEFAULT_SPI_MOSI_PIN
+#define PICO_DEFAULT_SPI_MOSI_PIN 19
+#endif
+
+#ifndef PICO_DEFAULT_SPI_MISO_PIN
+#define PICO_DEFAULT_SPI_MISO_PIN 20
+#endif
+
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+
+//------------- FLASH -------------//
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_FLOAT_SUPPORT_ROM_V1
+#define PICO_FLOAT_SUPPORT_ROM_V1 0
+#endif
+
+#ifndef PICO_DOUBLE_SUPPORT_ROM_V1
+#define PICO_DOUBLE_SUPPORT_ROM_V1 0
+#endif
+
+#endif

--- a/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
+++ b/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
@@ -34,7 +34,11 @@
 #endif
 
 #ifndef PICO_DEFAULT_WS2812_PIN
-#define PICO_DEFAULT_WS2812_PIN 17 // power enable is pin 16
+#define PICO_DEFAULT_WS2812_PIN 17
+#endif
+
+#ifndef PICO_DEFAULT_WS2812_POWER_PIN
+#define PICO_DEFAULT_WS2812_POWER_PIN 16
 #endif
 
 //------------- I2C -------------//

--- a/src/boards/include/boards/adafruit_qtpy_rp2040.h
+++ b/src/boards/include/boards/adafruit_qtpy_rp2040.h
@@ -33,7 +33,11 @@
 // #define PICO_DEFAULT_LED_PIN 13
 
 #ifndef PICO_DEFAULT_WS2812_PIN
-#define PICO_DEFAULT_WS2812_PIN 12 // power enable is pin 11
+#define PICO_DEFAULT_WS2812_PIN 12
+#endif
+
+#ifndef PICO_DEFAULT_WS2812_POWER_PIN
+#define PICO_DEFAULT_WS2812_POWER_PIN 11
 #endif
 
 //------------- I2C -------------//

--- a/src/boards/include/boards/adafruit_qtpy_rp2040.h
+++ b/src/boards/include/boards/adafruit_qtpy_rp2040.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+#ifndef _BOARDS_ADAFRUIT_QTPY_RP2040_H
+#define _BOARDS_ADAFRUIT_QTPY_RP2040_H
+
+// For board detection
+#define ADAFRUIT_QTPY_RP2040
+
+//------------- UART -------------//
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 20
+#endif
+
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 9
+#endif
+
+//------------- LED -------------//
+// No normal LED
+// #define PICO_DEFAULT_LED_PIN 13
+
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 12 // power enable is pin 11
+#endif
+
+//------------- I2C -------------//
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 24
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 25
+#endif
+
+//------------- SPI -------------//
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+
+#ifndef PICO_DEFAULT_SPI_MOSI_PIN
+#define PICO_DEFAULT_SPI_MOSI_PIN 3
+#endif
+
+#ifndef PICO_DEFAULT_SPI_MISO_PIN
+#define PICO_DEFAULT_SPI_MISO_PIN 4
+#endif
+
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 6
+#endif
+
+//------------- FLASH -------------//
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_FLOAT_SUPPORT_ROM_V1
+#define PICO_FLOAT_SUPPORT_ROM_V1 0
+#endif
+
+#ifndef PICO_DOUBLE_SUPPORT_ROM_V1
+#define PICO_DOUBLE_SUPPORT_ROM_V1 0
+#endif
+
+#endif


### PR DESCRIPTION
This PR adds board headers for Adafruit
- [Feather RP2040](https://www.adafruit.com/product/4884)
- [Itsy Bitsy RP2040](https://www.adafruit.com/product/4888)
- [QT Py RP2040](https://www.adafruit.com/product/4900)

I didn't see any boards define SPI pin, but the name is very obvious. Let me know if you would like to change the name 
- PICO_DEFAULT_SPI
- PICO_DEFAULT_SPI_MOSI_PIN
- PICO_DEFAULT_SPI_MISO_PIN
- PICO_DEFAULT_SPI_SCK_PIN

PS: It would be nice if this PR is merged before #192 , so that it got updated as well.

@ladyada