### PR TITLE
- interp_ fixes

### DIFF
--- a/src/rp2_common/hardware_interp/include/hardware/interp.h
+++ b/src/rp2_common/hardware_interp/include/hardware/interp.h
@@ -285,9 +285,9 @@ static inline void interp_set_force_bits(interp_hw_t *interp, uint lane, uint bi
 }
 
 typedef struct {
-    io_rw_32 accum[2];
-    io_rw_32 base[3];
-    io_rw_32 ctrl[2];
+    uint32_t accum[2];
+    uint32_t base[3];
+    uint32_t ctrl[2];
 } interp_hw_save_t;
 
 /*! \brief Save the specified interpolator state

--- a/src/rp2_common/hardware_interp/include/hardware/interp.h
+++ b/src/rp2_common/hardware_interp/include/hardware/interp.h
@@ -87,6 +87,14 @@ void interp_claim_lane_mask(interp_hw_t *interp, uint lane_mask);
  */
 void interp_unclaim_lane(interp_hw_t *interp, uint lane);
 
+/*! \brief Release previously claimed interpolator lanes \see interp_claim_lane_mask
+ *  \ingroup hardware_interp
+ *
+ * \param interp Interpolator on which to release lanes. interp0 or interp1
+ * \param lane_mask Bit pattern of lanes to unclaim (only bits 0 and 1 are valid)
+ */
+void interp_unclaim_lane_mask(interp_hw_t *interp, uint lane_mask);
+
 /*! \brief Set the interpolator shift value
  *  \ingroup interp_config
  *

--- a/src/rp2_common/hardware_interp/interp.c
+++ b/src/rp2_common/hardware_interp/interp.c
@@ -16,9 +16,13 @@ static_assert(NUM_DMA_CHANNELS <= 16, "");
 
 static uint8_t _claimed;
 
+static inline uint interp_get_bit(interp_hw_t *interp, uint lane) {
+  return 1u << ((interp_index(interp) << 1u) | lane);
+}
+
 void interp_claim_lane(interp_hw_t *interp, uint lane) {
     valid_params_if(INTERP, lane < 2);
-    uint bit = (interp_index(interp) << 1u) | lane;
+    uint bit = interp_get_bit(interp, lane);
     hw_claim_or_assert((uint8_t *) &_claimed, bit, "Lane is already claimed");
 }
 
@@ -30,8 +34,14 @@ void interp_claim_lane_mask(interp_hw_t *interp, uint lane_mask) {
 
 void interp_unclaim_lane(interp_hw_t *interp, uint lane) {
     valid_params_if(INTERP, lane < 2);
-    uint bit = (interp_index(interp) << 1u) | lane;
-    hw_claim_clear((uint8_t *) &_claimed, bit);
+    uint bit = interp_get_bit(interp, lane);
+    hw_claim_clear(&_claimed, bit);
+}
+
+void interp_unclaim_lane_mask(interp_hw_t *interp, uint lane_mask) {
+    valid_params_if(INTERP, lane_mask && lane_mask <= 0x3);
+    if (lane_mask & 1u) interp_unclaim_lane(interp, 0);
+    if (lane_mask & 2u) interp_unclaim_lane(interp, 1);
 }
 
 void interp_save(interp_hw_t *interp, interp_hw_save_t *saver) {


### PR DESCRIPTION
- fix interp_claim_lane (in case of interp1 and lane==1 "bit" was 0b11 instead of 0b1000)

- added missing function interp_unclaim_lane_mask()