### PR TITLE
Add networking stack from TinyUSB.

### DIFF
--- a/src/rp2_common/tinyusb/CMakeLists.txt
+++ b/src/rp2_common/tinyusb/CMakeLists.txt
@@ -46,6 +46,7 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
             ${PICO_TINYUSB_PATH}/src
             ${PICO_TINYUSB_PATH}/src/common
             ${PICO_TINYUSB_PATH}/hw
+            ${PICO_TINYUSB_PATH}/lib/networking
     )
 
     add_library(tinyusb_device_unmarked INTERFACE)
@@ -91,6 +92,13 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
             ${PICO_TINYUSB_PATH}/src/class/hid/hid_host.c
             ${PICO_TINYUSB_PATH}/src/class/msc/msc_host.c
             ${PICO_TINYUSB_PATH}/src/class/vendor/vendor_host.c
+            )
+
+    add_library(tinyusb_net INTERFACE)
+    target_sources(tinyusb_host INTERFACE
+            ${PICO_TINYUSB_PATH}/lib/networking/dhserver.c
+            ${PICO_TINYUSB_PATH}/lib/networking/dnserver.c
+            ${PICO_TINYUSB_PATH}/lib/networking/rndis_reports.c
             )
 
     # Sometimes have to do host specific actions in mostly


### PR DESCRIPTION
I'm not sure if this is a path the maintainers want to pursue. But I added a `tinyusb_net` target on CMakeLists to import the necessary headers and files to make it possible to use the Pico as a network device based on the RNDIS [example](https://github.com/hathach/tinyusb/tree/master/examples/device/net_lwip_webserver) from TinyUSB.

As of now, I use these patches to build my PiccoloSDR [project](https://github.com/luigifcruz/pico-stuff) without known problems.