### PR TITLE
Fix function-name misspelling

### DIFF
--- a/src/host/hardware_uart/uart.c
+++ b/src/host/hardware_uart/uart.c
@@ -24,7 +24,7 @@ struct termios _tty;
 static tcflag_t _res_oflg = 0;
 static tcflag_t _res_lflg = 0;
 
-void _resetty(void) {
+void _resettty(void) {
     if (!isatty(STDIN_FILENO))
         return;
 
@@ -49,7 +49,7 @@ void _inittty(void) {
     tcsetattr(STDIN_FILENO, TCSANOW, &_tty);
 
     fcntl(STDIN_FILENO, F_SETFL, FNONBLOCK);
-    atexit(_resetty);
+    atexit(_resettty);
 }
 
 #else


### PR DESCRIPTION
If "init tty" is `_inittty` then "reset tty" ought to be `_resettty`