### PR TITLE
(WIP) Disable UART when writing to LCR

### DIFF
--- a/src/rp2_common/hardware_uart/include/hardware/uart.h
+++ b/src/rp2_common/hardware_uart/include/hardware/uart.h
@@ -130,6 +130,13 @@ typedef enum {
  * Put the UART into a known state, and enable it. Must be called before other
  * functions.
  *
+ * This function always enables the FIFOs, and configures the UART for the
+ * following default line format:
+ * 
+ * - 8 data bits
+ * - No parity bit
+ * - One stop bit
+ * 
  * \note There is no guarantee that the baudrate requested will be possible, the nearest will be chosen,
  * and this function will return the configured baud rate.
  *
@@ -153,6 +160,17 @@ void uart_deinit(uart_inst_t *uart);
  *  \ingroup hardware_uart
  *
  * Set baud rate as close as possible to requested, and return actual rate selected.
+ * 
+ * The UART is paused for around two character periods whilst the settings are
+ * changed. Data received during this time may be dropped by the UART.
+ * 
+ * Any characters still in the transmit buffer will be sent using the new
+ * updated baud rate. uart_tx_wait_blocking() can be called before this
+ * function to ensure all characters at the old baud rate have been sent
+ * before the rate is changed.
+ * 
+ * This function should not be called from an interrupt context, and the UART
+ * interrupt should be disabled before calling this function.
  *
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param baudrate Baudrate in Hz
@@ -176,27 +194,25 @@ static inline void uart_set_hw_flow(uart_inst_t *uart, bool cts, bool rts) {
 /*! \brief Set UART data format
  *  \ingroup hardware_uart
  *
- * Configure the data format (bits etc() for the UART
- *
+ * Configure the data format (bits etc) for the UART.
+ * 
+ * The UART is paused for around two character periods whilst the settings are
+ * changed. Data received during this time may be dropped by the UART.
+ * 
+ * Any characters still in the transmit buffer will be sent using the new
+ * updated data format. uart_tx_wait_blocking() can be called before this
+ * function to ensure all characters needing the old format have been sent
+ * before the format is changed.
+ * 
+ * This function should not be called from an interrupt context, and the UART
+ * interrupt should be disabled before calling this function.
+ * 
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param data_bits Number of bits of data. 5..8
  * \param stop_bits Number of stop bits 1..2
  * \param parity Parity option.
  */
-static inline void uart_set_format(uart_inst_t *uart, uint data_bits, uint stop_bits, uart_parity_t parity) {
-    invalid_params_if(UART, data_bits < 5 || data_bits > 8);
-    invalid_params_if(UART, stop_bits != 1 && stop_bits != 2);
-    invalid_params_if(UART, parity != UART_PARITY_NONE && parity != UART_PARITY_EVEN && parity != UART_PARITY_ODD);
-    hw_write_masked(&uart_get_hw(uart)->lcr_h,
-                   ((data_bits - 5u) << UART_UARTLCR_H_WLEN_LSB) |
-                   ((stop_bits - 1u) << UART_UARTLCR_H_STP2_LSB) |
-                   (bool_to_bit(parity != UART_PARITY_NONE) << UART_UARTLCR_H_PEN_LSB) |
-                   (bool_to_bit(parity == UART_PARITY_EVEN) << UART_UARTLCR_H_EPS_LSB),
-                   UART_UARTLCR_H_WLEN_BITS |
-                   UART_UARTLCR_H_STP2_BITS |
-                   UART_UARTLCR_H_PEN_BITS |
-                   UART_UARTLCR_H_EPS_BITS);
-}
+void uart_set_format(uart_inst_t *uart, uint data_bits, uint stop_bits, uart_parity_t parity);
 
 /*! \brief Setup UART interrupts
  *  \ingroup hardware_uart
@@ -241,15 +257,20 @@ static inline bool uart_is_enabled(uart_inst_t *uart) {
 /*! \brief Enable/Disable the FIFOs on specified UART
  *  \ingroup hardware_uart
  *
+ * The UART is paused for around two character periods whilst the settings are
+ * changed. Data received during this time may be dropped by the UART.
+ * 
+ * Any characters still in the transmit FIFO will be lost if the FIFO is
+ * disabled. uart_tx_wait_blocking() can be called before this
+ * function to avoid this.
+ * 
+ * This function should not be called from an interrupt context, and the UART
+ * interrupt should be disabled when calling this function.
+ *
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param enabled true to enable FIFO (default), false to disable
  */
-static inline void uart_set_fifo_enabled(uart_inst_t *uart, bool enabled) {
-    hw_write_masked(&uart_get_hw(uart)->lcr_h,
-                   (bool_to_bit(enabled) << UART_UARTLCR_H_FEN_LSB),
-                   UART_UARTLCR_H_FEN_BITS);
-}
-
+void uart_set_fifo_enabled(uart_inst_t *uart, bool enabled);
 
 // ----------------------------------------------------------------------------
 // Generic input/output
@@ -397,12 +418,7 @@ static inline char uart_getc(uart_inst_t *uart) {
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param en Assert break condition (TX held low) if true. Clear break condition if false.
  */
-static inline void uart_set_break(uart_inst_t *uart, bool en) {
-    if (en)
-        hw_set_bits(&uart_get_hw(uart)->lcr_h, UART_UARTLCR_H_BRK_BITS);
-    else
-        hw_clear_bits(&uart_get_hw(uart)->lcr_h, UART_UARTLCR_H_BRK_BITS);
-}
+void uart_set_break(uart_inst_t *uart, bool en);
 
 /*! \brief Set CR/LF conversion on UART
  *  \ingroup hardware_uart


### PR DESCRIPTION
See #548.

Details are quite messy. Our API supposedly lets you poke the UART settings whilst it's enabled, and doesn't impose restrictions on what state it can be in when you do this (e.g. it might be mid-character).

First problem is the UART requires you to disable it when you change the settings, slightly bigger problem is there is seemingly no way to cleanly halt and restart the UART when it may be mid character, because it doesn't have the flags you would need to poll to do this. This PR attempts to address this by asserting a slightly longer than one character busy wait after disabling the UART.

Another approach would be to allow the UART to be left disabled after `uart_init()` is called, so the user can poke settings and then enable it. To change settings they would need to reinitialise the UART, which under the hood would just toggle the reset like it does today. This would be a breaking API change, but as the current implementation is quite broken, it doesn't seem like many people are using the uncommon UART formats.