### PR TITLE
Make printf trim trailing zeroes with %[Gg] format

### DIFF
--- a/src/rp2_common/pico_printf/printf.c
+++ b/src/rp2_common/pico_printf/printf.c
@@ -99,6 +99,7 @@
 #define FLAGS_LONG_LONG (1U <<  9U)
 #define FLAGS_PRECISION (1U << 10U)
 #define FLAGS_ADAPT_EXP (1U << 11U)
+#define FLAGS_TRIM_ZERO (1U << 12U)
 
 // import float.h for DBL_MAX
 #if PICO_PRINTF_SUPPORT_FLOAT
@@ -380,7 +381,7 @@ static size_t _ftoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, d
     }
     // limit precision to 9, cause a prec >= 10 can lead to overflow errors
     while ((len < PICO_PRINTF_FTOA_BUFFER_SIZE) && (prec > 9U)) {
-        buf[len++] = '0';
+        if (!(flags & FLAGS_TRIM_ZERO)) buf[len++] = '0';
         prec--;
     }
 
@@ -411,21 +412,30 @@ static size_t _ftoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, d
         }
     } else {
         unsigned int count = prec;
+        bool nonzero = false;
         // now do fractional part, as an unsigned number
         while (len < PICO_PRINTF_FTOA_BUFFER_SIZE) {
             --count;
-            buf[len++] = (char) (48U + (frac % 10U));
+            char digit = (frac % 10U);
+            // only print the digit if trimming isn't desired,
+            // a non-zero digit has already been printed, or it's non-zero
+            if (!(flags & FLAGS_TRIM_ZERO) || nonzero || digit != 0) {
+                buf[len++] = (char) (48U + digit);
+                nonzero = true;
+            }
             if (!(frac /= 10U)) {
                 break;
             }
         }
-        // add extra 0s
-        while ((len < PICO_PRINTF_FTOA_BUFFER_SIZE) && (count-- > 0U)) {
-            buf[len++] = '0';
-        }
-        if (len < PICO_PRINTF_FTOA_BUFFER_SIZE) {
-            // add decimal
-            buf[len++] = '.';
+        if (!(flags & FLAGS_TRIM_ZERO) || nonzero) {
+            // add extra 0s
+            while ((len < PICO_PRINTF_FTOA_BUFFER_SIZE) && (count-- > 0U)) {
+                buf[len++] = '0';
+            }
+            if (len < PICO_PRINTF_FTOA_BUFFER_SIZE) {
+                // add decimal
+                buf[len++] = '.';
+            }
         }
     }
 
@@ -797,7 +807,7 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
             case 'g':
             case 'G':
 #if PICO_PRINTF_SUPPORT_FLOAT && PICO_PRINTF_SUPPORT_EXPONENTIAL
-                if ((*format == 'g') || (*format == 'G')) flags |= FLAGS_ADAPT_EXP;
+                if ((*format == 'g') || (*format == 'G')) flags |= FLAGS_ADAPT_EXP | FLAGS_TRIM_ZERO;
                 if ((*format == 'E') || (*format == 'G')) flags |= FLAGS_UPPERCASE;
                 idx = _etoa(out, buffer, idx, maxlen, va_arg(va, double), precision, width, flags);
 #else


### PR DESCRIPTION
This PR modifies the behavior of `pico_printf` to automatically trim trailing zeroes when using the `%G` or `%g` format specifiers. This is the behavior that is [specified by GCC](https://www.gnu.org/software/libc/manual/html_node/Floating_002dPoint-Conversions.html):

> The ‘`%g`’ and ‘`%G`’ conversions print the argument in the style of ‘`%e`’ or ‘`%E`’ (respectively) if the exponent would be less than -4 or greater than or equal to the precision; otherwise they use the ‘`%f`’ style. A precision of `0`, is taken as 1. **Trailing zeros are removed from the fractional portion of the result and a decimal-point character appears only if it is followed by a digit.**

Previously, `printf("%.14g", 2000)` would output `2000.0000000000`, but with this change it outputs just `2000`. This is useful for programs that want the minimum-length conversion of a number with the most precision necessary. (My example is Lua, which uses `sprintf(s, "%.14g", num)` to convert numbers to strings; previously this would result in unnecessarily large conversions for small integers.)

This change does not affect the default `printf` - newlib exhibits the same behavior as `pico_printf` currently does, so that would have to be adjusted as well (and I can say after reading the code that I'm not the one to do that). Users will have to link `pico_printf` manually to benefit AFAICT.

Please let me know if this breaks anything - I didn't have a chance to test this fully (I'm embroiled in debugging some other stuff), but looking at the code I don't think there should be much to break.