### PR TITLE
corrected clk_gpout3 to gpio pin 25 as per the rp2040 datasheet

### DIFF
--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -322,7 +322,7 @@ void clock_gpio_init(uint gpio, uint src, uint div) {
     if      (gpio == 21) gpclk = clk_gpout0;
     else if (gpio == 23) gpclk = clk_gpout1;
     else if (gpio == 24) gpclk = clk_gpout2;
-    else if (gpio == 26) gpclk = clk_gpout3;
+    else if (gpio == 25) gpclk = clk_gpout3;
     else {
         invalid_params_if(CLOCKS, true);
     }

--- a/src/rp2_common/hardware_clocks/include/hardware/clocks.h
+++ b/src/rp2_common/hardware_clocks/include/hardware/clocks.h
@@ -170,7 +170,7 @@ void clocks_enable_resus(resus_callback_t resus_callback);
 /*! \brief Output an optionally divided clock to the specified gpio pin.
  *  \ingroup hardware_clocks
  *
- * \param gpio The GPIO pin to output the clock to. Valid GPIOs are: 21, 23, 24, 26. These GPIOs are connected to the GPOUT0-3 clock generators.
+ * \param gpio The GPIO pin to output the clock to. Valid GPIOs are: 21, 23, 24, 25. These GPIOs are connected to the GPOUT0-3 clock generators.
  * \param src  The source clock. See the register field CLOCKS_CLK_GPOUT0_CTRL_AUXSRC for a full list. The list is the same for each GPOUT clock generator.
  * \param div  The amount to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock.
  */


### PR DESCRIPTION
According to the RP2040 datasheet (https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf - 1.4.3. GPIO Functions table on page 14) the GPIO pin **25** is designated for clk_gpout3.

![gpout3](https://user-images.githubusercontent.com/1939103/110841927-c7035b00-82a6-11eb-8627-5c9d124bca1b.png)
