### PR TITLE
Definitions for IC_TX_BUFFER_DEPTH inconsistent

### DIFF
--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -257,7 +257,7 @@ int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, b
  * least that many bytes can be written without blocking.
  */
 static inline size_t i2c_get_write_available(i2c_inst_t *i2c) {
-    const size_t IC_TX_BUFFER_DEPTH = 32;
+    const size_t IC_TX_BUFFER_DEPTH = 16;
     return IC_TX_BUFFER_DEPTH - i2c_get_hw(i2c)->txflr;
 }
 


### PR DESCRIPTION
Correct definition is [here](https://github.com/raspberrypi/pico-sdk/blob/8f3c3ff12a07d1b5f06e35e4d00c7b5dfe1b64c6/src/rp2040/hardware_structs/include/hardware/structs/i2c.h#L132)