### PR TITLE
Optional feature to get the max level that has ever been held by a queue

### DIFF
--- a/src/common/pico_util/queue.c
+++ b/src/common/pico_util/queue.c
@@ -30,6 +30,14 @@ static inline uint16_t inc_index(queue_t *q, uint16_t index) {
     if (++index > q->element_count) { // > because we have element_count + 1 elements
         index = 0;
     }
+
+#if PICO_QUEUE_MAX_LEVEL
+    uint16_t level = queue_get_level_unsafe(q);
+    if (level > q->max_level) {
+        q->max_level = level;
+    }
+#endif
+
     return index;
 }
 


### PR DESCRIPTION
I'm using this in my application to get a better idea of how many entries I need to allocate to avoid blocking or losing data, and to debug performance issues. It adds some overhead, hence the opt-in.