### PR TITLE
Adding 10-bit i2c addressing support to the SDK

### DIFF
--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -30,6 +30,11 @@ static inline void i2c_unreset(i2c_inst_t *i2c) {
 static inline bool i2c_reserved_addr(uint8_t addr) {
     return (addr & 0x78) == 0 || (addr & 0x78) == 0x78;
 }
+//The "standard" reserved addresses are identical in 10-bit mode.
+//See Section 3.1.12 of v7.0 of the i2c spec.
+static inline bool i2c_reserved_addr_10bit(uint16_t addr) {
+    return (addr & 0x0378) == 0 || (addr & 0x0378) == 0x78;
+}
 
 uint i2c_init(i2c_inst_t *i2c, uint baudrate) {
     i2c_reset(i2c);
@@ -44,6 +49,32 @@ uint i2c_init(i2c_inst_t *i2c, uint baudrate) {
             I2C_IC_CON_MASTER_MODE_BITS |
             I2C_IC_CON_IC_SLAVE_DISABLE_BITS |
             I2C_IC_CON_IC_RESTART_EN_BITS |
+            I2C_IC_CON_TX_EMPTY_CTRL_BITS;
+
+    // Set FIFO watermarks to 1 to make things simpler. This is encoded by a register value of 0.
+    i2c->hw->tx_tl = 0;
+    i2c->hw->rx_tl = 0;
+
+    // Always enable the DREQ signalling -- harmless if DMA isn't listening
+    i2c->hw->dma_cr = I2C_IC_DMA_CR_TDMAE_BITS | I2C_IC_DMA_CR_RDMAE_BITS;
+
+    // Re-sets i2c->hw->enable upon returning:
+    return i2c_set_baudrate(i2c, baudrate);
+}
+uint i2c_init_10bit(i2c_inst_t *i2c, uint baudrate) {
+    i2c_reset(i2c);
+    i2c_unreset(i2c);
+    i2c->restart_on_next = false;
+
+    i2c->hw->enable = 0;
+
+    // Configure as a fast-mode master with RepStart support, 10-bit addresses
+    i2c->hw->con =
+            I2C_IC_CON_SPEED_VALUE_FAST << I2C_IC_CON_SPEED_LSB |
+            I2C_IC_CON_MASTER_MODE_BITS |
+            I2C_IC_CON_IC_SLAVE_DISABLE_BITS |
+            I2C_IC_CON_IC_RESTART_EN_BITS |
+            I2C_IC_CON_IC_10BITADDR_MASTER_BITS |
             I2C_IC_CON_TX_EMPTY_CTRL_BITS;
 
     // Set FIFO watermarks to 1 to make things simpler. This is encoded by a register value of 0.
@@ -112,7 +143,7 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate) {
 }
 
 void i2c_set_slave_mode(i2c_inst_t *i2c, bool slave, uint8_t addr) {
-    invalid_params_if(I2C, addr >= 0x80); // 7-bit addresses
+    invalid_params_if(I2C, addr >= 0x400); // 7-bit addresses
     invalid_params_if(I2C, i2c_reserved_addr(addr));
     i2c->hw->enable = 0;
     uint32_t ctrl_set_if_master = I2C_IC_CON_MASTER_MODE_BITS | I2C_IC_CON_IC_SLAVE_DISABLE_BITS;
@@ -123,6 +154,26 @@ void i2c_set_slave_mode(i2c_inst_t *i2c, bool slave, uint8_t addr) {
             ctrl_set_if_master | ctrl_set_if_slave
         );
         i2c->hw->sar = addr;
+    } else {
+        hw_write_masked(&i2c->hw->con,
+            ctrl_set_if_master,
+            ctrl_set_if_master | ctrl_set_if_slave
+        );
+    }
+    i2c->hw->enable = 1;
+}
+void i2c_set_slave_mode_10bit(i2c_inst_t *i2c, bool slave, uint16_t addr) {
+    invalid_params_if(I2C, addr >= 0xF00); // 7-bit addresses
+    invalid_params_if(I2C, i2c_reserved_addr_10bit(addr));
+    i2c->hw->enable = 0;
+    uint32_t ctrl_set_if_master = I2C_IC_CON_IC_10BITADDR_MASTER_BITS | I2C_IC_CON_MASTER_MODE_BITS | I2C_IC_CON_IC_SLAVE_DISABLE_BITS;
+    uint32_t ctrl_set_if_slave = I2C_IC_CON_IC_10BITADDR_SLAVE_BITS | I2C_IC_CON_RX_FIFO_FULL_HLD_CTRL_BITS;
+    if (slave) {
+        hw_write_masked(&i2c->hw->con,
+            ctrl_set_if_slave,
+            ctrl_set_if_master | ctrl_set_if_slave
+        );
+        i2c->hw->sar = addr & 0x03FF;
     } else {
         hw_write_masked(&i2c->hw->con,
             ctrl_set_if_master,
@@ -239,9 +290,120 @@ static int i2c_write_blocking_internal(i2c_inst_t *i2c, uint8_t addr, const uint
     i2c->restart_on_next = nostop;
     return rval;
 }
+static int i2c_write_blocking_internal_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop,
+                                       check_timeout_fn timeout_check, struct timeout_state *ts) {
+    invalid_params_if(I2C, addr >= 0x0400); // 10-bit addresses
+    invalid_params_if(I2C, i2c_reserved_addr_10bit(addr));
+    // Synopsys hw accepts start/stop flags alongside data items in the same
+    // FIFO word, so no 0 byte transfers.
+    invalid_params_if(I2C, len == 0);
+    invalid_params_if(I2C, ((int)len) < 0);
+
+    i2c->hw->enable = 0;
+    i2c->hw->tar = addr & 0x3FF;
+    i2c->hw->enable = 1;
+
+    bool abort = false;
+    bool timeout = false;
+
+    uint32_t abort_reason = 0;
+    int byte_ctr;
+
+    int ilen = (int)len;
+    for (byte_ctr = 0; byte_ctr < ilen; ++byte_ctr) {
+        bool first = byte_ctr == 0;
+        bool last = byte_ctr == ilen - 1;
+
+        i2c->hw->data_cmd =
+                bool_to_bit(first && i2c->restart_on_next) << I2C_IC_DATA_CMD_RESTART_LSB |
+                bool_to_bit(last && !nostop) << I2C_IC_DATA_CMD_STOP_LSB |
+                *src++;
+
+        // Wait until the transmission of the address/data from the internal
+        // shift register has completed. For this to function correctly, the
+        // TX_EMPTY_CTRL flag in IC_CON must be set. The TX_EMPTY_CTRL flag
+        // was set in i2c_init.
+        do {
+            if (timeout_check) {
+                timeout = timeout_check(ts);
+                abort |= timeout;
+            }
+            tight_loop_contents();
+        } while (!timeout && !(i2c->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_EMPTY_BITS));
+
+        // If there was a timeout, don't attempt to do anything else.
+        if (!timeout) {
+            abort_reason = i2c->hw->tx_abrt_source;
+            if (abort_reason) {
+                // Note clearing the abort flag also clears the reason, and
+                // this instance of flag is clear-on-read! Note also the
+                // IC_CLR_TX_ABRT register always reads as 0.
+                i2c->hw->clr_tx_abrt;
+                abort = true;
+            }
+
+            if (abort || (last && !nostop)) {
+                // If the transaction was aborted or if it completed
+                // successfully wait until the STOP condition has occured.
+
+                // TODO Could there be an abort while waiting for the STOP
+                // condition here? If so, additional code would be needed here
+                // to take care of the abort.
+                do {
+                    if (timeout_check) {
+                        timeout = timeout_check(ts);
+                        abort |= timeout;
+                    }
+                    tight_loop_contents();
+                } while (!timeout && !(i2c->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_STOP_DET_BITS));
+
+                // If there was a timeout, don't attempt to do anything else.
+                if (!timeout) {
+                    i2c->hw->clr_stop_det;
+                }
+            }
+        }
+
+        // Note the hardware issues a STOP automatically on an abort condition.
+        // Note also the hardware clears RX FIFO as well as TX on abort,
+        // because we set hwparam IC_AVOID_RX_FIFO_FLUSH_ON_TX_ABRT to 0.
+        if (abort)
+            break;
+    }
+
+    int rval;
+
+    // A lot of things could have just happened due to the ingenious and
+    // creative design of I2C. Try to figure things out.
+    if (abort) {
+        if (timeout)
+            rval = PICO_ERROR_TIMEOUT;
+        else if (!abort_reason || abort_reason & I2C_IC_TX_ABRT_SOURCE_ABRT_7B_ADDR_NOACK_BITS) {
+            // No reported errors - seems to happen if there is nothing connected to the bus.
+            // Address byte not acknowledged
+            rval = PICO_ERROR_GENERIC;
+        } else if (abort_reason & I2C_IC_TX_ABRT_SOURCE_ABRT_TXDATA_NOACK_BITS) {
+            // Address acknowledged, some data not acknowledged
+            rval = byte_ctr;
+        } else {
+            //panic("Unknown abort from I2C instance @%08x: %08x\n", (uint32_t) i2c->hw, abort_reason);
+            rval = PICO_ERROR_GENERIC;
+        }
+    } else {
+        rval = byte_ctr;
+    }
+
+    // nostop means we are now at the end of a *message* but not the end of a *transfer*
+    i2c->restart_on_next = nostop;
+    return rval;
+}
 
 int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop) {
     return i2c_write_blocking_internal(i2c, addr, src, len, nostop, NULL, NULL);
+}
+
+int i2c_write_blocking_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop) {
+    return i2c_write_blocking_internal_10bit(i2c, addr, src, len, nostop, NULL, NULL);
 }
 
 int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop,
@@ -250,10 +412,23 @@ int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, 
     return i2c_write_blocking_internal(i2c, addr, src, len, nostop, init_single_timeout_until(&ts, until), &ts);
 }
 
