### PR TITLE
Fix loading of PICO_TOOLCHAIN_PATH

### DIFF
--- a/cmake/pico_pre_load_toolchain.cmake
+++ b/cmake/pico_pre_load_toolchain.cmake
@@ -1,6 +1,5 @@
 # PICO_CMAKE_CONFIG: PICO_TOOLCHAIN_PATH, Path to search for compiler, default=none (i.e. search system paths), group=build
-# Set your compiler path here if it's not in the PATH environment variable.
-set(PICO_TOOLCHAIN_PATH "" CACHE INTERNAL "")
+set(PICO_TOOLCHAIN_PATH "${PICO_TOOLCHAIN_PATH}" CACHE INTERNAL "")
 
 # Set a default build type if none was specified
 set(default_build_type "Release")


### PR DESCRIPTION
- Add double quotes because build option it's a string.
- Remove comment as requested by @kilograham.
- Resolves #258.