### PR TITLE
Allow heap end to be equal to stack limit

### DIFF
--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -175,9 +175,9 @@ void *_sbrk(int incr) {
     prev_heap_end = heap_end;
     char *next_heap_end = heap_end + incr;
 
-    if (__builtin_expect(next_heap_end >= (&__StackLimit), false)) {
+    if (__builtin_expect(next_heap_end > (&__StackLimit), false)) {
 #if PICO_USE_OPTIMISTIC_SBRK
-        if (next_heap_end == &__StackLimit) {
+        if (heap_end == &__StackLimit) {
 //        errno = ENOMEM;
             return (char *) -1;
         }


### PR DESCRIPTION
Currently malloc won't allocate the last 4KB of RAM because the check against StackLimit uses `>=` not `>`, this fixes that.

Additionally in "optimistic" mode the allocation should fail if the *last* allocation took the heap end to the limit, not if the *current* allocation is going to do so.

This fixes issue #264.