### PR TITLE
Generate map files if `pico_add_extra_outputs` is called

### DIFF
--- a/src/rp2_common.cmake
+++ b/src/rp2_common.cmake
@@ -18,6 +18,7 @@ function(pico_add_dis_output TARGET)
 endfunction()
 
 function(pico_add_extra_outputs TARGET)
+    pico_add_map_output(${TARGET})
     pico_add_hex_output(${TARGET})
     pico_add_bin_output(${TARGET})
     pico_add_dis_output(${TARGET})


### PR DESCRIPTION
Many examples in the pico-examples repo call `pico_add_extra_outputs` with the comment "create map/bin/hex file etc.", so it seems like this is the intention.