### PR TITLE
Fix semihosting_putc

### DIFF
--- a/src/rp2_common/pico_stdio_semihosting/stdio_semihosting.c
+++ b/src/rp2_common/pico_stdio_semihosting/stdio_semihosting.c
@@ -18,7 +18,7 @@
 //    );
 //}
 
-static void __attribute__((naked)) semihosting_putc(char c) {
+static void __attribute__((naked)) semihosting_putc(const char *c) {
     __asm (
 
     "mov r1, r0\n"
@@ -31,7 +31,7 @@ static void __attribute__((naked)) semihosting_putc(char c) {
 
 static void stdio_semihosting_out_chars(const char *buf, int length) {
     for (uint i = 0; i <length; i++) {
-        semihosting_putc(buf[i]);
+        semihosting_putc(&buf[i]);
     }
 }
 


### PR DESCRIPTION
Per the Arm semihosting protocol documentation[1], the SYS_WRITEC command
expects *a pointer to* the character to be printed in r1, not the
character itself.

[1] https://developer.arm.com/documentation/dui0471/g/Semihosting/SYS-WRITEC--0x03-?lang=en