### PR TITLE
Define `__STRING` for other compilers than MSVC in the host platform.h file

### DIFF
--- a/src/host/pico_platform/include/pico/platform.h
+++ b/src/host/pico_platform/include/pico/platform.h
@@ -36,6 +36,10 @@ extern "C" {
 //int running_on_fpga() { return false; }
 extern void tight_loop_contents();
 
+#ifndef __STRING
+#define __STRING(x) #x
+#endif
+
 #ifndef _MSC_VER
 #ifndef __noreturn
 #define __noreturn __attribute((noreturn))
@@ -76,10 +80,6 @@ extern void tight_loop_contents();
 #ifndef __CONCAT
 #define __CONCAT(x,y) x ## y
 #endif
-
-#ifndef __STRING
-#define __STRING(x) #x
-#endif()
 
 #define __thread __declspec( thread )
 


### PR DESCRIPTION
I have a project where I'm linking some code to the pico stdlib with `PICO_PLATFORM=host` (for host-based unit testing). Without this change, I get errors like the following:

```
C:\MinGW\bin\gcc.exe   -DLIB_PICO_BIT_OPS=1 -DLIB_PICO_DIVIDER=1 -DLIB_PICO_PRINTF=1 -DLIB_PICO_STDIO=1 -DLIB_PICO_STDLIB=1 -DLIB_PICO_SYNC=1 -DLIB_PICO_SYNC_CORE=1 -DLIB_PICO_SYNC_CRITICAL_SECTION=1 -DLIB_PICO_SYNC_MUTEX=1 -DLIB_PICO_SYNC_SEM=1 -DLIB_PICO_TIME=1 -DLIB_PICO_UTIL=1 -DPICO_BOARD=\"pico\" -DPICO_BUILD=1 -DPICO_DEFAULT_UART_BAUD_RATE=921600 -DPICO_HARDWARE_TIMER_RESOLUTION_US=1000 -DPICO_NO_HARDWARE=1 -DPICO_ON_DEVICE=0 -DPICO_TIME_DEFAULT_ALARM_POOL_DISABLED=1 -I[...]/pico-sdk/src/common/pico_stdlib/include -I[...]/pico-sdk/src/host/hardware_gpio/include -I[...]/pico-sdk/src/common/pico_base/include -Igenerated/pico_base -I[...]/pico-sdk/src/boards/include -I[...]/pico-sdk/src/host/pico_platform/include -I[...]/pico-sdk/src/common/pico_bit_ops/include -I[...]/pico-sdk/src/host/hardware_uart/include -I[...]/pico-sdk/src/host/hardware_divider/include -I[...]/pico-sdk/src/common/pico_time/include -I[...]/pico-sdk/src/host/hardware_timer/include -I[...]/pico-sdk/src/common/pico_sync/include -I[...]/pico-sdk/src/host/hardware_sync/include -I[...]/pico-sdk/src/common/pico_util/include -I[...]/pico-sdk/src/common/pico_divider/include -I[...]/pico-sdk/src/common/pico_binary_info/include -I[...]/pico-sdk/src/host/pico_stdio/include -O3 -DNDEBUG   -Wno-unused-parameter -Wall -Wextra -fdiagnostics-color=always -std=gnu11 -MD -MT app/CMakeFiles/pm_comm_uart.dir/C_/dt/pico-sdk/src/host/hardware_gpio/gpio.c.obj -MF app\CMakeFiles\pm_comm_uart.dir\C_\dt\pico-sdk\src\host\hardware_gpio\gpio.c.obj.d -o app/CMakeFiles/pm_comm_uart.dir/C_/dt/pico-sdk/src/host/hardware_gpio/gpio.c.obj   -c [...]/pico-sdk/src/host/hardware_gpio/gpio.c
[...]/pico-sdk/src/host/hardware_gpio/gpio.c:54:32: error: _Pragma takes a parenthesized string literal
 PICO_WEAK_FUNCTION_DEF(gpio_get)
                                ^
In file included from [...]/pico-sdk/src/common/pico_base/include/pico.h:19,
                 from [...]/pico-sdk/src/host/hardware_gpio/include/hardware/gpio.h:14,
                 from [...]/pico-sdk/src/host/hardware_gpio/gpio.c:7:
[...]/pico-sdk/src/host/pico_platform/include/pico/platform.h:60:52: error: unknown type name 'weak'
 #define PICO_WEAK_FUNCTION_DEF(x) _Pragma(__STRING(weak x))
                                                    ^~~~
[...]/pico-sdk/src/host/hardware_gpio/gpio.c:54:1: note: in expansion of macro 'PICO_WEAK_FUNCTION_DEF'
 PICO_WEAK_FUNCTION_DEF(gpio_get)
 ^~~~~~~~~~~~~~~~~~~~~~
```

The fact that `__STRING` is only defined in the `#else` clause of an `#ifndef _MSC_VER` block seems like it's obviously a bug to me, but I'm a bit confused since I can't be the only one building for host with gcc?