### PR TITLE
Add missing board detection macros

### DIFF
--- a/src/boards/include/boards/pico.h
+++ b/src/boards/include/boards/pico.h
@@ -14,6 +14,9 @@
 #ifndef _BOARDS_PICO_H
 #define _BOARDS_PICO_H
 
+// For board detection
+#define RASPBERRYPI_PICO
+
 // --- UART ---
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0

--- a/src/boards/include/boards/sparkfun_micromod.h
+++ b/src/boards/include/boards/sparkfun_micromod.h
@@ -17,6 +17,9 @@
 #ifndef _BOARDS_SPARKFUN_MICROMOD_H
 #define _BOARDS_SPARKFUN_MICROMOD_H
 
+// For board detection
+#define SPARKFUN_MICROMOD
+
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0
 #endif

--- a/src/boards/include/boards/sparkfun_promicro.h
+++ b/src/boards/include/boards/sparkfun_promicro.h
@@ -17,6 +17,9 @@
 #ifndef _BOARDS_SPARKFUN_PROMICRO_H
 #define _BOARDS_SPARKFUN_PROMICRO_H
 
+// For board detection
+#define SPARKFUN_PROMICRO
+
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0
 #endif

--- a/src/boards/include/boards/sparkfun_thingplus.h
+++ b/src/boards/include/boards/sparkfun_thingplus.h
@@ -17,6 +17,9 @@
 #ifndef _BOARDS_SPARKFUN_THINGPLUS_H
 #define _BOARDS_SPARKFUN_THINGPLUS_H
 
+// For board detection
+#define SPARKFUN_THINGPLUS
+
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0
 #endif
@@ -69,7 +72,7 @@
 #define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
 #endif
 
-// The thing plus has a SD Card. 
+// The thing plus has a SD Card.
 #define PICO_SD_CLK_PIN   14
 #define PICO_SD_CMD_PIN   15
 #define PICO_SD_DAT0_PIN  12

--- a/src/boards/include/boards/vgaboard.h
+++ b/src/boards/include/boards/vgaboard.h
@@ -12,6 +12,9 @@
 #ifndef _BOARDS_VGABOARD_H
 #define _BOARDS_VGABOARD_H
 
+// For board detection
+#define RASPBERRYPI_VGABOARD
+
 // Audio pins. I2S BCK, LRCK are on the same pins as PWM L/R.
 // - When outputting I2S, PWM sees BCK and LRCK, which should sound silent as
 //   they are constant duty cycle, and above the filter cutoff


### PR DESCRIPTION
This adds macros to some of the boards' header files for detecting what board is targeted. This affects all Sparkfun boards and the RPi Pico & VGA board (for good measure). This doesn't really satisfy any particular issue, rather it keeps a uniform layout in the header files (all Pimoroni, Adafruit, and Arduino board headers already have this board detection macro).

@kirk-sfe this PR addresses my subsequent concern as mentioned in https://github.com/raspberrypi/pico-sdk/issues/328#issuecomment-845622997

I'm open to using a different nomenclature... I just went with `#define <board-producer>_<board-variant>`