### PR TITLE
fix when PICO_NO_BINARY_INFO is set, Fixes #692

### DIFF
--- a/src/common/pico_binary_info/include/pico/binary_info.h
+++ b/src/common/pico_binary_info/include/pico/binary_info.h
@@ -25,7 +25,5 @@
 #if !PICO_ON_DEVICE && !defined(PICO_NO_BINARY_INFO)
 #define PICO_NO_BINARY_INFO 1
 #endif
-#if !PICO_NO_BINARY_INFO
 #include "pico/binary_info/code.h"
-#endif
 #endif


### PR DESCRIPTION
Allows compilation when PICO_NO_BINARY_INFO is set as all the empty definitions in pico/binary_info/code.h are now included.

