### PR TITLE
Using ' inline __always_inline' also for GNUC 7.

### DIFF
--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -49,7 +49,7 @@ extern "C" {
 
 #define __packed_aligned __packed __aligned(4)
 
-#if defined(__GNUC__) && __GNUC__ < 7
+#if defined(__GNUC__) && __GNUC__ <= 7
 #define __force_inline inline __always_inline
 #else
 #define __force_inline __always_inline


### PR DESCRIPTION
Per the discussion at https://www.raspberrypi.org/forums/viewtopic.php?f=145&t=313961

GNU7 also expects the 'inline' keyword and generates warnings otherwise.