### PR TITLE
correct adafruit flash size for itsybitsy and qtpy rp2040 from 4 MB to 8 MB

### DIFF
--- a/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
+++ b/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
@@ -80,7 +80,7 @@
 #endif
 
 #ifndef PICO_FLASH_SIZE_BYTES
-#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 #endif
 
 // All boards have B1 RP2040

--- a/src/boards/include/boards/adafruit_qtpy_rp2040.h
+++ b/src/boards/include/boards/adafruit_qtpy_rp2040.h
@@ -79,7 +79,7 @@
 #endif
 
 #ifndef PICO_FLASH_SIZE_BYTES
-#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 #endif
 
 // All boards have B1 RP2040


### PR DESCRIPTION
This PR correct the flash size for [itsybitsy](https://www.adafruit.com/product/4888) and [qtpy](https://www.adafruit.com/product/4900) rp2040. Both use 8MB W25Q64JVxQ flash device