### PR TITLE
remove -Winline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,6 @@ if (NOT TARGET _pico_sdk_inclusion_marker)
     add_subdirectory(tools)
     add_subdirectory(src)
 
-    add_compile_options(-Winline)
-
     # allow customization
     add_sub_list_dirs(PICO_SDK_POST_LIST_DIRS)
     add_sub_list_files(PICO_SDK_POST_LIST_FILES)


### PR DESCRIPTION
Had been vaguely wondering why we get some rather dubiously useful warnings about inlining with some compilers. on looking at `make VERBOSE=1` output for something else I noticed we were passing `-Winline`

Looking at history this was added as temporary for a debug check during development (as you'd expect since it is not the correct way to add compiler options)