### PR TITLE
Hw claim bugfix

### DIFF
--- a/src/rp2_common/hardware_claim/claim.c
+++ b/src/rp2_common/hardware_claim/claim.c
@@ -14,22 +14,13 @@ void hw_claim_unlock(uint32_t save) {
     spin_unlock(spin_lock_instance(PICO_SPINLOCK_ID_HARDWARE_CLAIM), save);
 }
 
-bool hw_is_claimed(uint8_t *bits, uint bit_index) {
-    bool rc;
-    uint32_t save = hw_claim_lock();
-    if (bits[bit_index >> 3u] & (1u << (bit_index & 7u))) {
-        rc = false;
-    } else {
-        bits[bit_index >> 3u] |= (uint8_t)(1u << (bit_index & 7u));
-        rc = true;
-    }
-    hw_claim_unlock(save);
-    return rc;
+bool hw_is_claimed(const uint8_t *bits, uint bit_index) {
+    return bits[bit_index >> 3u] & (1u << (bit_index & 7u));
 }
 
 void hw_claim_or_assert(uint8_t *bits, uint bit_index, const char *message) {
     uint32_t save = hw_claim_lock();
-    if (bits[bit_index >> 3u] & (1u << (bit_index & 7u))) {
+    if (hw_is_claimed(bits, bit_index)) {
         panic(message, bit_index);
     } else {
         bits[bit_index >> 3u] |= (uint8_t)(1u << (bit_index & 7u));
@@ -57,7 +48,7 @@ int hw_claim_unused_from_range(uint8_t *bits, bool required, uint bit_lsb, uint 
 
 void hw_claim_clear(uint8_t *bits, uint bit_index) {
     uint32_t save = hw_claim_lock();
-    assert(bits[bit_index >> 3u] & (1u << (bit_index & 7u)));
+    assert("superfluous clear call" && (bits[bit_index >> 3u] & (1u << (bit_index & 7u))));
     bits[bit_index >> 3u] &= (uint8_t) ~(1u << (bit_index & 7u));
     hw_claim_unlock(save);
 }

--- a/src/rp2_common/hardware_claim/include/hardware/claim.h
+++ b/src/rp2_common/hardware_claim/include/hardware/claim.h
@@ -65,10 +65,10 @@ int hw_claim_unused_from_range(uint8_t *bits, bool required, uint bit_lsb, uint 
  * The resource ownership is indicated by the bit_index bit in an array of bits.
  *
  * \param bits pointer to an array of bits (8 bits per byte)
- * \param bit_index resource to unclaim (bit index into array of bits)
+ * \param bit_index resource to check (bit index into array of bits)
  * \return true if the resource is claimed
  */
-bool hw_is_claimed(uint8_t *bits, uint bit_index);
+bool hw_is_claimed(const uint8_t *bits, uint bit_index);
 
 /*! \brief Atomically unclaim a resource
  *  \ingroup hardware_claim


### PR DESCRIPTION
modified hw_is_claimed

Note a lock is not required as it is the access to a single memory cell which is locked automatically by HW