### PR TITLE
fix qtpy rp2040 uart rx rev B

### DIFF
--- a/src/boards/include/boards/adafruit_qtpy_rp2040.h
+++ b/src/boards/include/boards/adafruit_qtpy_rp2040.h
@@ -30,7 +30,7 @@
 #endif
 
 #ifndef PICO_DEFAULT_UART_RX_PIN
-#define PICO_DEFAULT_UART_RX_PIN 9
+#define PICO_DEFAULT_UART_RX_PIN 5
 #endif
 
 //------------- LED -------------//

--- a/src/rp2040/hardware_structs/include/hardware/structs/usb.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/usb.h
@@ -79,6 +79,7 @@ typedef struct {
 } usb_device_dpram_t;
 
 static_assert(sizeof(usb_device_dpram_t) == USB_DPRAM_MAX, "");
+static_assert(offsetof(usb_device_dpram_t, epx_data) == 0x180, "");
 
 typedef struct {
     // 4K of DPSRAM at beginning. Note this supports 8, 16, and 32 bit accesses
@@ -108,6 +109,7 @@ typedef struct {
 } usb_host_dpram_t;
 
 static_assert(sizeof(usb_host_dpram_t) == USB_DPRAM_MAX, "");
+static_assert(offsetof(usb_host_dpram_t, epx_data) == 0x180, "");
 
 typedef struct {
     io_rw_32 dev_addr_ctrl;


### PR DESCRIPTION
This Pr address the changes in production of Adafruit qtpy rp2040 revB with uart rx pin from 9 to 5. https://cdn-learn.adafruit.com/assets/assets/000/101/678/original/adafruit_products_QTRP_sch.png?1618955879

also add static check for USB DPRAM (a bit randomly, but it could be useful in the future).