### PR TITLE
Fix implementation config listing in structs/i2c.h

### DIFF
--- a/src/rp2040/hardware_structs/include/hardware/structs/i2c.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/i2c.h
@@ -68,7 +68,7 @@ typedef struct {
 // IC_UFM_SCL_HIGH_COUNT ............. 0x0006
 // IC_TX_TL .......................... 0x0
 // IC_TX_CMD_BLOCK ................... 0x1
-// IC_HAS_DMA ........................ 0x0
+// IC_HAS_DMA ........................ 0x1
 // IC_HAS_ASYNC_FIFO ................. 0x0
 // IC_SMBUS_ARP ...................... 0x0
 // IC_FIRST_DATA_BYTE_STATUS ......... 0x1


### PR DESCRIPTION
See conversation on #324. Missing automation link.