### PR TITLE
Make flash_do_cmd public

### DIFF
--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -123,9 +123,7 @@ static void __no_inline_not_in_flash_func(flash_cs_force)(bool high) {
     );
 }
 
-// May want to expose this at some point but this is unlikely to be the right
-// interface to do so. Keep it static
-static void __no_inline_not_in_flash_func(flash_do_cmd)(const uint8_t *txbuf, uint8_t *rxbuf, size_t count) {
+void __no_inline_not_in_flash_func(flash_do_cmd)(const uint8_t *txbuf, uint8_t *rxbuf, size_t count) {
     void (*connect_internal_flash)(void) = (void(*)(void))rom_func_lookup(rom_table_code('I', 'F'));
     void (*flash_exit_xip)(void) = (void(*)(void))rom_func_lookup(rom_table_code('E', 'X'));
     void (*flash_flush_cache)(void) = (void(*)(void))rom_func_lookup(rom_table_code('F', 'C'));

--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -80,6 +80,22 @@ void flash_range_program(uint32_t flash_offs, const uint8_t *data, size_t count)
  */
 void flash_get_unique_id(uint8_t *id_out);
 
+/*! \brief Execute bidirectional flash command
+ *  \ingroup hardware_flash
+ *
+ * Execute a bidirectional command to the flash. Bytes are simultaneously
+ * transmitted and received. Therefore, both buffers must be the same length,
+ * count, which is the lenght of the overall transaction. This is useful for
+ * reading metadata from the flash chip. Do *NOT* use it to mutate the data
+ * stored on the flash because it will not flush the cache.
+ *
+ *  \param txbuf Pointer to a byte buffer which will be transmitted to the flash
+ *  \param rxbuf Pointer to a byte buffer where data received from the flash will be written
+ *  \param count Length in bytes of txbuf and of rxbuf
+ */
+void flash_do_cmd(const uint8_t *txbuf, uint8_t *rxbuf, size_t count);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -85,7 +85,7 @@ void flash_get_unique_id(uint8_t *id_out);
  *
  * Execute a bidirectional command to the flash. Bytes are simultaneously
  * transmitted and received. Therefore, both buffers must be the same length,
- * count, which is the lenght of the overall transaction. This is useful for
+ * count, which is the length of the overall transaction. This is useful for
  * reading metadata from the flash chip. Do *NOT* use it to mutate the data
  * stored on the flash because it will not flush the cache.
  *


### PR DESCRIPTION
This makes flash_do_cmd public. We're using it in CircuitPython to read the RDID register to determine the flash size. (We always link to 1MB and the rest is used for the user filesystem.)