### PR TITLE
Add LIB_PICO_FOO=1 build defines

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,10 +11,12 @@ if (NOT EXISTS "${PICO_PLATFORM_CMAKE_FILE}")
     Either specify a valid PICO_PLATFORM (or PICO_PLATFORM_CMAKE_FILE).")
 endif ()
 
+# Initialize board related build/compile settings
 include(${CMAKE_CURRENT_LIST_DIR}/board_setup.cmake)
 
-# todo add option to disable skip flag
+# call add_subdirectory(subdir) unless SKIP_SUBDIR evaluates to true
 function(pico_add_subdirectory subdir)
+    # todo add option to disable skip flag
     string(TOUPPER ${subdir} subdir_upper)
     set(replace_flag SKIP_${subdir_upper})
     if (NOT ${replace_flag})
@@ -24,10 +26,12 @@ function(pico_add_subdirectory subdir)
     endif ()
 endfunction()
 
+# add a link option to wrap the given function name; i.e. -Wl:wrap=FUNCNAME for gcc
 function(pico_wrap_function TARGET FUNCNAME)
     target_link_options(${TARGET} INTERFACE "LINKER:--wrap=${FUNCNAME}")
 endfunction()
 
+# add map file generation for the given target
 function(pico_add_map_output TARGET)
     get_target_property(target_type ${TARGET} TYPE)
     if ("EXECUTABLE" STREQUAL "${target_type}")
@@ -37,11 +41,23 @@ function(pico_add_map_output TARGET)
     endif ()
 endfunction()
 
+# create a hardware_NAME_headers target (see pico_pico_simple_hardware_headers_target)
+# create a hardware_NAME target (see pico_pico_simple_hardware_target)
 macro(pico_simple_hardware_target NAME)
     pico_simple_hardware_headers_target(${NAME})
     pico_simple_hardware_impl_target(${NAME})
 endmacro()
 
+# create an INTERFACE library named target, and define LIB_TARGET=1 (upper case) as a compile option
+function(pico_add_impl_library target)
+    add_library(${target} INTERFACE)
+    string(TOUPPER ${target} TARGET_UPPER)
+    target_compile_definitions(${target} INTERFACE LIB_${TARGET_UPPER}=1)
+endfunction()
+
+# create an INTERFACE library named hardware_NAME_headers INTERFACE library if it doesn't already exist,
+#        and add include/ relative to the calling directory to the includes.
+#        and hardware_structs and hardware_claim as dependencies of the library
 macro(pico_simple_hardware_headers_target NAME)
     if (NOT TARGET hardware_${NAME}_headers)
         add_library(hardware_${NAME}_headers INTERFACE)
@@ -54,8 +70,15 @@ macro(pico_simple_hardware_headers_target NAME)
     endif()
 endmacro()
 
+# create an INTERFACE library named hardware_NAME if it doesn't exist, along with a hardware_NAME_headers
+#        INTERFACE library that it depends on. The hardware_NAME_headers library add include/ relative to
+#        and pico_base_headers, and harddware_structs as a dependency of the library
 macro(pico_simple_hardware_headers_only_target NAME)
     if (NOT TARGET hardware_${NAME})