+int i2c_write_blocking_until_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop,
+                             absolute_time_t until) {
+    timeout_state_t ts;
+    return i2c_write_blocking_internal_10bit(i2c, addr, src, len, nostop, init_single_timeout_until(&ts, until), &ts);
+}
+
 int i2c_write_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop,
                                   uint timeout_per_char_us) {
     timeout_state_t ts;
     return i2c_write_blocking_internal(i2c, addr, src, len, nostop,
+                                       init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts);
+}
+
+int i2c_write_timeout_per_char_us_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop,
+                                  uint timeout_per_char_us) {
+    timeout_state_t ts;
+    return i2c_write_blocking_internal_10bit(i2c, addr, src, len, nostop,
                                        init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts);
 }
 
@@ -319,9 +494,75 @@ static int i2c_read_blocking_internal(i2c_inst_t *i2c, uint8_t addr, uint8_t *ds
     i2c->restart_on_next = nostop;
     return rval;
 }
+static int i2c_read_blocking_internal_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop,
+                               check_timeout_fn timeout_check, timeout_state_t *ts) {
+    invalid_params_if(I2C, addr >= 0x0400); // 10-bit addresses
+    invalid_params_if(I2C, i2c_reserved_addr_10bit(addr));
+    invalid_params_if(I2C, len == 0);
+    invalid_params_if(I2C, ((int)len) < 0);
+
+    i2c->hw->enable = 0;
+    i2c->hw->tar = addr & 0x03FF;
+    i2c->hw->enable = 1;
+
+    bool abort = false;
+    bool timeout = false;
+    uint32_t abort_reason;
+    int byte_ctr;
+    int ilen = (int)len;
+    for (byte_ctr = 0; byte_ctr < ilen; ++byte_ctr) {
+        bool first = byte_ctr == 0;
+        bool last = byte_ctr == ilen - 1;
+        while (!i2c_get_write_available(i2c))
+            tight_loop_contents();
+
+        i2c->hw->data_cmd =
+                bool_to_bit(first && i2c->restart_on_next) << I2C_IC_DATA_CMD_RESTART_LSB |
+                bool_to_bit(last && !nostop) << I2C_IC_DATA_CMD_STOP_LSB |
+                I2C_IC_DATA_CMD_CMD_BITS; // -> 1 for read
+
+        do {
+            abort_reason = i2c->hw->tx_abrt_source;
+            abort = (bool) i2c->hw->clr_tx_abrt;
+            if (timeout_check) {
+                timeout = timeout_check(ts);
+                abort |= timeout;
+            }
+        } while (!abort && !i2c_get_read_available(i2c));
+
+        if (abort)
+            break;
+
+        *dst++ = (uint8_t) i2c->hw->data_cmd;
+    }
+
+    int rval;
+
+    if (abort) {
+        if (timeout)
+            rval = PICO_ERROR_TIMEOUT;
+        else if (!abort_reason || abort_reason & I2C_IC_TX_ABRT_SOURCE_ABRT_7B_ADDR_NOACK_BITS) {
+            // No reported errors - seems to happen if there is nothing connected to the bus.
+            // Address byte not acknowledged
+            rval = PICO_ERROR_GENERIC;
+        } else {
+//            panic("Unknown abort from I2C instance @%08x: %08x\n", (uint32_t) i2c->hw, abort_reason);
+            rval = PICO_ERROR_GENERIC;
+        }
+    } else {
+        rval = byte_ctr;
+    }
+
+    i2c->restart_on_next = nostop;
+    return rval;
+}
 
 int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop) {
     return i2c_read_blocking_internal(i2c, addr, dst, len, nostop, NULL, NULL);
+}
+
+int i2c_read_blocking_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop) {
+    return i2c_read_blocking_internal_10bit(i2c, addr, dst, len, nostop, NULL, NULL);
 }
 
 int i2c_read_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until) {
@@ -329,9 +570,21 @@ int i2c_read_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t 
     return i2c_read_blocking_internal(i2c, addr, dst, len, nostop, init_single_timeout_until(&ts, until), &ts);
 }
 
