### PR TITLE
gpio.h: docs: add mask column to gpio events table, fixes #716

### DIFF
--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -358,12 +358,14 @@ enum gpio_drive_strength gpio_get_drive_strength(uint gpio);
  *
  * Events is a bitmask of the following:
  *
- * bit | interrupt
- * ----|----------
- *   0 | Low level
- *   1 | High level
- *   2 | Edge low
- *   3 | Edge high
+ * bit | mask |interrupt
+ * ----|------|----------
+ *   0 |    1 | Low level
+ *   1 |    2 | High level
+ *   2 |    4 | Edge low
+ *   3 |    8 | Edge high
+ *
+ * See also \ref gpio_irq_level which defines the mask values.
  */
 void gpio_set_irq_enabled(uint gpio, uint32_t events, bool enabled);
 


### PR DESCRIPTION
The bit column is not the most helpful number to have in the documentation, really the mask value is what you're interested in when reading that part of the docs, so I added a column for it.

I have also added a mention of gpio_irq_level too, since that appears to define the mask values.
