### PR TITLE
Make Error: duplicate 'inline'

### DIFF
--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -234,7 +234,7 @@ extern "C" {
  *
  */
 #if defined(__GNUC__) && __GNUC__ <= 7
-#define __force_inline inline __always_inline
+#define __force_inline inline
 #else
 #define __force_inline __always_inline
 #endif


### PR DESCRIPTION
Fixes #659
Replaces #660

When building the Pico SDK, a `duplicate 'inline'` error is thrown. This error is thrown because `__always_inline`, `inline`, and `__force_inline` are used together. Removing __always_inline fixes the build error and compilation.