+int i2c_read_blocking_until_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until) {
+    timeout_state_t ts;
+    return i2c_read_blocking_internal_10bit(i2c, addr, dst, len, nostop, init_single_timeout_until(&ts, until), &ts);
+}
+
 int i2c_read_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop,
                                  uint timeout_per_char_us) {
     timeout_state_t ts;
     return i2c_read_blocking_internal(i2c, addr, dst, len, nostop,
+                                      init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts);
+}
+
+int i2c_read_timeout_per_char_us_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop,
+                                 uint timeout_per_char_us) {
+    timeout_state_t ts;
+    return i2c_read_blocking_internal_10bit(i2c, addr, dst, len, nostop,
                                       init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts);
 }

--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -32,7 +32,7 @@ extern "C" {
  * slaves when performing data transfers. A master is a device that initiates a data transfer on the bus and generates the
  * clock signals to permit that transfer. The first byte in the data transfer always contains the 7-bit address and
  * a read/write bit in the LSB position. This API takes care of toggling the read/write bit. After this, any device addressed
- * is considered a slave. 
+ * is considered a slave.
  *
  * This API allows the controller to be set up as a master or a slave using the \ref i2c_set_slave_mode function.
  *
@@ -97,6 +97,22 @@ extern i2c_inst_t i2c1_inst;
  */
 uint i2c_init(i2c_inst_t *i2c, uint baudrate);
 
+/*! \brief   Initialise the I2C HW block with 10-bit addressing
+ *  \ingroup hardware_i2c
+ *
+ * Put the I2C hardware into a known state, and enable it. Must be called
+ * before other functions. By default, the I2C is configured to operate as a
+ * master.
+ *
+ * The I2C bus frequency is set as close as possible to requested, and
+ * the return actual rate set is returned
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param baudrate Baudrate in Hz (e.g. 100kHz is 100000)
+ * \return Actual set baudrate
+ */
+uint i2c_init_10bit(i2c_inst_t *i2c, uint baudrate);
+
 /*! \brief   Disable the I2C HW block
  *  \ingroup hardware_i2c
  *
@@ -128,6 +144,15 @@ uint i2c_set_baudrate(i2c_inst_t *i2c, uint baudrate);
  * \param addr If \p slave is true, set the slave address to this value
  */
 void i2c_set_slave_mode(i2c_inst_t *i2c, bool slave, uint8_t addr);
+
+/*! \brief  Set I2C port to slave mode with 10-bit addressing
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param slave true to use slave mode, false to use master mode
+ * \param addr If \p slave is true, set the slave address to this value
+ */
+void i2c_set_slave_mode_10bit(i2c_inst_t *i2c, bool slave, uint16_t addr);
 
 // ----------------------------------------------------------------------------
 // Generic input/output
@@ -170,6 +195,23 @@ static inline i2c_hw_t *i2c_get_hw(i2c_inst_t *i2c) {
  */
 int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop, absolute_time_t until);
 
+/*! \brief Attempt to write specified number of bytes to address, blocking until the specified absolute time is reached with 10-bit addressing.
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 10-bit address of device to write to
+ * \param src Pointer to data to send
+ * \param len Length of data in bytes to send
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param until The absolute time that the block will wait until the entire transaction is complete. Note, an individual timeout of
+ *           this value divided by the length of data is applied for each byte transfer, so if the first or subsequent
+ *           bytes fails to transfer within that sub timeout, the function will return with an error.
+ *
+ * \return Number of bytes written, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+int i2c_write_blocking_until_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop, absolute_time_t until);
+
 /*! \brief  Attempt to read specified number of bytes from address, blocking until the specified absolute time is reached.
  *  \ingroup hardware_i2c
  *
@@ -183,6 +225,20 @@ int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, 
  * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
  */
 int i2c_read_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until);
