### PR TITLE
Disable core 0 SIO FIFO IRQ during core1 launch sequence

### DIFF
--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -129,6 +129,9 @@ void multicore_launch_core1(void (*entry)(void)) {
 void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vector_table) {
     uint32_t cmd_sequence[] = {0, 0, 1, (uintptr_t) vector_table, (uintptr_t) sp, (uintptr_t) entry};
 
+    bool enabled = irq_is_enabled(SIO_IRQ_PROC0);
+    irq_set_enabled(SIO_IRQ_PROC0, false);
+
     uint seq = 0;
     do {
         uint cmd = cmd_sequence[seq];
@@ -142,6 +145,8 @@ void multicore_launch_core1_raw(void (*entry)(void), uint32_t *sp, uint32_t vect
         // move to next state on correct response otherwise start over
         seq = cmd == response ? seq + 1 : 0;
     } while (seq < count_of(cmd_sequence));
+
+    irq_set_enabled(SIO_IRQ_PROC0, enabled);
 }
 
 #define LOCKOUT_MAGIC_START 0x73a8831eu


### PR DESCRIPTION
This way the user can pre-install an IRQ handler to receive FIFO requests once the core starts, without it receiving any during the init