### PR TITLE
rename pybstick26_rp2040.h to garatronic_pybstick26_rp2040.h

### DIFF
--- a/src/boards/include/boards/garatronic_pybstick26_rp2040.h
+++ b/src/boards/include/boards/garatronic_pybstick26_rp2040.h
@@ -9,11 +9,11 @@
 //       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
 // -----------------------------------------------------
 
-#ifndef _BOARDS_PYBSTICK26_RP2040_H
-#define _BOARDS_PYBSTICK26_RP2040_H
+#ifndef _BOARDS_GARATRONIC_PYBSTICK26_RP2040_H
+#define _BOARDS_GARATRONIC_PYBSTICK26_RP2040_H
 
 // For board detection
-#define PYBSTICK26_RP2040
+#define GARATRONIC_PYBSTICK26_RP2040
 
 // --- UART ---
 #ifndef PICO_DEFAULT_UART
@@ -82,4 +82,4 @@
 #endif
 
 #endif
-// of #define _BOARDS_PYBSTICK26_RP2040_H
+// of #define _BOARDS_GARATRONIC_PYBSTICK26_RP2040_H


### PR DESCRIPTION
Replacement for #671 