### PR TITLE
Fixup PICO_CONFIG entries

### DIFF
--- a/src/common/pico_stdlib/include/pico/stdlib.h
+++ b/src/common/pico_stdlib/include/pico/stdlib.h
@@ -56,15 +56,15 @@ extern "C" {
 #include "pico/stdio_semihosting.h"
 #endif
 
-// PICO_CONFIG: PICO_DEFAULT_LED_PIN, Optionally defined a pin that drives a regular LED on the board, default=undefined, group=pico_stdlib
+// PICO_CONFIG: PICO_DEFAULT_LED_PIN, Optionally define a pin that drives a regular LED on the board, group=pico_stdlib
 
-// PICO_CONFIG: PICO_DEFAULT_LED_PIN_INVERTED, 1 if LED is inverted, 0 otherwise, type=int, default=0, group=pico_stdlib
+// PICO_CONFIG: PICO_DEFAULT_LED_PIN_INVERTED, 1 if LED is inverted or 0 if not, type=int, default=0, group=pico_stdlib
 #ifndef PICO_DEFAULT_LED_PIN_INVERTED
 #define PICO_DEFAULT_LED_PIN_INVERTED 0
 #endif
 
-// PICO_CONFIG: PICO_DEFAULT_WS2812_PIN, Optionally defined a pin that controls data to a WS2812 compatible LED on the board, default=undefined, group=pico_stdlib
-// PICO_CONFIG: PICO_DEFAULT_WS2812_POWER_PIN, Optionally defined a pin that controls power to a WS2812 compatible LED on the board, default=undefined, group=pico_stdlib
+// PICO_CONFIG: PICO_DEFAULT_WS2812_PIN, Optionally define a pin that controls data to a WS2812 compatible LED on the board, group=pico_stdlib
+// PICO_CONFIG: PICO_DEFAULT_WS2812_POWER_PIN, Optionally define a pin that controls power to a WS2812 compatible LED on the board, group=pico_stdlib
 
 /*! \brief Set up the default UART and assign it to the default GPIO's
  *  \ingroup pico_stdlib

--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -48,9 +48,9 @@ extern "C" {
 
 typedef struct i2c_inst i2c_inst_t;
 
-// PICO_CONFIG: PICO_DEFAULT_I2C, Define the default I2C for a board, default=undefined, group=hardware_i2c
-// PICO_CONFIG: PICO_DEFAULT_I2C_SDA_PIN, Define the default I2C SDA, min=0, max=29, default=undefined, group=hardware_i2c
-// PICO_CONFIG: PICO_DEFAULT_I2C_SCL_PIN, Define the default I2C SCL pin, min=0, max=29, default=undefined, group=hardware_i2c
+// PICO_CONFIG: PICO_DEFAULT_I2C, Define the default I2C for a board, group=hardware_i2c
+// PICO_CONFIG: PICO_DEFAULT_I2C_SDA_PIN, Define the default I2C SDA pin, min=0, max=29, group=hardware_i2c
+// PICO_CONFIG: PICO_DEFAULT_I2C_SCL_PIN, Define the default I2C SCL pin, min=0, max=29, group=hardware_i2c
 
 /** The I2C identifiers for use in I2C functions.
  *

--- a/src/rp2_common/hardware_spi/include/hardware/spi.h
+++ b/src/rp2_common/hardware_spi/include/hardware/spi.h
@@ -35,11 +35,11 @@ extern "C" {
  * Each controller can be connected to a number of GPIO pins, see the datasheet GPIO function selection table for more information.
  */
 
-// PICO_CONFIG: PICO_DEFAULT_SPI, Define the default SPI for a board, default=undefined, group=hardware_spi
-// PICO_CONFIG: PICO_DEFAULT_SPI_SCK_PIN, Define the default SPI SCK pin, min=0, max=29, default=undefined, group=hardware_spi
-// PICO_CONFIG: PICO_DEFAULT_SPI_TX_PIN, Define the default SPI TX pin, min=0, max=29, default=undefined, group=hardware_spi
-// PICO_CONFIG: PICO_DEFAULT_SPI_RX_PIN, Define the default SPI RX pin, min=0, max=29, default=undefined, group=hardware_spi
-// PICO_CONFIG: PICO_DEFAULT_SPI_CSN_PIN, Define the default SPI CSN pin, min=0, max=29, default=undefined, group=hardware_spi
+// PICO_CONFIG: PICO_DEFAULT_SPI, Define the default SPI for a board, group=hardware_spi
+// PICO_CONFIG: PICO_DEFAULT_SPI_SCK_PIN, Define the default SPI SCK pin, min=0, max=29, group=hardware_spi
+// PICO_CONFIG: PICO_DEFAULT_SPI_TX_PIN, Define the default SPI TX pin, min=0, max=29, group=hardware_spi
+// PICO_CONFIG: PICO_DEFAULT_SPI_RX_PIN, Define the default SPI RX pin, min=0, max=29, group=hardware_spi
+// PICO_CONFIG: PICO_DEFAULT_SPI_CSN_PIN, Define the default SPI CSN pin, min=0, max=29, group=hardware_spi
 
 /**
  * Opaque type representing an SPI instance.

--- a/src/rp2_common/hardware_uart/include/hardware/uart.h
+++ b/src/rp2_common/hardware_uart/include/hardware/uart.h
@@ -29,9 +29,9 @@ extern "C" {
 #define PICO_UART_DEFAULT_CRLF 0
 #endif
 
-// PICO_CONFIG: PICO_DEFAULT_UART, Define the default UART used for printf etc, default=undefined, group=hardware_uart
-// PICO_CONFIG: PICO_DEFAULT_UART_TX_PIN, Define the default UART TX pin, min=0, max=29, default=undefined, group=hardware_uart
-// PICO_CONFIG: PICO_DEFAULT_UART_RX_PIN, Define the default UART RX pin, min=0, max=29, default=undefined, group=hardware_uart
+// PICO_CONFIG: PICO_DEFAULT_UART, Define the default UART used for printf etc, group=hardware_uart
+// PICO_CONFIG: PICO_DEFAULT_UART_TX_PIN, Define the default UART TX pin, min=0, max=29, group=hardware_uart
+// PICO_CONFIG: PICO_DEFAULT_UART_RX_PIN, Define the default UART RX pin, min=0, max=29, group=hardware_uart
 
 // PICO_CONFIG: PICO_DEFAULT_UART_BAUD_RATE, Define the default UART baudrate, max=921600, default=115200, group=hardware_uart
 #ifndef PICO_DEFAULT_UART_BAUD_RATE

--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
@@ -49,7 +49,7 @@
 #define PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE 1
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE, baud rate that if selected causes a reset into BOOTSEL mode (if PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE==1), default=1200, group=pico_stdio_usb
+// PICO_CONFIG: PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE, baud rate that if selected causes a reset into BOOTSEL mode (if PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=pico_stdio_usb
 #ifndef PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE
 #define PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE 1200
 #endif


### PR DESCRIPTION
 * remove default=undefined
 * fix a couple of typos / syntax "errors"
 * perform even better default-value-checking in extract_configs.py