### PR TITLE
queue: make data pointers const in queue_try_add and queue_add_blocking

### DIFF
--- a/src/common/pico_util/include/pico/util/queue.h
+++ b/src/common/pico_util/include/pico/util/queue.h
@@ -129,7 +129,7 @@ static inline bool queue_is_full(queue_t *q) {
  * If the queue is full this function will return immediately with false, otherwise
  * the data is copied into a new value added to the queue, and this function will return true.
  */
-bool queue_try_add(queue_t *q, void *data);
+bool queue_try_add(queue_t *q, const void *data);
 
 /*! \brief Non-blocking removal of entry from the queue if non empty
  *  \ingroup queue
@@ -165,7 +165,7 @@ bool queue_try_peek(queue_t *q, void *data);
  *
  * If the queue is full this function will block, until a removal happens on the queue
  */
-void queue_add_blocking(queue_t *q, void *data);
+void queue_add_blocking(queue_t *q, const void *data);
 
 /*! \brief Blocking remove entry from queue
  *  \ingroup queue

--- a/src/common/pico_util/queue.c
+++ b/src/common/pico_util/queue.c
@@ -33,7 +33,7 @@ static inline uint16_t inc_index(queue_t *q, uint16_t index) {
     return index;
 }
 
-static bool queue_add_internal(queue_t *q, void *data, bool block) {
+static bool queue_add_internal(queue_t *q, const void *data, bool block) {
     do {
         uint32_t save = spin_lock_blocking(q->core.spin_lock);
         if (queue_get_level_unsafe(q) != q->element_count) {
@@ -86,7 +86,7 @@ static bool queue_peek_internal(queue_t *q, void *data, bool block) {
     } while (true);
 }
 
-bool queue_try_add(queue_t *q, void *data) {
+bool queue_try_add(queue_t *q, const void *data) {
     return queue_add_internal(q, data, false);
 }
 
@@ -98,7 +98,7 @@ bool queue_try_peek(queue_t *q, void *data) {
     return queue_peek_internal(q, data, false);
 }
 
-void queue_add_blocking(queue_t *q, void *data) {
+void queue_add_blocking(queue_t *q, const void *data) {
     queue_add_internal(q, data, true);
 }
 


### PR DESCRIPTION
The only operation done on the data pointer is to pass it into the second argument of memcpy, which is `const void *`