### PR TITLE
portability issue on RPI2 -> uint to uin32_t

### DIFF
--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -69,7 +69,7 @@ void pico_get_unique_board_id(pico_unique_board_id_t *id_out);
  * \param id_out a pointer to a char buffer of size len, to which the identifier will be written
  * \param len the size of id_out. For full serial, len >= 2 * PICO_UNIQUE_BOARD_ID_SIZE_BYTES + 1
  */
-void pico_get_unique_board_id_string(char *id_out, uint len);
+void pico_get_unique_board_id_string(char *id_out, uint32_t len);
 
 
 #ifdef __cplusplus

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -27,7 +27,7 @@ void pico_get_unique_board_id(pico_unique_board_id_t *id_out) {
     *id_out = retrieved_id;
 }
 
-void pico_get_unique_board_id_string(char *id_out, uint len) {
+void pico_get_unique_board_id_string(char *id_out, uint32_t len) {
     assert(len > 0);
     size_t i;
     // Generate hex one nibble at a time


### PR DESCRIPTION
Compiler on RPI2 was failing on type uint. I changed code from uint to uin32_t