### PR TITLE
adafruit_feather_rp2040: Fix default I2C instance

### DIFF
--- a/src/boards/include/boards/adafruit_feather_rp2040.h
+++ b/src/boards/include/boards/adafruit_feather_rp2040.h
@@ -44,7 +44,7 @@
 
 //------------- I2C -------------//
 #ifndef PICO_DEFAULT_I2C
-#define PICO_DEFAULT_I2C 0
+#define PICO_DEFAULT_I2C 1
 #endif
 
 #ifndef PICO_DEFAULT_I2C_SDA_PIN


### PR DESCRIPTION
Use i2c1 as default, because the default pins can't be muxed to i2c0.