### PR TITLE
Remove PICO_FLASH_SIZE_BYTES warning from header to allow -Werror

### DIFF
--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -45,9 +45,6 @@
 #define FLASH_UNIQUE_ID_SIZE_BYTES 8
 
 // PICO_CONFIG: PICO_FLASH_SIZE_BYTES, size of primary flash in bytes, type=int, group=hardware_flash
-#ifndef PICO_FLASH_SIZE_BYTES
-#warning PICO_FLASH_SIZE_BYTES is not set
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/rp2_common/pico_double/double_init_rom.c
+++ b/src/rp2_common/pico_double/double_init_rom.c
@@ -13,7 +13,7 @@
 uint32_t sd_table[SF_TABLE_V2_SIZE / 2];
 
 #if !PICO_DOUBLE_SUPPORT_ROM_V1
-static __attribute__((noreturn)) void missing_double_func_shim() {
+static __attribute__((noreturn)) void missing_double_func_shim(void) {
     panic("missing double function");
 }
 #endif

--- a/src/rp2_common/pico_float/float_init_rom.c
+++ b/src/rp2_common/pico_float/float_init_rom.c
@@ -14,7 +14,7 @@ uint32_t sf_table[SF_TABLE_V2_SIZE / 2];
 void *sf_clz_func;
 
 #if !PICO_FLOAT_SUPPORT_ROM_V1
-static __attribute__((noreturn)) void missing_float_func_shim() {
+static __attribute__((noreturn)) void missing_float_func_shim(void) {
     panic("");
 }
 #endif


### PR DESCRIPTION
it breaks any build with -Werror; actual uses in C/CXX source that care should warn instead