+        # Choosing not to add LIB_HARDWARE_ defines to avoid command line bloat pending a need (they aren't
+        #   super interesting except to determine functionality as they are mostly passive accessors, however
+        #   they could be useful to determine if the header is available.
+        # pico_add_sdk_impl_library(hardware_${NAME})
         add_library(hardware_${NAME} INTERFACE)
 
         target_include_directories(hardware_${NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -66,8 +89,14 @@ macro(pico_simple_hardware_headers_only_target NAME)
     endif()
 endmacro()
 
+# create an INTERFACE library named hardware_NAME if it doesn't exist, dependent on a pre-existing  hardware_NAME_headers
+#        INTERFACE library and pico_platform. The file NAME.c relative to the caller is added to the C sources for the hardware_NAME
 macro(pico_simple_hardware_impl_target NAME)
     if (NOT TARGET hardware_${NAME})
+        # Choosing not to add LIB_HARDWARE_ defines to avoid command line bloat pending a need (they aren't
+        #   super interesting except to determine functionality as they are mostly passive accessors, however
+        #   they could be useful to determine if the header is available.
+        # pico_add_sdk_impl_library(hardware_${NAME})
         add_library(hardware_${NAME} INTERFACE)
 
         target_sources(hardware_${NAME} INTERFACE

--- a/src/common/pico_binary_info/CMakeLists.txt
+++ b/src/common/pico_binary_info/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(pico_binary_info_headers INTERFACE)
 
 target_include_directories(pico_binary_info_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-add_library(pico_binary_info INTERFACE)
+pico_add_impl_library(pico_binary_info)
 
 target_link_libraries(pico_binary_info INTERFACE pico_binary_info_headers)
 

--- a/src/common/pico_stdlib/include/pico/stdlib.h
+++ b/src/common/pico_stdlib/include/pico/stdlib.h
@@ -44,15 +44,15 @@ extern "C" {
 // respective INTERFACE libraries, so these defines are set if the library
 // is included for the target executable
 
-#if PICO_STDIO_UART
+#if LIB_PICO_STDIO_UART
 #include "pico/stdio_uart.h"
 #endif
 
-#if PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB
 #include "pico/stdio_usb.h"
 #endif
 
-#if PICO_STDIO_SEMIHOSTING
+#if LIB_PICO_STDIO_SEMIHOSTING
 #include "pico/stdio_semihosting.h"
 #endif
 

--- a/src/common/pico_sync/CMakeLists.txt
+++ b/src/common/pico_sync/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT TARGET pico_sync_headers)
 endif()
 
 if (NOT TARGET pico_sync_core)
-    add_library(pico_sync_core INTERFACE)
+    pico_add_impl_library(pico_sync_core)
     target_sources(pico_sync_core INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/lock_core.c
     )
@@ -13,7 +13,7 @@ if (NOT TARGET pico_sync_core)
 endif()
 
 if (NOT TARGET pico_sync_sem)
-    add_library(pico_sync_sem INTERFACE)
+    pico_add_impl_library(pico_sync_sem)
     target_sources(pico_sync_sem INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/sem.c
     )
@@ -21,7 +21,7 @@ if (NOT TARGET pico_sync_sem)
 endif()
 
 if (NOT TARGET pico_sync_mutex)
-    add_library(pico_sync_mutex INTERFACE)
+    pico_add_impl_library(pico_sync_mutex)
     target_sources(pico_sync_mutex INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/mutex.c
             )
@@ -29,7 +29,7 @@ if (NOT TARGET pico_sync_mutex)
 endif()
 
 if (NOT TARGET pico_sync_critical_section)
-    add_library(pico_sync_critical_section INTERFACE)
+    pico_add_impl_library(pico_sync_critical_section)
     target_sources(pico_sync_critical_section INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/critical_section.c
             )
@@ -37,7 +37,7 @@ if (NOT TARGET pico_sync_critical_section)
 endif()
 
 if (NOT TARGET pico_sync)
-    add_library(pico_sync INTERFACE)
+    pico_add_impl_library(pico_sync)
     target_link_libraries(pico_sync INTERFACE pico_sync_sem pico_sync_mutex pico_sync_critical_section pico_sync_core)
 endif()
 

--- a/src/common/pico_time/CMakeLists.txt
+++ b/src/common/pico_time/CMakeLists.txt
@@ -7,7 +7,7 @@ if (NOT TARGET pico_time_headers)
 endif()
 
 if (NOT TARGET pico_time)
-    add_library(pico_time INTERFACE)
+    pico_add_impl_library(pico_time)
 
     target_sources(pico_time INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/time.c

--- a/src/common/pico_util/CMakeLists.txt
+++ b/src/common/pico_util/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT TARGET pico_util_headers)
 endif()
 
 if (NOT TARGET pico_util)
-    add_library(pico_util INTERFACE)
+    pico_add_impl_library(pico_util)
     target_sources(pico_util INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/datetime.c
             ${CMAKE_CURRENT_LIST_DIR}/pheap.c

--- a/src/host/pico_bit_ops/CMakeLists.txt
+++ b/src/host/pico_bit_ops/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(pico_bit_ops INTERFACE)
+pico_add_impl_library(pico_bit_ops)
 
 target_sources(pico_bit_ops INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/bit_ops.c)

--- a/src/host/pico_divider/CMakeLists.txt
+++ b/src/host/pico_divider/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(pico_divider INTERFACE)
+pico_add_impl_library(pico_divider)
 
 target_sources(pico_divider INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/divider.c)

--- a/src/host/pico_multicore/CMakeLists.txt
+++ b/src/host/pico_multicore/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_multicore)
-    add_library(pico_multicore INTERFACE)
+    pico_add_impl_library(pico_multicore)
 
     target_include_directories(pico_multicore INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 endif()

--- a/src/host/pico_platform/CMakeLists.txt
+++ b/src/host/pico_platform/CMakeLists.txt
@@ -11,7 +11,7 @@ if (NOT TARGET pico_platform_headers)
 endif()
 
 if (NOT TARGET pico_platform)
-    add_library(pico_platform INTERFACE)
+    pico_add_impl_library(pico_platform)
 
     target_sources(pico_platform INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/platform_base.c

--- a/src/host/pico_printf/CMakeLists.txt
+++ b/src/host/pico_printf/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_printf)
-    add_library(pico_printf INTERFACE)
+    pico_add_impl_library(pico_printf)
     function(pico_set_printf_implementation)
     endfunction()
 endif()

--- a/src/host/pico_stdio/CMakeLists.txt
+++ b/src/host/pico_stdio/CMakeLists.txt
@@ -1,14 +1,14 @@
 if (NOT TARGET pico_stdio)
-    add_library(pico_stdio INTERFACE)
+    pico_add_impl_library(pico_stdio)
 
     target_include_directories(pico_stdio INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     target_sources(pico_stdio INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/stdio.c
             )
-    add_library(pico_stdio_usb INTERFACE)
-    add_library(pico_stdio_uart INTERFACE)
-    add_library(pico_stdio_semihosting INTERFACE)
+    pico_add_impl_library(pico_stdio_usb)
+    pico_add_impl_library(pico_stdio_uart)
+    pico_add_impl_library(pico_stdio_semihosting)
     
     function(pico_enable_stdio_uart)
     endfunction()

--- a/src/host/pico_stdlib/CMakeLists.txt
+++ b/src/host/pico_stdlib/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_stdlib)
-    add_library(pico_stdlib INTERFACE)
+    pico_add_impl_library(pico_stdlib)
 
     target_sources(pico_stdlib INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/stdlib.c

--- a/src/rp2_common/hardware_claim/CMakeLists.txt
+++ b/src/rp2_common/hardware_claim/CMakeLists.txt
@@ -1,6 +1,2 @@
-add_library(hardware_claim INTERFACE)
-target_include_directories(hardware_claim INTERFACE include)
-target_sources(hardware_claim INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/claim.c)
-
+pico_simple_hardware_target(claim)
 target_link_libraries(hardware_claim INTERFACE hardware_sync)

--- a/src/rp2_common/hardware_divider/CMakeLists.txt
+++ b/src/rp2_common/hardware_divider/CMakeLists.txt
@@ -1,4 +1,3 @@
-add_library(hardware_divider INTERFACE)
+pico_simple_hardware_headers_only_target(divider)
 target_sources(hardware_divider INTERFACE ${CMAKE_CURRENT_LIST_DIR}/divider.S)
-target_include_directories(hardware_divider INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(hardware_divider INTERFACE hardware_structs)

--- a/src/rp2_common/hardware_flash/CMakeLists.txt
+++ b/src/rp2_common/hardware_flash/CMakeLists.txt
@@ -1,8 +1,2 @@
-add_library(hardware_flash INTERFACE)
-
-target_sources(hardware_flash INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/flash.c
-        )
-
-target_include_directories(hardware_flash INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-target_link_libraries(hardware_flash INTERFACE pico_base_headers pico_bootrom)
+pico_simple_hardware_target(flash)
+target_link_libraries(hardware_flash INTERFACE pico_bootrom)

--- a/src/rp2_common/hardware_resets/CMakeLists.txt
+++ b/src/rp2_common/hardware_resets/CMakeLists.txt
@@ -1,2 +1,1 @@
-add_library(hardware_resets INTERFACE)
-target_include_directories(hardware_resets INTERFACE include)
+pico_simple_hardware_headers_only_target(resets)

--- a/src/rp2_common/pico_bit_ops/CMakeLists.txt
+++ b/src/rp2_common/pico_bit_ops/CMakeLists.txt
@@ -1,13 +1,9 @@
 if (NOT TARGET pico_bit_ops)
     #shims for ROM functions for -lgcc functions  (listed below)
-    add_library(pico_bit_ops INTERFACE)
+    pico_add_impl_library(pico_bit_ops)
 
     # no custom implementation; falls thru to compiler
-    add_library(pico_bit_ops_compiler INTERFACE)
-    # PICO_BUILD_DEFINE: PICO_BIT_OPS_COMPILER, whether compiler provided bit_ops bit functions support is being used, type=bool, default=0, but dependent on CMake options, group=pico_bit_ops
-    target_compile_definitions(pico_bit_ops_compiler INTERFACE
-            PICO_BIT_OPS_COMPILER=1
-            )
+    pico_add_impl_library(pico_bit_ops_compiler)
 
     # add alias "default" which is just pico.
     add_library(pico_bit_ops_default INTERFACE)
@@ -15,14 +11,9 @@ if (NOT TARGET pico_bit_ops)
 
     set(PICO_DEFAULT_BIT_OPS_IMPL pico_bit_ops_default)
 
-    add_library(pico_bit_ops_pico INTERFACE)
+    pico_add_impl_library(pico_bit_ops_pico)
     target_link_libraries(pico_bit_ops INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_BIT_OPS_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_BIT_OPS_IMPL>,${PICO_DEFAULT_BIT_OPS_IMPL}>)
-
-    # PICO_BUILD_DEFINE: PICO_BIT_OPS_PICO, whether optimized pico/bootrom provided bit_ops bit functions support is being used, type=bool, default=1, but dependent on CMake options, group=pico_bit_ops
-    target_compile_definitions(pico_bit_ops_pico INTERFACE
-            PICO_BIT_OPS_PICO=1
-            )
 
     target_sources(pico_bit_ops_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/bit_ops_aeabi.S

--- a/src/rp2_common/pico_bootsel_via_double_reset/CMakeLists.txt
+++ b/src/rp2_common/pico_bootsel_via_double_reset/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(pico_bootsel_via_double_reset INTERFACE)
+pico_add_impl_library(pico_bootsel_via_double_reset)
 
 target_sources(pico_bootsel_via_double_reset INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/pico_bootsel_via_double_reset.c

--- a/src/rp2_common/pico_divider/CMakeLists.txt
+++ b/src/rp2_common/pico_divider/CMakeLists.txt
@@ -1,12 +1,9 @@
 if (NOT TARGET pico_divider)
     # library to be depended on - we make this depend on particular implementations using per target generator expressions
-    add_library(pico_divider INTERFACE)
+    pico_add_impl_library(pico_divider)
 
     # no custom implementation; falls thru to compiler
-    add_library(pico_divider_compiler INTERFACE)
-    target_compile_definitions(pico_divider_compiler INTERFACE
-            PICO_DIVIDER_COMPILER=1
-    )
+    pico_add_impl_library(pico_divider_compiler)
 
     # add alias "default" which is just hardware.
     add_library(pico_divider_default INTERFACE)
@@ -27,10 +24,7 @@ if (NOT TARGET pico_divider)
             hardware_regs
             )
 
-    add_library(pico_divider_hardware INTERFACE)
-    target_compile_definitions(pico_divider_hardware INTERFACE
-            PICO_DIVIDER_HARDWARE=1
-            )
+    pico_add_impl_library(pico_divider_hardware)
 
     target_link_libraries(pico_divider_hardware INTERFACE pico_divider_hardware_explicit)
 

--- a/src/rp2_common/pico_double/CMakeLists.txt
+++ b/src/rp2_common/pico_double/CMakeLists.txt
@@ -1,13 +1,9 @@
 if (NOT TARGET pico_double)
     # library to be depended on - we make this depend on particular implementations using per target generator expressions
-    add_library(pico_double INTERFACE)
+    pico_add_impl_library(pico_double)
 
     # no custom implementation; falls thru to compiler
-    add_library(pico_double_compiler INTERFACE)
-    # PICO_BUILD_DEFINE: PICO_DOUBLE_COMPILER, whether compiler provided double support is being used, type=bool, default=0, but dependent on CMake options, group=pico_double
-    target_compile_definitions(pico_double_compiler INTERFACE
-            PICO_DOUBLE_COMPILER=1
-    )
+    pico_add_impl_library(pico_double_compiler)
 
     add_library(pico_double_headers INTERFACE)
     target_include_directories(pico_double_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -21,30 +17,24 @@ if (NOT TARGET pico_double)
     target_link_libraries(pico_double INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_DOUBLE_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_DOUBLE_IMPL>,${PICO_DEFAULT_DOUBLE_IMPL}>)
 
-    add_library(pico_double_pico INTERFACE)
+    pico_add_impl_library(pico_double_pico)
     target_sources(pico_double_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/double_aeabi.S
             ${CMAKE_CURRENT_LIST_DIR}/double_init_rom.c
             ${CMAKE_CURRENT_LIST_DIR}/double_math.c
             ${CMAKE_CURRENT_LIST_DIR}/double_v1_rom_shim.S
     )
-    # PICO_BUILD_DEFINE: PICO_DOUBLE_PICO, whether optimized pico/bootrom provided double support is being used, type=bool, default=1, but dependent on CMake options, group=pico_double
-    target_compile_definitions(pico_double_pico INTERFACE
-            PICO_DOUBLE_PICO=1
-            )
 
     target_link_libraries(pico_double_pico INTERFACE pico_bootrom pico_double_headers)
 
-    add_library(pico_double_none INTERFACE)
+    pico_add_impl_library(pico_double_none)
     target_sources(pico_double_none INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/double_none.S
             )
 
     target_link_libraries(pico_double_none INTERFACE pico_double_headers)
 
-    # PICO_BUILD_DEFINE: PICO_DOUBLE_NONE, whether double support is disabled and functions will panic, type=bool, default=0, but dependent on CMake options, group=pico_double
     target_compile_definitions(pico_double_none INTERFACE
-            PICO_DOUBLE_NONE=1
             PICO_PRINTF_SUPPORT_FLOAT=0 # printing floats/doubles won't work, so we can save space by removing it
     )
 

--- a/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/CMakeLists.txt
+++ b/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(pico_fix_rp2040_usb_device_enumeration INTERFACE)
+pico_add_impl_library(pico_fix_rp2040_usb_device_enumeration)
 
 target_sources(pico_fix_rp2040_usb_device_enumeration INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/rp2040_usb_device_enumeration.c

--- a/src/rp2_common/pico_float/CMakeLists.txt
+++ b/src/rp2_common/pico_float/CMakeLists.txt
@@ -1,13 +1,9 @@
 if (NOT TARGET pico_float)
     # library to be depended on - we make this depend on particular implementations using per target generator expressions
-    add_library(pico_float INTERFACE)
+    pico_add_impl_library(pico_float)
 
     # no custom implementation; falls thru to compiler
-    add_library(pico_float_compiler INTERFACE)
-    # PICO_BUILD_DEFINE: PICO_FLOAT_COMPILER, whether compiler provided float support is being used, type=bool, default=0, but dependent on CMake options, group=pico_float
-    target_compile_definitions(pico_float_compiler INTERFACE
-            PICO_FLOAT_COMPILER=1
-    )
+    pico_add_impl_library(pico_float_compiler)
 
     add_library(pico_float_headers INTERFACE)
     target_include_directories(pico_float_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -21,31 +17,22 @@ if (NOT TARGET pico_float)
     target_link_libraries(pico_float INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_FLOAT_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_FLOAT_IMPL>,${PICO_DEFAULT_FLOAT_IMPL}>)
 
-    add_library(pico_float_pico INTERFACE)
+    pico_add_impl_library(pico_float_pico)
     target_sources(pico_float_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/float_aeabi.S
             ${CMAKE_CURRENT_LIST_DIR}/float_init_rom.c
             ${CMAKE_CURRENT_LIST_DIR}/float_math.c
             ${CMAKE_CURRENT_LIST_DIR}/float_v1_rom_shim.S
     )
-    # PICO_BUILD_DEFINE: PICO_FLOAT_PICO, whether optimized pico/bootrom provided float support is being used, type=bool, default=1, but dependent on CMake options, group=pico_float
-    target_compile_definitions(pico_float_pico INTERFACE
-            PICO_FLOAT_PICO=1
-            )
 
     target_link_libraries(pico_float_pico INTERFACE pico_bootrom pico_float_headers)
 
-    add_library(pico_float_none INTERFACE)
+    pico_add_impl_library(pico_float_none)
     target_sources(pico_float_none INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/float_none.S
             )
 
     target_link_libraries(pico_float_none INTERFACE pico_float_headers)
-
-    # PICO_BUILD_DEFINE: PICO_FLOAT_NONE, whether float support is disabled and functions will panic, type=bool, default=0, but dependent on CMake options, group=pico_float
-    target_compile_definitions(pico_float_none INTERFACE
-            PICO_FLOAT_NONE=1
-    )
 
     function(wrap_float_functions TARGET)
         pico_wrap_function(${TARGET} __aeabi_fadd)

--- a/src/rp2_common/pico_int64_ops/CMakeLists.txt
+++ b/src/rp2_common/pico_int64_ops/CMakeLists.txt
@@ -1,14 +1,10 @@
 if (NOT TARGET pico_int64_ops)
 
     #shims for ROM functions for -lgcc functions  (listed below)
-    add_library(pico_int64_ops INTERFACE)
+    pico_add_impl_library(pico_int64_ops)
 
     # no custom implementation; falls thru to compiler
-    add_library(pico_int64_ops_compiler INTERFACE)
-    # PICO_BUILD_DEFINE: PICO_INT64_OPS_COMPILER, whether compiler provided int64_ops multiplication support is being used, type=bool, default=0, but dependent on CMake options, group=pico_int64_ops
-    target_compile_definitions(pico_int64_ops_compiler INTERFACE
-            PICO_INT64_OPS_COMPILER=1
-            )
+    pico_add_impl_library(pico_int64_ops_compiler)
 
     # add alias "default" which is just pico.
     add_library(pico_int64_ops_default INTERFACE)
@@ -19,17 +15,12 @@ if (NOT TARGET pico_int64_ops)
     target_link_libraries(pico_int64_ops INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_INT64_OPS_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_INT64_OPS_IMPL>,${PICO_DEFAULT_INT64_OPS_IMPL}>)
 
-    add_library(pico_int64_ops_pico INTERFACE)
+    pico_add_impl_library(pico_int64_ops_pico)
     target_include_directories(pico_int64_ops_pico INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     target_sources(pico_int64_ops_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/pico_int64_ops_aeabi.S
     )
-
-    # PICO_BUILD_DEFINE: PICO_INT64_OPS_PICO, whether optimized pico/bootrom provided int64_ops multiplication support is being used, type=bool, default=1, but dependent on CMake options, group=pico_int64_ops
-    target_compile_definitions(pico_int64_ops_pico INTERFACE
-            PICO_INT64_OPS_PICO=1
-            )
 
     pico_wrap_function(pico_int64_ops_pico __aeabi_lmul)
 

--- a/src/rp2_common/pico_malloc/CMakeLists.txt
+++ b/src/rp2_common/pico_malloc/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (NOT TARGET pico_malloc)
     #shims for ROM functions for -lgcc functions  (listed below)
-    add_library(pico_malloc INTERFACE)
+    pico_add_impl_library(pico_malloc)
 
     target_sources(pico_malloc INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/pico_malloc.c

--- a/src/rp2_common/pico_malloc/include/pico/malloc.h
+++ b/src/rp2_common/pico_malloc/include/pico/malloc.h
@@ -16,7 +16,7 @@
 */
 
 // PICO_CONFIG: PICO_USE_MALLOC_MUTEX, Whether to protect malloc etc with a mutex, type=bool, default=1 with pico_multicore, 0 otherwise, group=pico_malloc
-#if PICO_MULTICORE && !defined(PICO_USE_MALLOC_MUTEX)
+#if LIB_PICO_MULTICORE && !defined(PICO_USE_MALLOC_MUTEX)
 #define PICO_USE_MALLOC_MUTEX 1
 #endif
 

--- a/src/rp2_common/pico_mem_ops/CMakeLists.txt
+++ b/src/rp2_common/pico_mem_ops/CMakeLists.txt
@@ -1,13 +1,9 @@
 if (NOT TARGET pico_mem_ops)
     #shims for ROM functions for -lgcc functions  (listed below)
-    add_library(pico_mem_ops INTERFACE)
+    pico_add_impl_library(pico_mem_ops)
 
     # no custom implementation; falls thru to compiler
-    add_library(pico_mem_ops_compiler INTERFACE)
-    # PICO_BUILD_DEFINE: PICO_MEM_OPS_COMPILER, whether compiler provided mem_ops memcpy etc. support is being used, type=bool, default=0, but dependent on CMake options, group=pico_mem_ops
-    target_compile_definitions(pico_mem_ops_compiler INTERFACE
-            PICO_MEM_OPS_COMPILER=1
-            )
+    pico_add_impl_library(pico_mem_ops_compiler)
 
     # add alias "default" which is just pico.
     add_library(pico_mem_ops_default INTERFACE)
@@ -15,15 +11,9 @@ if (NOT TARGET pico_mem_ops)
 
     set(PICO_DEFAULT_MEM_OPS_IMPL pico_mem_ops_default)
 
-    add_library(pico_mem_ops_pico INTERFACE)
+    pico_add_impl_library(pico_mem_ops_pico)
     target_link_libraries(pico_mem_ops INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_MEM_OPS_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_MEM_OPS_IMPL>,${PICO_DEFAULT_MEM_OPS_IMPL}>)
-
-    # PICO_BUILD_DEFINE: PICO_MEM_OPS_PICO, whether optimized pico/bootrom provided mem_ops memcpy etc. support is being used, type=bool, default=1, but dependent on CMake options, group=pico_mem_ops
-    target_compile_definitions(pico_mem_ops_pico INTERFACE
-            PICO_MEM_OPS_PICO=1
-            )
-
 
     target_sources(pico_mem_ops_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/mem_ops_aeabi.S

--- a/src/rp2_common/pico_multicore/CMakeLists.txt
+++ b/src/rp2_common/pico_multicore/CMakeLists.txt
@@ -1,14 +1,10 @@
 if (NOT TARGET pico_multicore)
-    add_library(pico_multicore INTERFACE)
+    pico_add_impl_library(pico_multicore)
 
     target_sources(pico_multicore INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/multicore.c)
 
     target_include_directories(pico_multicore INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-
-    target_compile_definitions(pico_multicore INTERFACE
-        PICO_MULTICORE=1
-    )
 
     target_link_libraries(pico_multicore INTERFACE pico_sync)
 endif()

--- a/src/rp2_common/pico_platform/CMakeLists.txt
+++ b/src/rp2_common/pico_platform/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT TARGET pico_platform_headers)
 endif()
 
 if (NOT TARGET pico_platform)
-    add_library(pico_platform INTERFACE)
+    pico_add_impl_library(pico_platform)
     target_sources(pico_platform INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/platform.c)
 

--- a/src/rp2_common/pico_printf/CMakeLists.txt
+++ b/src/rp2_common/pico_printf/CMakeLists.txt
@@ -1,12 +1,9 @@
 if (NOT TARGET pico_printf)
     # library to be depended on - we make this depend on particular implementations using per target generator expressions
-    add_library(pico_printf INTERFACE)
+    pico_add_impl_library(pico_printf)
 
     # no custom implementation; falls thru to compiler
-    add_library(pico_printf_compiler INTERFACE)
-    target_compile_definitions(pico_printf_compiler INTERFACE
-            PICO_PRINTF_COMPILER=1
-    )
+    pico_add_impl_library(pico_printf_compiler)
 
     add_library(pico_printf_headers INTERFACE)
     target_include_directories(pico_printf_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
@@ -20,27 +17,19 @@ if (NOT TARGET pico_printf)
     target_link_libraries(pico_printf INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_PRINTF_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_PRINTF_IMPL>,${PICO_DEFAULT_PRINTF_IMPL}>)
 
-    add_library(pico_printf_pico INTERFACE)
+    pico_add_impl_library(pico_printf_pico)
     target_sources(pico_printf_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/printf.c
     )
 
-    target_compile_definitions(pico_printf_pico INTERFACE
-            PICO_PRINTF_PICO=1
-    )
-
     target_link_libraries(pico_printf_pico INTERFACE pico_printf_headers)
 
-    add_library(pico_printf_none INTERFACE)
+    pico_add_impl_library(pico_printf_none)
     target_sources(pico_printf_none INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/printf_none.S
     )
 
     target_link_libraries(pico_printf_none INTERFACE pico_printf_headers)
-
-    target_compile_definitions(pico_printf_none INTERFACE
-        PICO_PRINTF_NONE=1
-    )
 
     function(wrap_printf_functions TARGET)
         # note that printf and vprintf are in pico_stdio so we can provide thread safety

--- a/src/rp2_common/pico_printf/include/pico/printf.h
+++ b/src/rp2_common/pico_printf/include/pico/printf.h
@@ -55,7 +55,7 @@ extern "C" {
 #endif
 #endif
 
-#if PICO_PRINTF_PICO
+#if LIB_PICO_PRINTF_PICO
 // weak raw printf may be a puts if printf has not been called,
 // so that we can support gc of printf when it isn't called
 //

--- a/src/rp2_common/pico_printf/printf.c
+++ b/src/rp2_common/pico_printf/printf.c
@@ -918,7 +918,7 @@ int vfctprintf(void (*out)(char character, void *arg), void *arg, const char *fo
     return _vsnprintf(_out_fct, (char *) (uintptr_t) &out_fct_wrap, (size_t) -1, format, va);
 }
 
-#if PICO_PRINTF_PICO
+#if LIB_PICO_PRINTF_PICO
 #if !PICO_PRINTF_ALWAYS_INCLUDED
 bool weak_raw_printf(const char *fmt, ...) {
     va_list va;

--- a/src/rp2_common/pico_runtime/CMakeLists.txt
+++ b/src/rp2_common/pico_runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(pico_runtime INTERFACE)
+pico_add_impl_library(pico_runtime)
 
 target_sources(pico_runtime INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/runtime.c

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -225,7 +225,7 @@ void __attribute__((noreturn)) panic_unsupported() {
 void __attribute__((noreturn)) __printflike(1, 0) panic(const char *fmt, ...) {
     puts("\n*** PANIC ***\n");
     if (fmt) {
-#if PICO_PRINTF_NONE
+#if LIB_PICO_PRINTF_NONE
         puts(fmt);
 #else
         va_list args;

--- a/src/rp2_common/pico_standard_link/CMakeLists.txt
+++ b/src/rp2_common/pico_standard_link/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_standard_link)
-    add_library(pico_standard_link INTERFACE)
+    pico_add_impl_library(pico_standard_link)
 
     target_sources(pico_standard_link INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/crt0.S

--- a/src/rp2_common/pico_stdio/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_stdio)
-    add_library(pico_stdio INTERFACE)
+    pico_add_impl_library(pico_stdio)
 
     target_include_directories(pico_stdio INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 

--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -15,15 +15,15 @@
 #include "pico/stdio/driver.h"
 #include "pico/time.h"
 
-#if PICO_STDIO_UART
+#if LIB_PICO_STDIO_UART
 #include "pico/stdio_uart.h"
 #endif
 
-#if PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB
 #include "pico/stdio_usb.h"
 #endif
 
-#if PICO_STDIO_SEMIHOSTING
+#if LIB_PICO_STDIO_SEMIHOSTING
 #include "pico/stdio_semihosting.h"
 #endif
 
@@ -212,12 +212,12 @@ int WRAPPER_FUNC(vprintf)(const char *format, va_list va) {
 #endif
     }
     int ret;
-#if PICO_PRINTF_PICO
+#if LIB_PICO_PRINTF_PICO
     struct stdio_stack_buffer buffer = {.used = 0};
     ret = vfctprintf(stdio_buffered_printer, &buffer, format, va);
     stdio_stack_buffer_flush(&buffer);
     stdio_flush();
-#elif PICO_PRINTF_NONE
+#elif LIB_PICO_PRINTF_NONE
     extern void printf_none_assert();
     printf_none_assert();
 #else
@@ -242,15 +242,15 @@ int __printflike(1, 0) WRAPPER_FUNC(printf)(const char* format, ...)
 void stdio_init_all() {
     // todo add explicit custom, or registered although you can call stdio_enable_driver explicitly anyway
     // These are well known ones
-#if PICO_STDIO_UART
+#if LIB_PICO_STDIO_UART
     stdio_uart_init();
 #endif
 
-#if PICO_STDIO_SEMIHOSTING
+#if LIB_PICO_STDIO_SEMIHOSTING
     stdio_semihosting_init();
 #endif
 
-#if PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB
     stdio_usb_init();
 #endif
 }

--- a/src/rp2_common/pico_stdio_semihosting/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio_semihosting/CMakeLists.txt
@@ -1,13 +1,9 @@
-add_library(pico_stdio_semihosting INTERFACE)
+pico_add_impl_library(pico_stdio_semihosting)
 
 target_sources(pico_stdio_semihosting INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/stdio_semihosting.c
 )
 
 target_include_directories(pico_stdio_semihosting INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-
-target_compile_definitions(pico_stdio_semihosting INTERFACE
-        PICO_STDIO_SEMIHOSTING=1
-)
 
 target_link_libraries(pico_stdio_semihosting INTERFACE pico_stdio)

--- a/src/rp2_common/pico_stdio_uart/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio_uart/CMakeLists.txt
@@ -1,13 +1,9 @@
-add_library(pico_stdio_uart INTERFACE)
+pico_add_impl_library(pico_stdio_uart)
 
 target_sources(pico_stdio_uart INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/stdio_uart.c
 )
 
 target_include_directories(pico_stdio_uart INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-
-target_compile_definitions(pico_stdio_uart INTERFACE
-        PICO_STDIO_UART=1
-)
 
 target_link_libraries(pico_stdio_uart INTERFACE pico_stdio)

--- a/src/rp2_common/pico_stdio_usb/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio_usb/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (TARGET tinyusb_device_unmarked)
-    add_library(pico_stdio_usb INTERFACE)
+    pico_add_impl_library(pico_stdio_usb)
 
     target_include_directories(pico_stdio_usb INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -14,9 +14,5 @@ if (TARGET tinyusb_device_unmarked)
         pico_stdio
         pico_time
         pico_unique_id
-    )
-
-    target_compile_definitions(pico_stdio_usb INTERFACE
-            PICO_STDIO_USB=1
     )
 endif()

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#if !defined(TINYUSB_HOST_LINKED) && !defined(TINYUSB_DEVICE_LINKED)
+#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
 #include "tusb.h"
 
 #include "pico/time.h"

--- a/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
@@ -26,7 +26,7 @@
  * THE SOFTWARE.
  */
 
-#if !defined(TINYUSB_HOST_LINKED) && !defined(TINYUSB_DEVICE_LINKED)
+#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
 
 #include "tusb.h"
 #include "pico/stdio_usb/reset_interface.h"

--- a/src/rp2_common/pico_stdlib/CMakeLists.txt
+++ b/src/rp2_common/pico_stdlib/CMakeLists.txt
@@ -6,7 +6,7 @@ option(PICO_STDIO_USB "Globablly enable stdio USB" 0)
 option(PICO_STDIO_USB "Globablly enable stdio semihosting " 0)
 
 if (NOT TARGET pico_stdlib)
-    add_library(pico_stdlib INTERFACE)
+    pico_add_impl_library(pico_stdlib)
     target_sources(pico_stdlib INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/stdlib.c
     )

--- a/src/rp2_common/pico_stdlib/stdlib.c
+++ b/src/rp2_common/pico_stdlib/stdlib.c
@@ -7,7 +7,7 @@
 #include "pico/stdlib.h"
 #include "hardware/pll.h"
 #include "hardware/clocks.h"
-#if PICO_STDIO_UART
+#if LIB_PICO_STDIO_UART
 #include "pico/stdio_uart.h"
 #else
 #include "pico/binary_info.h"
@@ -90,7 +90,7 @@ bool check_sys_clock_khz(uint32_t freq_khz, uint *vco_out, uint *postdiv1_out, u
 }
 
 void setup_default_uart() {
-#if PICO_STDIO_UART
+#if LIB_PICO_STDIO_UART
     stdio_uart_init();
 #elif defined(PICO_DEFAULT_UART_BAUD_RATE) && defined(PICO_DEFAULT_UART_TX_PIN) && defined(PICO_DEFAULT_UART_RX_PIN)
     // this is mostly for backwards compatibility - stdio_uart_init is a bit more nuanced, and usually likely to be present

--- a/src/rp2_common/pico_unique_id/CMakeLists.txt
+++ b/src/rp2_common/pico_unique_id/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(pico_unique_id INTERFACE)
+pico_add_impl_library(pico_unique_id)
 
 target_sources(pico_unique_id INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/unique_id.c

--- a/src/rp2_common/tinyusb/CMakeLists.txt
+++ b/src/rp2_common/tinyusb/CMakeLists.txt
@@ -73,14 +73,13 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
     # unmarked version used by stdio USB
     target_link_libraries(tinyusb_device_unmarked INTERFACE tinyusb_common pico_fix_rp2040_usb_device_enumeration)
 
-    add_library(tinyusb_device INTERFACE)
+    pico_add_impl_library(tinyusb_device)
     target_link_libraries(tinyusb_device INTERFACE tinyusb_device_unmarked)
     target_compile_definitions(tinyusb_device INTERFACE
-            RP2040_USB_DEVICE_MODE=1
-            TINYUSB_DEVICE_LINKED=1
+            RP2040_USB_DEVICE_MODE=1 #define is used by tinyusb still
             )
 
-    add_library(tinyusb_host INTERFACE)
+    pico_add_impl_library(tinyusb_host)
     target_sources(tinyusb_host INTERFACE
             ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/rp2040/hcd_rp2040.c
             ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -96,13 +95,12 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
     # Sometimes have to do host specific actions in mostly
     # common functions
     target_compile_definitions(tinyusb_host INTERFACE
-            RP2040_USB_HOST_MODE=1
-            TINYUSB_HOST_LINKED=1
+            RP2040_USB_HOST_MODE=1 #define is used by tinyusb still
             )
 
     target_link_libraries(tinyusb_host INTERFACE tinyusb_common)
 
-    add_library(tinyusb_board INTERFACE)
+    pico_add_impl_library(tinyusb_board)
     target_sources(tinyusb_board INTERFACE
             ${PICO_TINYUSB_PATH}/hw/bsp/raspberry_pi_pico/board_raspberry_pi_pico.c
     )


### PR DESCRIPTION
make all non hardware_ libraries foo add C preprocessor definition LIB_FOO=1, and remove bespoke definitions which were all undocumented anyway