+
+/*! \brief  Attempt to read specified number of bytes from address, blocking until the specified absolute time is reached with 10-bit addressing.
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 10-bit address of device to read from
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param until The absolute time that the block will wait until the entire transaction is complete.
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+int i2c_read_blocking_until_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until);
 
 /*! \brief Attempt to write specified number of bytes to address, with timeout
  *  \ingroup hardware_i2c
@@ -204,7 +260,29 @@ static inline int i2c_write_timeout_us(i2c_inst_t *i2c, uint8_t addr, const uint
     return i2c_write_blocking_until(i2c, addr, src, len, nostop, t);
 }
 
+/*! \brief Attempt to write specified number of bytes to address, with timeout, with 10-bit addressing.
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 10-bit address of device to write to
+ * \param src Pointer to data to send
+ * \param len Length of data in bytes to send
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param timeout_us The time that the function will wait for the entire transaction to complete. Note, an individual timeout of
+ *           this value divided by the length of data is applied for each byte transfer, so if the first or subsequent
+ *           bytes fails to transfer within that sub timeout, the function will return with an error.
+ *
+ * \return Number of bytes written, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+static inline int i2c_write_timeout_us_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop, uint timeout_us) {
+    absolute_time_t t = make_timeout_time_us(timeout_us);
+    return i2c_write_blocking_until_10bit(i2c, addr, src, len, nostop, t);
+}
+
 int i2c_write_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop, uint timeout_per_char_us);
+
+int i2c_write_timeout_per_char_us_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop, uint timeout_per_char_us);
 
 /*! \brief  Attempt to read specified number of bytes from address, with timeout
  *  \ingroup hardware_i2c
@@ -223,7 +301,26 @@ static inline int i2c_read_timeout_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *ds
     return i2c_read_blocking_until(i2c, addr, dst, len, nostop, t);
 }
 
+/*! \brief  Attempt to read specified number of bytes from address, with timeout, with 10-bit addressing
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 10-bit address of device to read from
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \param timeout_us The time that the function will wait for the entire transaction to complete
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged, no device present, or PICO_ERROR_TIMEOUT if a timeout occurred.
+ */
+static inline int i2c_read_timeout_us_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop, uint timeout_us) {
+    absolute_time_t t = make_timeout_time_us(timeout_us);
+    return i2c_read_blocking_until_10bit(i2c, addr, dst, len, nostop, t);
+}
+
 int i2c_read_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop, uint timeout_per_char_us);
