### PR TITLE
Fix assert in adc_set_round_robin()

### DIFF
--- a/src/rp2_common/hardware_adc/include/hardware/adc.h
+++ b/src/rp2_common/hardware_adc/include/hardware/adc.h
@@ -106,7 +106,7 @@ static inline uint adc_get_selected_input(void) {
  * \param input_mask A bit pattern indicating which of the 5 inputs are to be sampled. Write a value of 0 to disable round robin sampling.
  */
 static inline void adc_set_round_robin(uint input_mask) {
-    invalid_params_if(ADC, input_mask & ~ADC_CS_RROBIN_BITS);
+    valid_params_if(ADC, input_mask < (1 << NUM_ADC_CHANNELS));
     hw_write_masked(&adc_hw->cs, input_mask << ADC_CS_RROBIN_LSB, ADC_CS_RROBIN_BITS);
 }
 


### PR DESCRIPTION
The mask passed in shouldn't already be shifted by `ADC_CS_RROBIN_LSB` (`16`) otherwise the shift in the call to `hw_write_masked()` would shift all of the bits off the end of the mask, hence we should be asserting not against `ADC_CS_RROBIN_BITS` (`0x1f0000`) but against the number of ADC channels available.

[The documentation](https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf#group_hardware_adc_1ga16d25be75e16f0671d3e3185b0b59771) also states that the mask should be a `Value between 0 and 0x1f (bit 0 to bit 4 for GPIO 26 to 29 and temperature sensor input respectively)` of which only the value `0` would have passed the `invalid_params_if()` assert due to it not setting any bits, so I'm not sure how nobody has hit this before.