### PR TITLE
U64 divide save restore issue

### DIFF
--- a/src/rp2_common/pico_divider/divider.S
+++ b/src/rp2_common/pico_divider/divider.S
@@ -413,6 +413,7 @@ y64:
  lsls r3,#16
  orrs r3,r4
  str r3,[r7,#SIO_DIV_UDIVIDEND_OFFSET] @ y1=(r0<<16)+(((ui32)y)>>16);
+ str r2,[r7,#SIO_DIV_UDIVISOR_OFFSET]  @ must set divisor again, as we do not save/restore regs at all in IRQs if not dirty
  wait_div 1
  uxth r4,r0
  ldr r3,[r7,#SIO_DIV_REMAINDER_OFFSET] @ r1=y1-q1*x; 0<=r1<x
@@ -420,6 +421,7 @@ y64:
  lsls r3,#16
  orrs r3,r4
  str r3,[r7,#SIO_DIV_UDIVIDEND_OFFSET] @ y1=(r0<<16)+(((ui32)y)>>16);
+ str r2,[r7,#SIO_DIV_UDIVISOR_OFFSET]  @ must set divisor again, as we do not save/restore regs at all in IRQs if not dirty
  wait_div 3
  movs r3,#0
  lsls r4,r5,#16             @ quotient=(q0<<32)+(q1<<16)+q2

--- a/test/pico_divider_test/pico_divider_nesting_test.c
+++ b/test/pico_divider_test/pico_divider_nesting_test.c
@@ -158,6 +158,23 @@ void test_nesting() {
             if (0xffffffffu != a * 11 + b) {
                 FAILED();
             }
+            static uint64_t z64;
+            z64 -= 47;
+            uint64_t a64 = z64 / -13635;
+            uint64_t b64 = z64 % -13635;
+            if (z64 != a64 * -13635 + b64) {
+                FAILED();
+            }
+            // specifically check 64/32 divide
+            static uint64_t c64 = 0x13ffffffffull;
+            static uint32_t cd = 1;
+            a64 = c64 / cd;
+            b64 = c64 % cd;
+            if (c64 != a64 * cd + b64) {
+                FAILED();
+            }
+            cd++;
+
         }
         // these use the divider
         for(uint i=0;i<=100;i+=20) {


### PR DESCRIPTION
The 64 bit divide code path made repeated use of the divider with the same DIVISOR without reloading it, which fails if an interrupt which uses the divider happens *between* the actual hardware divisions. In this case the hardware divider is not _dirty_, so the nested division does not bother to save/restore the divider state.

Fixed by reloading the divisor each time (it was in a CPU register anyway)