### PR TITLE
Add __wrap_ prefix to remquo and remquof calls

### DIFF
--- a/src/rp2_common/pico_double/double_math.c
+++ b/src/rp2_common/pico_double/double_math.c
@@ -619,8 +619,8 @@ double WRAPPER_FUNC(remquo)(double x,double y,int*quo) {
     return fix642double(mx,0x3ff-ey+52);
 }
 
-double WRAPPER_FUNC(drem)(double x,double y) { check_nan_d2(x, y); return remquo(x,y,0); }
+double WRAPPER_FUNC(drem)(double x,double y) { check_nan_d2(x, y); return __wrap_remquo(x,y,0); }
 
-double WRAPPER_FUNC(remainder)(double x,double y) { check_nan_d2(x, y); return remquo(x,y,0); }
+double WRAPPER_FUNC(remainder)(double x,double y) { check_nan_d2(x, y); return __wrap_remquo(x,y,0); }
 
 _Pragma("GCC diagnostic pop") // conversion

--- a/src/rp2_common/pico_float/float_math.c
+++ b/src/rp2_common/pico_float/float_math.c
@@ -577,8 +577,8 @@ float WRAPPER_FUNC(remquof)(float x,float y,int*quo) {
     return fix2float(mx,0x7f-ey+23);
 }
 
-float WRAPPER_FUNC(dremf)(float x,float y) { check_nan_f2(x,y); return remquof(x,y,0); }
+float WRAPPER_FUNC(dremf)(float x,float y) { check_nan_f2(x,y); return __wrap_remquof(x,y,0); }
 
-float WRAPPER_FUNC(remainderf)(float x,float y) { check_nan_f2(x,y); return remquof(x,y,0); }
+float WRAPPER_FUNC(remainderf)(float x,float y) { check_nan_f2(x,y); return __wrap_remquof(x,y,0); }
 
 _Pragma("GCC diagnostic pop") // conversion


### PR DESCRIPTION
Linking with LTO enabled would otherwise result in an error with `undefined reference to __wrap_remquof'` possibly because they are in the same translation unit. Compiling without LTO worked but I'm not which function `remquof` was resolved.
