### PR TITLE
Fix documentation for queue_is_empty()

### DIFF
--- a/src/common/pico_util/include/pico/util/queue.h
+++ b/src/common/pico_util/include/pico/util/queue.h
@@ -101,6 +101,7 @@ static inline uint queue_get_level(queue_t *q) {
     return level;
 }
 
+#if PICO_QUEUE_MAX_LEVEL
 /*! \brief Returns the highest level reached by the specified queue since it was created
  *         or since the max level was reset
  *  \ingroup queue
@@ -108,18 +109,17 @@ static inline uint queue_get_level(queue_t *q) {
  * \param q Pointer to a queue_t structure, used as a handle
  * \return Maximum level of the queue
  */
-#if PICO_QUEUE_MAX_LEVEL
 static inline uint queue_get_max_level(queue_t *q) {
     return q->max_level;
 }
 #endif
 
+#if PICO_QUEUE_MAX_LEVEL
 /*! \brief Reset the highest level reached of the specified queue.
  *  \ingroup queue
  *
  * \param q Pointer to a queue_t structure, used as a handle
  */
-#if PICO_QUEUE_MAX_LEVEL
 static inline void queue_reset_max_level(queue_t *q) {
     uint32_t save = spin_lock_blocking(q->core.spin_lock);
     q->max_level = queue_get_level_unsafe(q);


### PR DESCRIPTION
Moves the #if guards to before the comments for the two functions that were not included because of the #if checks.
Those comments were included in the doxygen output but are not included now which fixes the issue.

Fixes #683 