### PR TITLE
pico_time: Fix alarm_pool_dump_key format string

### DIFF
--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -279,7 +279,7 @@ static void alarm_pool_dump_key(pheap_node_id_t id, void *user_data) {
 #if PICO_ON_DEVICE
     printf("%lld (hi %02x)", to_us_since_boot(get_entry(pool, id)->target), *get_entry_id_high(pool, id));
 #else
-    printf(PRIu64, to_us_since_boot(get_entry(pool, id)->target));
+    printf("%"PRIu64, to_us_since_boot(get_entry(pool, id)->target));
 #endif
 }
 


### PR DESCRIPTION
Add requred "%" before PRIu64.

pico-sdk/src/common/pico_time/time.c:282:20: warning: data argument not used by format string [-Wformat-extra-args]