### PR TITLE
include pico.h so that uint is defined

### DIFF
--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -7,6 +7,8 @@
 #ifndef _PICO_UNIQUE_ID_H_
 #define _PICO_UNIQUE_ID_H_
 
+#include "pico.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fixes #474 