### PR TITLE
split out usb_reset_interface header into its own library for consumption by picotool or others

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 pico_add_subdirectory(boot_picoboot)
 pico_add_subdirectory(boot_uf2)
 pico_add_subdirectory(pico_base)
+pico_add_subdirectory(pico_usb_reset_interface)
 
 # PICO_CMAKE_CONFIG: PICO_BARE_METAL, Flag to exclude anything except base headers from the build, type=bool, default=0, group=build
 if (NOT PICO_BARE_METAL)

--- a/src/common/pico_usb_reset_interface/CMakeLists.txt
+++ b/src/common/pico_usb_reset_interface/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(pico_usb_reset_interface_headers INTERFACE)
+target_include_directories(pico_usb_reset_interface_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/src/common/pico_usb_reset_interface/include/pico/usb_reset_interface.h
+++ b/src/common/pico_usb_reset_interface/include/pico/usb_reset_interface.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_USB_RESET_INTERFACE_H
+#define _PICO_USB_RESET_INTERFACE_H
+
+/** \file usb_reset_interface.h
+ *  \defgroup pico_usb_reset_interface pico_usb_reset_interface
+ *
+ * Definition for the reset interface that may be exposed by the pico_stdio_usb library
+ */
+
+// VENDOR sub-class for the reset interface
+#define RESET_INTERFACE_SUBCLASS 0x00
+// VENDOR protocol for the reset interface
+#define RESET_INTERFACE_PROTOCOL 0x01
+
+// CONTROL requests:
+
+// reset to BOOTSEL
+#define RESET_REQUEST_BOOTSEL 0x01
+// regular flash boot
+#define RESET_REQUEST_FLASH 0x02
+
+#endif

--- a/src/rp2_common/pico_stdio_usb/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio_usb/CMakeLists.txt
@@ -14,5 +14,6 @@ if (TARGET tinyusb_device_unmarked)
         pico_stdio
         pico_time
         pico_unique_id
+        pico_usb_reset_interface_headers
     )
 endif()

--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb/reset_interface.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb/reset_interface.h
@@ -7,17 +7,7 @@
 #ifndef _PICO_STDIO_USB_RESET_INTERFACE_H
 #define _PICO_STDIO_USB_RESET_INTERFACE_H
 
-// We use VENDOR, 0, 0 for PICOBOOT, so lets use VENDOR, 0, 1 for RESET
+// definitions have been moved here
+#include "pico/usb_reset_interface.h"
 
-// VENDOR sub-class for the reset interface
-#define RESET_INTERFACE_SUBCLASS 0x00
-// VENDOR protocol for the reset interface
-#define RESET_INTERFACE_PROTOCOL 0x01
-
-// CONTROL requests:
-
-// reset to BOOTSEL
-#define RESET_REQUEST_BOOTSEL 0x01
-// regular flash boot
-#define RESET_REQUEST_FLASH 0x02
 #endif


### PR DESCRIPTION
fix #588 