### PR TITLE
Previous change didn't allow CI checks to run when an external fork PRs to raspberrypi

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,5 @@
 name: CMake
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
ping @JamesH65 and @liamfraser again :wink: 