### PR TITLE
Add missing cast to uint32_t in hw_divider_u32_quotient for host

### DIFF
--- a/src/host/hardware_divider/include/hardware/divider.h
+++ b/src/host/hardware_divider/include/hardware/divider.h
@@ -78,7 +78,7 @@ static inline int32_t hw_divider_s32_remainder_wait() {
 }
 
 static inline uint32_t hw_divider_u32_quotient(uint32_t a, uint32_t b) {
-    return b ? (a / b) : -1;
+    return b ? (a / b) : (uint32_t)(-1);
 }
 
 static inline uint32_t hw_divider_u32_remainder(uint32_t a, uint32_t b) {


### PR DESCRIPTION
Fixes the following warning:

```
[...]/pico-sdk/src/host/hardware_divider/include/hardware/divider.h:81:26: warning: operand of ?: changes signedness from 'int' to 'uint32_t' {aka 'unsigned int'} due to unsignedness of other operand [-Wsign-compare]
     return b ? (a / b) : -1;
                          ^~
```

The fix is to make the cast explicit, like `hw_divider_divmod_u32` already does