### PR TITLE
i2c: set hold time of SDA during transmit to an appropriate value

### DIFF
--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -76,11 +76,11 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
     invalid_params_if(I2C, lcnt < 8);
 
     // The SDA hold time should be at least 300 ns, per the I2C standard.
-    // sda_hold_count [cycles] = freq_in [cycles/s] * 300ns * (1s / 1e9ns)
+    // sda_tx_hold_count [cycles] = freq_in [cycles/s] * 300ns * (1s / 1e9ns)
     // Reduce 300/1e9 to 3/1e7 to avoid numbers that don't fit in uint.
     // Add 1 to avoid division truncation.
-    uint sda_hold_count = ((freq_in * 3) / 10000000) + 1;
-    invalid_params_if(I2C, sda_hold_count > lcnt - 2);
+    uint sda_tx_hold_count = ((freq_in * 3) / 10000000) + 1;
+    invalid_params_if(I2C, sda_tx_hold_count > lcnt - 2);
 
     i2c->hw->enable = 0;
     // Always use "fast" mode (<= 400 kHz, works fine for standard mode too)
@@ -92,7 +92,7 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
     i2c->hw->fs_scl_lcnt = lcnt;
     i2c->hw->fs_spklen = lcnt < 16 ? 1 : lcnt / 16;
     hw_write_masked(&i2c->hw->sda_hold,
-                    sda_hold_count,
+                    sda_tx_hold_count,
                     I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_BITS);
 
     i2c->hw->enable = 1;

--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -87,9 +87,9 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
         sda_tx_hold_count = ((freq_in * 3) / 10000000) + 1;
     } else {
         // sda_tx_hold_count = freq_in [cycles/s] * 120ns * (1s / 1e9ns)
-        // Reduce 120/1e9 to 12/1e8 to avoid numbers that don't fit in uint.
+        // Reduce 120/1e9 to 3/25e6 to avoid numbers that don't fit in uint.
         // Add 1 to avoid division truncation.
-        sda_tx_hold_count = ((freq_in * 12) / 100000000) + 1;
+        sda_tx_hold_count = ((freq_in * 3) / 25000000) + 1;
     }
     assert(sda_tx_hold_count <= lcnt - 2);
 

--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -75,11 +75,22 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
     invalid_params_if(I2C, hcnt < 8);
     invalid_params_if(I2C, lcnt < 8);
 
-    // The SDA hold time should be at least 300 ns, per the I2C standard.
-    // sda_tx_hold_count [cycles] = freq_in [cycles/s] * 300ns * (1s / 1e9ns)
-    // Reduce 300/1e9 to 3/1e7 to avoid numbers that don't fit in uint.
-    // Add 1 to avoid division truncation.
-    uint sda_tx_hold_count = ((freq_in * 3) / 10000000) + 1;
+    // Per I2C-bus specification a device in standard or fast mode must
+    // internally provide a hold time of at least 300ns for the SDA signal to
+    // bridge the undefined region of the falling edge of SCL. A smaller hold
+    // time of 120ns is used for fast mode plus.
+    uint sda_tx_hold_count;
+    if (baudrate < 1000000) {
+        // sda_tx_hold_count = freq_in [cycles/s] * 300ns * (1s / 1e9ns)
+        // Reduce 300/1e9 to 3/1e7 to avoid numbers that don't fit in uint.
+        // Add 1 to avoid division truncation.
+        sda_tx_hold_count = ((freq_in * 3) / 10000000) + 1;
+    } else {
+        // sda_tx_hold_count = freq_in [cycles/s] * 120ns * (1s / 1e9ns)
+        // Reduce 120/1e9 to 12/1e8 to avoid numbers that don't fit in uint.
+        // Add 1 to avoid division truncation.
+        sda_tx_hold_count = ((freq_in * 12) / 100000000) + 1;
+    }
     assert(sda_tx_hold_count <= lcnt - 2);
 
     i2c->hw->enable = 0;

--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -103,7 +103,7 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
     i2c->hw->fs_scl_lcnt = lcnt;
     i2c->hw->fs_spklen = lcnt < 16 ? 1 : lcnt / 16;
     hw_write_masked(&i2c->hw->sda_hold,
-                    sda_tx_hold_count,
+                    sda_tx_hold_count << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_LSB,
                     I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_BITS);
 
     i2c->hw->enable = 1;

--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -84,6 +84,10 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
     i2c->hw->fs_scl_hcnt = hcnt;
     i2c->hw->fs_scl_lcnt = lcnt;
     i2c->hw->fs_spklen = lcnt < 16 ? 1 : lcnt / 16;
+    // Set hold time of SDA during transmit to 2 for TCS34725 color sensor
+    i2c->hw->sda_hold =
+            I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_RESET << I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_LSB |
+            2 << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_LSB;
 
     i2c->hw->enable = 1;
     return freq_in / period;

--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -80,7 +80,7 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
     // Reduce 300/1e9 to 3/1e7 to avoid numbers that don't fit in uint.
     // Add 1 to avoid division truncation.
     uint sda_tx_hold_count = ((freq_in * 3) / 10000000) + 1;
-    invalid_params_if(I2C, sda_tx_hold_count > lcnt - 2);
+    assert(sda_tx_hold_count <= lcnt - 2);
 
     i2c->hw->enable = 0;
     // Always use "fast" mode (<= 400 kHz, works fine for standard mode too)


### PR DESCRIPTION
Fixes https://github.com/adafruit/circuitpython/issues/4082

~~Increases the set hold time of SDA during transmit from its default value of 1 to 2 enabling pico-sdk to function correctly with the TCS34725 color sensor.~~

On page 48 of the [I2C-bus specification and user manual](https://www.nxp.com/docs/en/user-guide/UM10204.pdf) Table 10 lists the "Characteristics of the SDA and SCL bus lines for Standard, Fast, and Fast-mode Plus I2C-bus devices". Below this table note [3] mentions the following:

> [3] A device must internally provide a hold time of at least 300 ns for the SDA signal (with respect to the V IH(min) of the SCL signal) to bridge the undefined region of the falling edge of SCL.

This PR sets the IC_SDA_TX_HOLD field in the IC_SDA_HOLD register to value required for a hold time of 300 ns in Standard-mode and Fast-mode and 120 ns  in Fast-mode Plus.

The following tests were performed with this PR at 10000, 100000 and 400000 baud with two devices ([MCP9808](https://www.adafruit.com/product/1782) and [TCS34725](https://www.adafruit.com/product/1334)) on the I2C bus and all tests ran successfully.

- Scan the I2C bus with [bus_scan](https://github.com/raspberrypi/pico-examples/tree/master/i2c/bus_scan) from pico-examples. Without this this PR the TCS34725 is not detected. With this PR the TCS34725 is detected.
- Read the Device ID register form the TCS34725. Without this PR there is an error. With this PR the Device ID register can be successfully read and is 0x44.
- Read the temperature from the MCP9808 temperature sensor in an infinite loop (works with or without this PR.)

Tests were also successfully performed with a BME280 and TCS34725 at 1000000 baud.

~~Unfortunately, I can't really explain why the modification made by this PR is needed to to get pico-sdk to function correctly with the TCS34725. According to figure 11 on page 10 of the [TCS34725 datasheet](https://www.mouser.de/datasheet/2/588/TCS3472_DS000390_3-00-1844543.pdf) the minimum data hold time, t(HDDAT), is 0μs and the maximum is 0.9μs. However, the notes below figure 11 do say the following:~~

~~Note(s):~~
~~1. Specified by design and characterization; not production tested.~~
