### PR TITLE
Update to TinyUSB 0.12.0

### DIFF
--- a/src/rp2040/hardware_structs/include/hardware/structs/usb.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/usb.h
@@ -49,10 +49,10 @@
 #define EP_CTRL_INTERRUPT_PER_DOUBLE_BUFFER (1u << 28)
 #define EP_CTRL_INTERRUPT_ON_NAK (1u << 16)
 #define EP_CTRL_INTERRUPT_ON_STALL (1u << 17)
-#define EP_CTRL_BUFFER_TYPE_LSB 26
-#define EP_CTRL_HOST_INTERRUPT_INTERVAL_LSB 16
+#define EP_CTRL_BUFFER_TYPE_LSB 26u
+#define EP_CTRL_HOST_INTERRUPT_INTERVAL_LSB 16u
 
-#define USB_DPRAM_SIZE 4096
+#define USB_DPRAM_SIZE 4096u
 
 // PICO_CONFIG: USB_DPRAM_MAX, Set amount of USB RAM used by USB system, min=0, max=4096, default=4096, group=hardware_usb
 // Allow user to claim some of the USB RAM for themselves

--- a/src/rp2_common/pico_stdio_semihosting/stdio_semihosting.c
+++ b/src/rp2_common/pico_stdio_semihosting/stdio_semihosting.c
@@ -18,7 +18,7 @@
 //    );
 //}
 
-static void __attribute__((naked)) semihosting_putc(const char *c) {
+static void __attribute__((naked)) semihosting_putc(__unused const char *c) {
     __asm (
 
     "mov r1, r0\n"
@@ -30,7 +30,7 @@ static void __attribute__((naked)) semihosting_putc(const char *c) {
 
 
 static void stdio_semihosting_out_chars(const char *buf, int length) {
-    for (uint i = 0; i <length; i++) {
+    for (int i = 0; i < length; i++) {
         semihosting_putc(&buf[i]);
     }
 }

--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -38,7 +38,7 @@ static uint16_t resetd_open(uint8_t __unused rhport, tusb_desc_interface_t const
 }
 
 // Support for parameterized reset via vendor interface control request
-static bool resetd_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_request_t const * request) {
+static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_control_request_t const * request) {
     // nothing to do with DATA & ACK stage
     if (stage != CONTROL_STAGE_SETUP) return true;
 

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -41,10 +41,10 @@ static void stdio_usb_out_chars(const char *buf, int length) {
     if (tud_cdc_connected()) {
         for (int i = 0; i < length;) {
             int n = length - i;
-            int avail = tud_cdc_write_available();
+            int avail = (int) tud_cdc_write_available();
             if (n > avail) n = avail;
             if (n) {
-                int n2 = tud_cdc_write(buf + i, n);
+                int n2 = (int) tud_cdc_write(buf + i, (uint32_t)n);
                 tud_task();
                 tud_cdc_write_flush();
                 i += n2;
@@ -73,7 +73,7 @@ int stdio_usb_in_chars(char *buf, int length) {
     }
     int rc = PICO_ERROR_NO_DATA;
     if (tud_cdc_connected() && tud_cdc_available()) {
-        int count = tud_cdc_read(buf, length);
+        int count = (int) tud_cdc_read(buf, (uint32_t) length);
         rc =  count ? count : PICO_ERROR_NO_DATA;
     }
     mutex_exit(&stdio_usb_mutex);

--- a/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
@@ -143,7 +143,7 @@ const uint16_t *tud_descriptor_string_cb(uint8_t index, __unused uint16_t langid
     }
 
     // first byte is length (including header), second byte is string type
-    desc_str[0] = (TUSB_DESC_STRING << 8) | (2 * len + 2);
+    desc_str[0] = (uint16_t) ((TUSB_DESC_STRING << 8) | (2 * len + 2));
 
     return desc_str;
 }

--- a/src/rp2_common/tinyusb/CMakeLists.txt
+++ b/src/rp2_common/tinyusb/CMakeLists.txt
@@ -20,7 +20,8 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
     pico_register_common_scope_var(PICO_TINYUSB_PATH)
 
     set(BOARD pico_sdk)
-    include(${PICO_TINYUSB_PATH}/hw/bsp/rp2040/family.cmake)
+    set(FAMILY rp2040)
+    include(${PICO_TINYUSB_PATH}/hw/bsp/family_support.cmake)
 
     add_library(tinyusb_common INTERFACE)
     target_link_libraries(tinyusb_common INTERFACE tinyusb_common_base)

--- a/test/kitchen_sink/CMakeLists.txt
+++ b/test/kitchen_sink/CMakeLists.txt
@@ -97,7 +97,8 @@ pico_set_program_name(kitchen_sink "Wombat tentacles")
 pico_add_extra_outputs(kitchen_sink)
 
 add_executable(kitchen_sink_extra_stdio)
-target_link_libraries(kitchen_sink_extra_stdio kitchen_sink_libs) # no kitchen_sink_options as TinyUSB has warnings
+suppress_tinyusb_warnings() # suppress warnings explicitly in TinyUSB files which have them
+target_link_libraries(kitchen_sink_extra_stdio kitchen_sink_libs kitchen_sink_options)
 pico_add_extra_outputs(kitchen_sink_extra_stdio)
 pico_enable_stdio_usb(kitchen_sink_extra_stdio 1)
 pico_enable_stdio_semihosting(kitchen_sink_extra_stdio 1)
@@ -111,3 +112,4 @@ add_executable(kitchen_sink_no_flash)
 pico_set_binary_type(kitchen_sink_no_flash no_flash)
 target_link_libraries(kitchen_sink_no_flash kitchen_sink_libs kitchen_sink_options)
 pico_add_extra_outputs(kitchen_sink_no_flash)
+


### PR DESCRIPTION
Update to TinyUSB 0.12.0
Update `kitchen_sink` compilation test to include TinyUSB to catch warnings
Fix warnings in `stdio_usb` and `stdio_semihosting` caught by above