### PR TITLE
pio: allow programs with 32 instructions

### DIFF
--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -60,7 +60,7 @@ static_assert(PIO_INSTRUCTION_COUNT <= 32, "");
 static uint32_t _used_instruction_space[2];
 
 static int _pio_find_offset_for_program(PIO pio, const pio_program_t *program) {
-    assert(program->length < PIO_INSTRUCTION_COUNT);
+    assert(program->length <= PIO_INSTRUCTION_COUNT);
     uint32_t used_mask = _used_instruction_space[pio_get_index(pio)];
     uint32_t program_mask = (1u << program->length) - 1;
     if (program->origin >= 0) {


### PR DESCRIPTION
The PIO library currently errors when trying to find an offset for PIO programs with exactly 32 instructions.

I assume that this is a bug (?), because pioasm only errors (correctly) when a program has 33 instructions or more.