### PR TITLE
Define `void operator delete[](void *p, std::size_t n)` in new_delete.cpp

### DIFF
--- a/src/rp2_common/pico_standard_link/new_delete.cpp
+++ b/src/rp2_common/pico_standard_link/new_delete.cpp
@@ -23,4 +23,6 @@ void operator delete(void *p) { std::free(p); }
 
 void operator delete[](void *p) noexcept { std::free(p); }
 
+void operator delete[](void *p, __unused std::size_t n) noexcept { std::free(p); }
+
 #endif

--- a/src/rp2_common/pico_standard_link/new_delete.cpp
+++ b/src/rp2_common/pico_standard_link/new_delete.cpp
@@ -17,12 +17,16 @@ void *operator new[](std::size_t n) {
     return std::malloc(n);
 }
 
-void operator delete(void *p, __unused std::size_t n) noexcept { std::free(p); }
-
 void operator delete(void *p) { std::free(p); }
 
 void operator delete[](void *p) noexcept { std::free(p); }
 
+#if __cpp_sized_deallocation
+
+void operator delete(void *p, __unused std::size_t n) noexcept { std::free(p); }
+
 void operator delete[](void *p, __unused std::size_t n) noexcept { std::free(p); }
+
+#endif
 
 #endif


### PR DESCRIPTION
This prevents the following warning when compiling with `-Wextra`:

```C
[redacted]/pico-sdk/src/rp2_common/pico_standard_link/new_delete.cpp:24:6: error: the program should also define 'void operator delete [](void*, unsigned int)' [-Werror=sized-deallocation]
   24 | void operator delete[](void *p) noexcept { std::free(p); }
      |      ^~~~~~~~
```

This function signature was introduced in C++14. I don't _think_ that should cause any issues, but I'm not sure.