+
+int i2c_read_timeout_per_char_us_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop, uint timeout_per_char_us);
 
 /*! \brief Attempt to write specified number of bytes to address, blocking
  *  \ingroup hardware_i2c
@@ -238,6 +335,19 @@ int i2c_read_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, si
  */
 int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop);
 
+/*! \brief Attempt to write specified number of bytes to address, blocking
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 10-bit address of device to write to
+ * \param src Pointer to data to send
+ * \param len Length of data in bytes to send
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \return Number of bytes written, or PICO_ERROR_GENERIC if address not acknowledged, no device present.
+ */
+int i2c_write_blocking_10bit(i2c_inst_t *i2c, uint16_t addr, const uint8_t *src, size_t len, bool nostop);
+
 /*! \brief  Attempt to read specified number of bytes from address, blocking
  *  \ingroup hardware_i2c
  *
@@ -250,6 +360,19 @@ int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t
  * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged or no device present.
  */
 int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop);
+
+/*! \brief  Attempt to read specified number of bytes from address, blocking
+ *  \ingroup hardware_i2c
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 10-bit address of device to read from
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \param nostop  If true, master retains control of the bus at the end of the transfer (no Stop is issued),
+ *           and the next transfer will begin with a Restart rather than a Start.
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged or no device present.
+ */
+int i2c_read_blocking_10bit(i2c_inst_t *i2c, uint16_t addr, uint8_t *dst, size_t len, bool nostop);
 
 
 /*! \brief Determine non-blocking write space available


### PR DESCRIPTION
Fixes #720 

# Raspberry Pi Pico SDK with 10-bit i2c addressing support
   As of v1.3.0 of the SDK, neither 10-bit i2c master mode nor 10-bit i2c slave mode is implemented.

   The [RP2040 Datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf)
   suggests, in two places that I can find, that 10-bit i2c addressing is not supported in slave mode.

   | ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/10biti2cEvidence1.jpg) |
   |:--:|
   | Figure 1 - Suggesting 10-bit addressing is only available in Master mode|

   | ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/10biti2cEvidence2.jpg) |
   |:--:|
   | Figure 2 - Also suggesting 10-bit addressing is only available in Master mode |

## Introducing 10-bit i2c addressing support

In the revised [i2c.h](https://github.com/zbaltzer228/pico-sdk-i2c-10bit-explained/blob/develop/src/rp2_common/hardware_i2c/include/hardware/i2c.h)
there are 10 new functions

- i2c_init_10bit
- i2c_set_slave_mode_10bit
- i2c_write_blocking_until_10bit
- i2c_read_blocking_until_10bit
- i2c_write_timeout_us_10bit
- i2c_write_timeout_per_char_us_10bit
- i2c_read_timeout_us_10bit
- i2c_read_timeout_per_char_us_10bit
- i2c_write_blocking_10bit
- i2c_read_blocking_10bit

In the revised [i2c.c](https://github.com/zbaltzer228/pico-sdk-i2c-10bit-explained/blob/develop/src/rp2_common/hardware_i2c/i2c.c)
there are 3 new functions

- i2c_reserved_addr_10bit
- i2c_write_blocking_internal_10bit
- i2c_read_blocking_internal_10bit

All prototypes are identical to their non-10-bit-qualified counterparts,
except wherever there is a **uint8_t addr** parameter, it has been replaced with
**uint16_t addr**.

Their functionality is also identical, but adapted to 10-bit addressing.

Example usage is found at [RP2040_10bit_i2c_host.c](https://github.com/zbaltzer228/pico-sdk-i2c-10bit-explained/blob/develop/Examples/RP2040_10bit_i2c_host/RP2040_10bit_i2c_host.c)
 and [RP2040_10bit_i2c_periph.c](https://github.com/zbaltzer228/pico-sdk-i2c-10bit-explained/blob/develop/Examples/RP2040_10bit_i2c_periph/RP2040_10bit_i2c_periph.c)


### Overview of a 10-bit i2c transaction using the examples

RP2040_10bit_i2c_host and RP2040_10bit_i2c_periph were built using the modified SDK proposed here.

Due to the limitations of the scope used to measure the i2c bus, the transaction
will be split across 6 different pictures.

In whole, the i2c host writes 2 bytes to the bus for address 0x02CF, then asks
the device with address 0x02CF for 3 bytes in response.

| ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/StartOfHostI2CWriteLabeled.jpg) |
|:--:|
| Figure 3 - Start of the i2c host write |

The host initiates a transaction by dropping SDA while SCL is held high.

The next 5 bits are a specific sequence, 0b11110, reserved by the i2c spec to signal a 10-bit transaction,
followed by the 2 most significant bits of the 10-bit address, in this case 0x2.

The next byte delivers the rest of the 10-bit address, 0xCF.

| ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/EndOfHostI2CWriteLabeled.jpg) |
|:--:|
| Figure 4 - End of the i2c host write |

Here, the 2 bytes are written to the bus, 0xA5 proceeded by 0x5A with the required ACK inbetween.

| ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/StartOfHostI2CReqLabeled.jpg) |
|:--:|
| Figure 5 - Start of the i2c host read request |

The host then starts a read request by transmitting the peripheral address, 0x02CF in a similar manner to Figure 3.
The R/W bit suggests a write, even though this is a read request. This is solved by
transmitting a 3rd byte with the Read bit set.

| ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/EndOfHostI2CReqLabeled.jpg) |
|:--:|
| Figure 6 - Start of the i2c host read request |

The host transmits its 3rd and final byte for the read request, this is a repeat of the first
start byte, with the reserved 0b11110 and 2 most significant bits of the periph address,
but with the Read bit set.

The peripheral then holds SDA low while it prepares to transmit its data.

| ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/StartOfPeriphI2CWrite.jpg) |
|:--:|
| Figure 7 - Start of the i2c periph write |

The periph transmits its data and gets the required ACK, it transmits 3 bytes in total.
The first being a constant 0x5A, and the last two bytes are a counter that is incremented
each time a i2c transaction takes place.

| ![](https://raw.githubusercontent.com/zbaltzer228/pico-sdk-i2c-10bit-explained/develop/Support/EndOfPeriphI2CWriteLabeled.jpg) |
|:--:|
| Figure 8 - End of the i2c transaction |

At the end, the host has acknowledged the bytes its expects and stops driving SCL.

## In conclusion
The RP2040 does, in fact, support 10-bit addressing in both host and peripheral modes.
The changes required to the SDK to fully support 10-bit addressing are provided in [i2c.h](https://github.com/zbaltzer228/pico-sdk/blob/develop/src/rp2_common/hardware_i2c/include/hardware/i2c.h)
and [i2c.c](https://github.com/zbaltzer228/pico-sdk/blob/develop/src/rp2_common/hardware_i2c/i2c.c)

