### PR TITLE
Change _watchdog_enable to trigger immediate reboot when no delay set

### DIFF
--- a/src/rp2_common/hardware_watchdog/watchdog.c
+++ b/src/rp2_common/hardware_watchdog/watchdog.c
@@ -49,18 +49,19 @@ void _watchdog_enable(uint32_t delay_ms, bool pause_on_debug) {
         hw_clear_bits(&watchdog_hw->ctrl, dbg_bits);
     }
 
-    if (!delay_ms) delay_ms = 50;
+    if (!delay_ms) {
+        hw_set_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_TRIGGER_BITS);
+    } else {
+        // Note, we have x2 here as the watchdog HW currently decrements twice per tick
+        load_value = delay_ms * 1000 * 2;
 
-    // Note, we have x2 here as the watchdog HW currently decrements twice per tick
-    load_value = delay_ms * 1000 * 2;
+        if (load_value > 0xffffffu)
+            load_value = 0xffffffu;
 
-    if (load_value > 0xffffffu)
-        load_value = 0xffffffu;
+        watchdog_update();
 
-
-    watchdog_update();
-
-    hw_set_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);
+        hw_set_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);
+    }
 }
 // end::watchdog_enable[]
 


### PR DESCRIPTION
This fixes an issue where where calling watchdog_reboot will appear as a TIMER reset event in the WATCHDOG_REASON register rather than a FORCE event, making it difficult to tell whether the microcontroller was reset from a watchdog expiring or a software reset. This makes it where if the delay_ms is 0 it will trigger a watchdog reset immediately rather than defaulting to a value of 50ms.