### PR TITLE
fixup __forceinline for cpp code

### DIFF
--- a/src/host/pico_platform/include/pico/platform.h
+++ b/src/host/pico_platform/include/pico/platform.h
@@ -22,7 +22,7 @@ extern "C" {
 
 #define __not_in_flash(group)
 #define __not_in_flash_func(func) func
-#define __no_inline_not_in_flash_func(func)
+#define __no_inline_not_in_flash_func(func) func
 #define __in_flash(group)
 #define __scratch_x(group)
 #define __scratch_y(group)

--- a/src/rp2040/hardware_structs/include/hardware/structs/adc.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/adc.h
@@ -86,6 +86,6 @@ typedef struct {
     io_ro_32 ints;
 } adc_hw_t;
 
-#define adc_hw ((adc_hw_t *const)ADC_BASE)
+#define adc_hw ((adc_hw_t *)ADC_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/bus_ctrl.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/bus_ctrl.h
@@ -72,6 +72,6 @@ typedef struct {
     bus_ctrl_perf_hw_t counter[4];
 } bus_ctrl_hw_t;
 
-#define bus_ctrl_hw ((bus_ctrl_hw_t *const)BUSCTRL_BASE)
+#define bus_ctrl_hw ((bus_ctrl_hw_t *)BUSCTRL_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/clocks.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/clocks.h
@@ -319,7 +319,7 @@ typedef struct {
     io_ro_32 ints;
 } clocks_hw_t;
 
-#define clocks_hw ((clocks_hw_t *const)CLOCKS_BASE)
+#define clocks_hw ((clocks_hw_t *)CLOCKS_BASE)
 
 static_assert( CLK_COUNT == 10, "");
 

--- a/src/rp2040/hardware_structs/include/hardware/structs/i2c.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/i2c.h
@@ -327,7 +327,7 @@ typedef struct {
     io_ro_32 comp_type;
 } i2c_hw_t;
 
-#define i2c0_hw ((i2c_hw_t *const)I2C0_BASE)
-#define i2c1_hw ((i2c_hw_t *const)I2C1_BASE)
+#define i2c0_hw ((i2c_hw_t *)I2C0_BASE)
+#define i2c1_hw ((i2c_hw_t *)I2C1_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/iobank0.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/iobank0.h
@@ -208,7 +208,7 @@ typedef struct {
     io_irq_ctrl_hw_t dormant_wake_irq_ctrl;
 } iobank0_hw_t;
 
-#define iobank0_hw ((iobank0_hw_t *const)IO_BANK0_BASE)
+#define iobank0_hw ((iobank0_hw_t *)IO_BANK0_BASE)
 /// \end::iobank0_hw[]
 
 static_assert( NUM_BANK0_GPIOS == 30, "");

--- a/src/rp2040/hardware_structs/include/hardware/structs/ioqspi.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/ioqspi.h
@@ -167,7 +167,7 @@ typedef struct {
     io_qspi_ctrl_hw_t dormant_wake_qspi_ctrl;
 } ioqspi_hw_t;
 
-#define ioqspi_hw ((ioqspi_hw_t *const)IO_QSPI_BASE)
+#define ioqspi_hw ((ioqspi_hw_t *)IO_QSPI_BASE)
 
 static_assert( NUM_QSPI_GPIOS == 6, "");
 

--- a/src/rp2040/hardware_structs/include/hardware/structs/mpu.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/mpu.h
@@ -56,6 +56,6 @@ typedef struct {
     io_rw_32 rasr;
 } mpu_hw_t;
 
-#define mpu_hw ((mpu_hw_t *const)(PPB_BASE + M0PLUS_MPU_TYPE_OFFSET))
+#define mpu_hw ((mpu_hw_t *)(PPB_BASE + M0PLUS_MPU_TYPE_OFFSET))
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/pads_qspi.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/pads_qspi.h
@@ -40,7 +40,7 @@ typedef struct {
     io_rw_32 io[NUM_QSPI_GPIOS]; // 6
 } pads_qspi_hw_t;
 
-#define pads_qspi_hw ((pads_qspi_hw_t *const)PADS_QSPI_BASE)
+#define pads_qspi_hw ((pads_qspi_hw_t *)PADS_QSPI_BASE)
 
 static_assert( NUM_QSPI_GPIOS == 6, "");
 

--- a/src/rp2040/hardware_structs/include/hardware/structs/padsbank0.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/padsbank0.h
@@ -40,7 +40,7 @@ typedef struct {
     io_rw_32 io[NUM_BANK0_GPIOS]; // 30
 } padsbank0_hw_t;
 
-#define padsbank0_hw ((padsbank0_hw_t *const)PADS_BANK0_BASE)
+#define padsbank0_hw ((padsbank0_hw_t *)PADS_BANK0_BASE)
 
 static_assert( NUM_BANK0_GPIOS == 30, "");
 

--- a/src/rp2040/hardware_structs/include/hardware/structs/pio.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/pio.h
@@ -275,8 +275,8 @@ typedef struct {
     io_ro_32 ints1;
 } pio_hw_t;
 
-#define pio0_hw ((pio_hw_t *const)PIO0_BASE)
-#define pio1_hw ((pio_hw_t *const)PIO1_BASE)
+#define pio0_hw ((pio_hw_t *)PIO0_BASE)
+#define pio1_hw ((pio_hw_t *)PIO1_BASE)
 
 static_assert( NUM_PIO_STATE_MACHINES == 4, "");
 static_assert( PIO_INSTRUCTION_COUNT == 32, "");

--- a/src/rp2040/hardware_structs/include/hardware/structs/pll.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/pll.h
@@ -49,8 +49,8 @@ typedef struct {
     io_rw_32 prim;
 } pll_hw_t;
 
-#define pll_sys_hw ((pll_hw_t *const)PLL_SYS_BASE)
-#define pll_usb_hw ((pll_hw_t *const)PLL_USB_BASE)
+#define pll_sys_hw ((pll_hw_t *)PLL_SYS_BASE)
+#define pll_usb_hw ((pll_hw_t *)PLL_USB_BASE)
 /// \end::pll_hw[]
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/psm.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/psm.h
@@ -106,6 +106,6 @@ typedef struct {
     io_ro_32 done;
 } psm_hw_t;
 
-#define psm_hw ((psm_hw_t *const)PSM_BASE)
+#define psm_hw ((psm_hw_t *)PSM_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/pwm.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/pwm.h
@@ -119,7 +119,7 @@ typedef struct {
     io_ro_32 ints;
 } pwm_hw_t;
 
-#define pwm_hw ((pwm_hw_t *const)PWM_BASE)
+#define pwm_hw ((pwm_hw_t *)PWM_BASE)
 
 static_assert( NUM_PWM_SLICES == 8, "");
 

--- a/src/rp2040/hardware_structs/include/hardware/structs/resets.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/resets.h
@@ -110,7 +110,7 @@ typedef struct {
     io_ro_32 reset_done;
 } resets_hw_t;
 
-#define resets_hw ((resets_hw_t *const)RESETS_BASE)
+#define resets_hw ((resets_hw_t *)RESETS_BASE)
 /// \end::resets_hw[]
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/rosc.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/rosc.h
@@ -81,6 +81,6 @@ typedef struct {
     io_rw_32 count;
 } rosc_hw_t;
 
-#define rosc_hw ((rosc_hw_t *const)ROSC_BASE)
+#define rosc_hw ((rosc_hw_t *)ROSC_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/rtc.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/rtc.h
@@ -109,6 +109,6 @@ typedef struct {
     io_ro_32 ints;
 } rtc_hw_t;
 
-#define rtc_hw ((rtc_hw_t *const)RTC_BASE)
+#define rtc_hw ((rtc_hw_t *)RTC_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/scb.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/scb.h
@@ -64,6 +64,6 @@ typedef struct {
     io_rw_32 scr;
 } armv6m_scb_t;
 
-#define scb_hw ((armv6m_scb_t *const)(PPB_BASE + M0PLUS_CPUID_OFFSET))
+#define scb_hw ((armv6m_scb_t *)(PPB_BASE + M0PLUS_CPUID_OFFSET))
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/sio.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/sio.h
@@ -171,6 +171,6 @@ typedef struct {
     interp_hw_t interp[2];
 } sio_hw_t;
 
-#define sio_hw ((sio_hw_t *const)SIO_BASE)
+#define sio_hw ((sio_hw_t *)SIO_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/spi.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/spi.h
@@ -94,7 +94,7 @@ typedef struct {
     io_rw_32 dmacr;
 } spi_hw_t;
 
-#define spi0_hw ((spi_hw_t *const)SPI0_BASE)
-#define spi1_hw ((spi_hw_t *const)SPI1_BASE)
+#define spi0_hw ((spi_hw_t *)SPI0_BASE)
+#define spi1_hw ((spi_hw_t *)SPI1_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/ssi.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/ssi.h
@@ -205,6 +205,6 @@ typedef struct {
     io_rw_32 txd_drive_edge;
 } ssi_hw_t;
 
-#define ssi_hw ((ssi_hw_t *const)XIP_SSI_BASE)
+#define ssi_hw ((ssi_hw_t *)XIP_SSI_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/syscfg.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/syscfg.h
@@ -72,6 +72,6 @@ typedef struct {
     io_rw_32 mempowerdown;
 } syscfg_hw_t;
 
-#define syscfg_hw ((syscfg_hw_t *const)SYSCFG_BASE)
+#define syscfg_hw ((syscfg_hw_t *)SYSCFG_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/systick.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/systick.h
@@ -47,6 +47,6 @@ typedef struct {
     io_ro_32 calib;
 } systick_hw_t;
 
-#define systick_hw ((systick_hw_t *const)(PPB_BASE + M0PLUS_SYST_CSR_OFFSET))
+#define systick_hw ((systick_hw_t *)(PPB_BASE + M0PLUS_SYST_CSR_OFFSET))
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/timer.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/timer.h
@@ -100,7 +100,7 @@ typedef struct {
     io_ro_32 ints;
 } timer_hw_t;
 
-#define timer_hw ((timer_hw_t *const)TIMER_BASE)
+#define timer_hw ((timer_hw_t *)TIMER_BASE)
 
 static_assert( NUM_TIMERS == 4, "");
 

--- a/src/rp2040/hardware_structs/include/hardware/structs/uart.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/uart.h
@@ -171,7 +171,7 @@ typedef struct {
     io_rw_32 dmacr;
 } uart_hw_t;
 
-#define uart0_hw ((uart_hw_t *const)UART0_BASE)
-#define uart1_hw ((uart_hw_t *const)UART1_BASE)
+#define uart0_hw ((uart_hw_t *)UART0_BASE)
+#define uart1_hw ((uart_hw_t *)UART1_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/usb.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/usb.h
@@ -568,7 +568,7 @@ typedef struct {
     io_ro_32 ints;
 } usb_hw_t;
 
-#define usb_hw ((usb_hw_t *const)USBCTRL_REGS_BASE)
+#define usb_hw ((usb_hw_t *)USBCTRL_REGS_BASE)
 
 #define usb_dpram ((usb_device_dpram_t *)USBCTRL_DPRAM_BASE)
 #define usbh_dpram ((usb_host_dpram_t *)USBCTRL_DPRAM_BASE)

--- a/src/rp2040/hardware_structs/include/hardware/structs/vreg_and_chip_reset.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/vreg_and_chip_reset.h
@@ -44,6 +44,6 @@ typedef struct {
     io_rw_32 chip_reset;
 } vreg_and_chip_reset_hw_t;
 
-#define vreg_and_chip_reset_hw ((vreg_and_chip_reset_hw_t *const)VREG_AND_CHIP_RESET_BASE)
+#define vreg_and_chip_reset_hw ((vreg_and_chip_reset_hw_t *)VREG_AND_CHIP_RESET_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/watchdog.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/watchdog.h
@@ -57,6 +57,6 @@ typedef struct {
     io_rw_32 tick;
 } watchdog_hw_t;
 
-#define watchdog_hw ((watchdog_hw_t *const)WATCHDOG_BASE)
+#define watchdog_hw ((watchdog_hw_t *)WATCHDOG_BASE)
 
 #endif

--- a/src/rp2040/hardware_structs/include/hardware/structs/xip_ctrl.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/xip_ctrl.h
@@ -63,7 +63,7 @@ typedef struct {
     io_ro_32 stream_fifo;
 } xip_ctrl_hw_t;
 
-#define xip_ctrl_hw ((xip_ctrl_hw_t *const)XIP_CTRL_BASE)
+#define xip_ctrl_hw ((xip_ctrl_hw_t *)XIP_CTRL_BASE)
 
 #define XIP_STAT_FIFO_FULL XIP_STAT_FIFO_FULL_BITS
 #define XIP_STAT_FIFO_EMPTY XIP_STAT_FIFO_EMPTY_BITS

--- a/src/rp2040/hardware_structs/include/hardware/structs/xosc.h
+++ b/src/rp2040/hardware_structs/include/hardware/structs/xosc.h
@@ -54,7 +54,7 @@ typedef struct {
     io_rw_32 count;
 } xosc_hw_t;
 
-#define xosc_hw ((xosc_hw_t *const)XOSC_BASE)
+#define xosc_hw ((xosc_hw_t *)XOSC_BASE)
 /// \end::xosc_hw[]
 
 #endif

--- a/src/rp2_common/hardware_spi/include/hardware/spi.h
+++ b/src/rp2_common/hardware_spi/include/hardware/spi.h
@@ -53,7 +53,7 @@ typedef struct spi_inst spi_inst_t;
  *
  *  \ingroup hardware_spi
  */
-#define spi0 ((spi_inst_t * const)spi0_hw)
+#define spi0 ((spi_inst_t *)spi0_hw)
 
 /** Identifier for the second (SPI 1) hardware SPI instance (for use in SPI functions).
  *
@@ -61,7 +61,7 @@ typedef struct spi_inst spi_inst_t;
  *
  *  \ingroup hardware_spi
  */
-#define spi1 ((spi_inst_t * const)spi1_hw)
+#define spi1 ((spi_inst_t *)spi1_hw)
 
 #if !defined(PICO_DEFAULT_SPI_INSTANCE) && defined(PICO_DEFAULT_SPI)
 #define PICO_DEFAULT_SPI_INSTANCE (__CONCAT(spi,PICO_DEFAULT_SPI))

--- a/src/rp2_common/hardware_uart/include/hardware/uart.h
+++ b/src/rp2_common/hardware_uart/include/hardware/uart.h
@@ -78,8 +78,8 @@ typedef struct uart_inst uart_inst_t;
  *  \ingroup hardware_uart
  * @{
  */
-#define uart0 ((uart_inst_t * const)uart0_hw) ///< Identifier for UART instance 0
-#define uart1 ((uart_inst_t * const)uart1_hw) ///< Identifier for UART instance 1
+#define uart0 ((uart_inst_t *)uart0_hw) ///< Identifier for UART instance 0
+#define uart1 ((uart_inst_t *)uart1_hw) ///< Identifier for UART instance 1
 
 /** @} */
 

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -233,7 +233,7 @@ extern "C" {
  *      int __force_inline my_function(int x) {
  *
  */
-#if defined(__GNUC__) && __GNUC__ <= 7
+#if defined(__GNUC__) && (__GNUC__ <= 6 || (__GNUC__ == 7 && (__GNUC_MINOR__ < 3 || !defined(__cplusplus))))
 #define __force_inline inline __always_inline
 #else
 #define __force_inline __always_inline

--- a/test/kitchen_sink/CMakeLists.txt
+++ b/test/kitchen_sink/CMakeLists.txt
@@ -1,7 +1,4 @@
 add_library(kitchen_sink_libs INTERFACE)
-target_sources(kitchen_sink_libs INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c
-)
 target_link_libraries(kitchen_sink_libs INTERFACE
     hardware_adc
     hardware_clocks
@@ -91,12 +88,12 @@ target_compile_definitions(kitchen_sink_libs INTERFACE
         PICO_AUDIO_DMA_IRQ=1
 )
 
-add_executable(kitchen_sink)
+add_executable(kitchen_sink ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c)
 target_link_libraries(kitchen_sink kitchen_sink_libs kitchen_sink_options)
 pico_set_program_name(kitchen_sink "Wombat tentacles")
 pico_add_extra_outputs(kitchen_sink)
 
-add_executable(kitchen_sink_extra_stdio)
+add_executable(kitchen_sink_extra_stdio ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c)
 if (COMMAND suppress_tinyusb_warnings)
     # Explicitly suppress warnings in TinyUSB files which have them (this has to be done
     # from the project that uses them per CMake "feature"). Note the function comes from
@@ -108,13 +105,17 @@ pico_add_extra_outputs(kitchen_sink_extra_stdio)
 pico_enable_stdio_usb(kitchen_sink_extra_stdio 1)
 pico_enable_stdio_semihosting(kitchen_sink_extra_stdio 1)
 
-add_executable(kitchen_sink_copy_to_ram)
+add_executable(kitchen_sink_copy_to_ram ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c)
 pico_set_binary_type(kitchen_sink_copy_to_ram copy_to_ram)
 target_link_libraries(kitchen_sink_copy_to_ram kitchen_sink_libs kitchen_sink_options)
 pico_add_extra_outputs(kitchen_sink_copy_to_ram)
 
-add_executable(kitchen_sink_no_flash)
+add_executable(kitchen_sink_no_flash ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c)
 pico_set_binary_type(kitchen_sink_no_flash no_flash)
 target_link_libraries(kitchen_sink_no_flash kitchen_sink_libs kitchen_sink_options)
 pico_add_extra_outputs(kitchen_sink_no_flash)
 
+add_executable(kitchen_sink_cpp ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink_cpp.cpp)
+target_link_libraries(kitchen_sink_cpp kitchen_sink_libs kitchen_sink_options)
+pico_set_program_name(kitchen_sink_cpp "Wombat tentacles CPP")
+pico_add_extra_outputs(kitchen_sink_cpp)

--- a/test/kitchen_sink/kitchen_sink.c
+++ b/test/kitchen_sink/kitchen_sink.c
@@ -97,13 +97,17 @@ uint32_t *foo = (uint32_t *) 200;
 uint32_t dma_to = 0;
 uint32_t dma_from = 0xaaaa5555;
 
-void spiggle(void) {
+void __noinline spiggle(void) {
     dma_channel_config c = dma_channel_get_default_config(1);
     channel_config_set_bswap(&c, true);
     channel_config_set_transfer_data_size(&c, DMA_SIZE_16);
     channel_config_set_ring(&c, true, 13);
     dma_channel_set_config(1, &c, false);
     dma_channel_transfer_from_buffer_now(1, foo, 23);
+}
+
+__force_inline int something_inlined(int x) {
+    return x * 2;
 }
 
 void __isr dma_handler_a(void) {
@@ -131,7 +135,7 @@ int main(void) {
 
     stdio_init_all();
 
-    printf("HI %d\n", (int)time_us_32());
+    printf("HI %d\n", something_inlined((int)time_us_32()));
     puts("Hello Everything!");
     puts("Hello Everything2!");
 

--- a/test/kitchen_sink/kitchen_sink_cpp.cpp
+++ b/test/kitchen_sink/kitchen_sink_cpp.cpp
@@ -1,0 +1,1 @@
+#include "kitchen_sink.c"


### PR DESCRIPTION
note the "const" pointer values in the struct headers cause a warning in cpp mode, arguably because they really aren't useful (telling the compiler that the constant value is constant)