### PR TITLE
Fix flash size for Adafruit RP2040 boards

### DIFF
--- a/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
+++ b/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
@@ -80,7 +80,7 @@
 #endif
 
 #ifndef PICO_FLASH_SIZE_BYTES
-#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 #endif
 
 // All boards have B1 RP2040

--- a/src/boards/include/boards/adafruit_qtpy_rp2040.h
+++ b/src/boards/include/boards/adafruit_qtpy_rp2040.h
@@ -79,7 +79,7 @@
 #endif
 
 #ifndef PICO_FLASH_SIZE_BYTES
-#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 #endif
 
 // All boards have B1 RP2040


### PR DESCRIPTION
Adafruit QT Py RP2040 and Itsybitsy RP2040 ship with 8M of flash.