### PR TITLE
Fix possible IRQ worker starvation in release gcc 10 builds in stdio_usb

### DIFF
--- a/src/rp2_common/pico_stdio/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio/CMakeLists.txt
@@ -11,6 +11,7 @@ if (NOT TARGET pico_stdio)
     pico_wrap_function(pico_stdio vprintf)
     pico_wrap_function(pico_stdio puts)
     pico_wrap_function(pico_stdio putchar)
+    pico_wrap_function(pico_stdio getchar)
 
     if (TARGET pico_printf)
         target_link_libraries(pico_stdio INTERFACE pico_printf)


### PR DESCRIPTION
Fixes #363 

Also adds missing linker wrap argument for `getchar` which was making the build non deterministic (either our or _newlib_ 's `getchar` would be used)