### PR TITLE
Allow lengthening xosc startup delay with a compile option

### DIFF
--- a/src/boards/include/boards/adafruit_feather_rp2040.h
+++ b/src/boards/include/boards/adafruit_feather_rp2040.h
@@ -15,6 +15,11 @@
 // For board detection
 #define ADAFRUIT_FEATHER_RP2040
 
+// On some samples, the xosc can take longer to stabilize than is usual
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+#endif
+
 //------------- UART -------------//
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0

--- a/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
+++ b/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
@@ -15,6 +15,11 @@
 // For board detection
 #define ADAFRUIT_ITSYBITSY_RP2040
 
+// On some samples, the xosc can take longer to stabilize than is usual
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+#endif
+
 //------------- UART -------------//
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 0

--- a/src/boards/include/boards/adafruit_qtpy_rp2040.h
+++ b/src/boards/include/boards/adafruit_qtpy_rp2040.h
@@ -15,6 +15,11 @@
 // For board detection
 #define ADAFRUIT_QTPY_RP2040
 
+// On some samples, the xosc can take longer to stabilize than is usual
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+#endif
+
 //------------- UART -------------//
 #ifndef PICO_DEFAULT_UART
 #define PICO_DEFAULT_UART 1

--- a/src/rp2_common/hardware_xosc/include/hardware/xosc.h
+++ b/src/rp2_common/hardware_xosc/include/hardware/xosc.h
@@ -10,6 +10,15 @@
 #include "pico.h"
 #include "hardware/structs/xosc.h"
 
+
+// Allow lengthening startup delay to accommodate slow-starting oscillators
+
+// PICO_CONFIG: PICO_XOSC_STARTUP_DELAY_MULTIPLIER, Multiplier to lengthen xosc startup delay to accommodate slow-starting oscillators, type=int, min=1, default=1, group=hardware_xosc
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 1
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/rp2_common/hardware_xosc/xosc.c
+++ b/src/rp2_common/hardware_xosc/xosc.c
@@ -13,6 +13,11 @@
 #include "hardware/regs/xosc.h"
 #include "hardware/structs/xosc.h"
 
+// Allow lengthening startup delay to accommodate slow-starting oscillators
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 1
+#endif
+
 void xosc_init(void) {
     // Assumes 1-15 MHz input
     assert(XOSC_MHZ <= 15);
@@ -20,7 +25,9 @@ void xosc_init(void) {
 
     // Set xosc startup delay
     uint32_t startup_delay = (((12 * MHZ) / 1000) + 128) / 256;
-    xosc_hw->startup = startup_delay;
+
+    // Allow lengthening startup delay to accommodate slow-starting oscillators
+    xosc_hw->startup = startup_delay * PICO_XOSC_STARTUP_DELAY_MULTIPLIER;
 
     // Set the enable bit now that we have set freq range and startup delay
     hw_set_bits(&xosc_hw->ctrl, XOSC_CTRL_ENABLE_VALUE_ENABLE << XOSC_CTRL_ENABLE_LSB);

--- a/src/rp2_common/hardware_xosc/xosc.c
+++ b/src/rp2_common/hardware_xosc/xosc.c
@@ -13,7 +13,7 @@
 #include "hardware/regs/xosc.h"
 #include "hardware/structs/xosc.h"
 
-// Allow lengthening startup delay to accommodate slow-starting oscillators
+// PICO_CONFIG: PICO_XOSC_STARTUP_DELAY_MULTIPLIER, Multiplier to lengthen xosc startup delay to accommodate slow-starting oscillators, type=int, min=1, default=1, group=hardware_xosc
 #ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
 #define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 1
 #endif

--- a/src/rp2_common/hardware_xosc/xosc.c
+++ b/src/rp2_common/hardware_xosc/xosc.c
@@ -11,14 +11,7 @@
 
 #include "hardware/platform_defs.h"
 #include "hardware/regs/xosc.h"
-#include "hardware/structs/xosc.h"
-
-// Allow lengthening startup delay to accommodate slow-starting oscillators
-
-// PICO_CONFIG: PICO_XOSC_STARTUP_DELAY_MULTIPLIER, Multiplier to lengthen xosc startup delay to accommodate slow-starting oscillators, type=int, min=1, default=1, group=hardware_xosc
-#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
-#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 1
-#endif
+#include "hardware/xosc.h"
 
 #if XOSC_MHZ < 1 || XOSC_MHZ > 15
 #error XOSC_MHZ must be in the range 1-15


### PR DESCRIPTION
This PR allows you to specify a multiplier, at compile time to lengthen the default XOSC startup time. The multiplier, `PICO_XOSC_STARTUP_DELAY_MULTIPLIER`, is `1` by default.

Motivation: On a few samples of some Adafruit RP2040 boards, the XOSC takes much longer to stabilize than would be expected. This appears to be due to some mismatch between the chosen XOSC crystal and capacitors. Sometimes the problem is intermittent, and may depend on handling the board while restarting, humidity, etc. We are going to fix future boards, but this PR is a software fix that accommodates all boards.

The Adafruit board include files set `PICO_XOSC_STARTUP_DELAY_MULTIPLIER` to be 64. This was chosen empirically. 16 can be too low sometimes. 32 seems to work, and so 64 includes a safety margin.

This issue has been discussed at length in #401. The default XOSC startup time is used in the boot ROM when using USB, but the XOSC startup problem does not seem to be an issue: the boards all can connect to USB successfully. Also relevant: https://github.com/raspberrypi/pico-feedback/issues/158/.

I've tested this on an Adafruit QT Py RP2040 that exhibits the problem, with the `pico-examples` `blink` example.

One minor thing: `xosc.c` did not end in a newline, and my editor fixed that automatically.