### PR TITLE
Use W25Q080 second stage loader for Nano RP2040 Connect

### DIFF
--- a/src/boards/include/boards/arduino_nano_rp2040_connect.h
+++ b/src/boards/include/boards/arduino_nano_rp2040_connect.h
@@ -66,7 +66,7 @@
 
 //------------- FLASH -------------//
 
-#define PICO_BOOT_STAGE2_CHOOSE_AT25SF128A 1
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
 
 #ifndef PICO_FLASH_SPI_CLKDIV
 #define PICO_FLASH_SPI_CLKDIV 2


### PR DESCRIPTION
Due to the well known electronic market situation, we were forced to mount an alternative part number in a batch of Arduino Nano RP2040 Connect.
These flash chips, from ISSI, need yet another way to configure the QE sticky bit :disappointed: 
At the moment, the safest way to handle the dual sourcing is to fallback using W25Q080 loader, and requiring that the sticky bit has already been programmed during production.

@pnndra @alranel @iabdalkader 
