### PR TITLE
bug in sleep_until on host mode for macOS

### DIFF
--- a/src/host/hardware_timer/timer.c
+++ b/src/host/hardware_timer/timer.c
@@ -65,12 +65,12 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(busy_wait_until)(absolute_time_t target) {
     const int chunk = 1u<<30u;
     uint64_t target_us = to_us_since_boot(target);
     uint64_t time_us = time_us_64();
-    while (target_us - time_us >= chunk) {
+    while ((int64_t)(target_us - time_us) >= chunk) {
         busy_wait_us_32(chunk);
         time_us = time_us_64();
     }
-    if (target_us != time_us) {
-        busy_wait_us_32(target_us - chunk);
+    if (target_us > time_us) {
+        busy_wait_us_32(target_us - time_us);
     }
 #endif
 }


### PR DESCRIPTION
if sleep target was in the past, it would hang