### PR TITLE
compile failure with PICO_STDOUT_MUTEX=0

### DIFF
--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -53,10 +53,10 @@ void stdout_serialize_end(void) {
 }
 
 #else
-static bool print_serialize_begin(void) {
+static bool stdout_serialize_begin(void) {
     return true;
 }
-static void print_serialize_end(void) {
+static void stdout_serialize_end(void) {
 }
 #endif
 


### PR DESCRIPTION
a previous refactoring failed to rename some functions, causing build to fail with PICO_STDOUT_MUTEX=0; this fix correctly renames the functions which were guarded by the #if