### PR TITLE
Only warn about Doxygen missing when Pico SDK is the top-level project

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,10 @@
-find_package(Doxygen)
-if (PICO_SDK_TOP_LEVEL_PROJECT AND ${DOXYGEN_FOUND})
-    set(PICO_BUILD_DOCS_DEFAULT 1)
+find_package(Doxygen QUIET)
+if (PICO_SDK_TOP_LEVEL_PROJECT)
+    if (DOXYGEN_FOUND)
+        set(PICO_BUILD_DOCS_DEFAULT 1)
+    else()
+        message("Doxygen was not found (needed to generate documentation)")
+    endif()
 endif()
 option(PICO_BUILD_DOCS "Build HTML Doxygen docs" ${PICO_BUILD_DOCS_DEFAULT})
 


### PR DESCRIPTION
This silences the following warning for projects that include the Pico SDK:

```
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
```

I don't think projects that include the pico-sdk would want to generate the
Pico SDK documentation (perhaps with the sole exception of the example repo?),
so this warning is not all that relevant outside of the top-level project.