### PR TITLE
Adafruit Feather RP2040 fixes

### DIFF
--- a/src/boards/include/boards/adafruit_feather_rp2040.h
+++ b/src/boards/include/boards/adafruit_feather_rp2040.h
@@ -69,11 +69,11 @@
 
 //------------- FLASH -------------//
 #ifndef PICO_FLASH_SPI_CLKDIV
-#define PICO_FLASH_SPI_CLKDIV 2
+#define PICO_FLASH_SPI_CLKDIV 4
 #endif
 
 #ifndef PICO_FLASH_SIZE_BYTES
-#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 #endif
 
 // All boards have B1 RP2040


### PR DESCRIPTION
The following changes are based on information from the Adafruit forum: https://forums.adafruit.com/viewtopic.php?f=57&t=176745&p=860819&hilit=rp2040#p860819

The pre-built CircuitPython .uf2 was working on my board, but none of the `pico-examples` were without the following SDK changes.

1) The board has 8 MB of flash according to the product page: https://www.adafruit.com/product/4884

2) CircultPython sets `PICO_FLASH_SPI_CLKDIV` to `4`: https://github.com/adafruit/circuitpython/blob/main/ports/raspberrypi/Makefile#L237

3) CircultPython uses `boot2_generic_03h.S` for boot2: https://github.com/adafruit/circuitpython/blob/main/ports/raspberrypi/Makefile#L236 

There's probably a better have a board specific `PICO_DEFAULT_BOOT_STAGE2_FILE` value instead of editing `src/rp2_common/boot_stage2/CMakeLists.txt` - but I wanted to get the discussion going :)