### PR TITLE
Add hardware_divider to pico_divider dependencies

### DIFF
--- a/src/rp2_common/pico_divider/CMakeLists.txt
+++ b/src/rp2_common/pico_divider/CMakeLists.txt
@@ -21,6 +21,7 @@ if (NOT TARGET pico_divider)
 
     target_link_libraries(pico_divider_hardware_explicit INTERFACE
             pico_divider_headers
+            hardware_divider
             hardware_regs
             )
 


### PR DESCRIPTION
Fixes build when pico_stdlib isn't included in the target libraries:
  pico-sdk/src/rp2_common/pico_divider/divider.S:8:10: fatal error: hardware/divider_helper.S: No such file or directory

Also fixes the same error in pico_double, though I'm not sure how/why:
  pico-sdk/src/rp2_common/pico_double/double_aeabi.S:9:10: fatal error: hardware/divider_helper.S: No such file or directory