### PR TITLE
Removed unused pico_stdio target from pico_stdlib.

### DIFF
--- a/src/common/pico_stdlib/include/pico/stdlib.h
+++ b/src/common/pico_stdlib/include/pico/stdlib.h
@@ -8,7 +8,6 @@
 #define _PICO_STDLIB_H
 
 #include "pico.h"
-#include "pico/stdio.h"
 #include "pico/time.h"
 #include "hardware/gpio.h"
 #include "hardware/uart.h"

--- a/src/rp2_common/pico_stdlib/CMakeLists.txt
+++ b/src/rp2_common/pico_stdlib/CMakeLists.txt
@@ -14,7 +14,6 @@ if (NOT TARGET pico_stdlib)
         pico_stdlib_headers
         pico_platform
         pico_runtime
-        pico_stdio
         pico_time
     )
 


### PR DESCRIPTION
Removed unused pico_stdio target from pico_stdlib. This allows a program to use the stdlib without including stdio, which allows for a program to write its own versions of _read and _write. This issue is discussed in https://forums.raspberrypi.com/viewtopic.php?t=304905. 

This will cause potential compatibility issues if a program is expecting pico_stdio functions but only includes pico_stdlib. But it is a quick fix, and all of the examples compile without further changes needed. 