### PR TITLE
Mark __aeabi_lmul section as allocatable and executable

### DIFF
--- a/src/rp2_common/pico_int64_ops/pico_int64_ops_aeabi.S
+++ b/src/rp2_common/pico_int64_ops/pico_int64_ops_aeabi.S
@@ -10,11 +10,16 @@
 
 #include "pico/asm_helper.S"
 
+.macro int64_section name
 #if PICO_INT64_OPS_IN_RAM
-.section RAM_SECTION_NAME(__aeabi_lmul)
+.section RAM_SECTION_NAME(\name), "ax"
 #else
-.section SECTION_NAME(__aeabi_lmul)
+.section SECTION_NAME(\name), "ax"
 #endif
+.endm
+
+int64_section __aeabi_lmul
+
 wrapper_func __aeabi_lmul
     muls   r1, r2
     muls   r3, r0
@@ -41,4 +46,3 @@ wrapper_func __aeabi_lmul
     adcs   r1, r2
     add    r1, r12
     bx lr
-


### PR DESCRIPTION
When using a linker script which does not provide a `.time_critical.` section that is marked "ax" and wrongly define PICO_INT64_OPS_IN_RAM=1 this would generate a malformed executable with strange runtime bugs in the worst case.

I ran into this issue when porting the RP2040 to ChibiOS which does not provide this section in its default linker scripts. The result was `__aeabi_lmul` being put outside of the flash region. But more importantly this did only show in subtle runtime bug, not a hardfault as one would suspect.

```
38 .time_critical.__aeabi_lmul 00000032 00000000 00000000 
```

Therefore I used the pattern as seen in the other pico supplied functions.