### PR TITLE
Make clocks_init weak so a user can provide their own version

### DIFF
--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -118,7 +118,8 @@ bool clock_configure(enum clock_index clk_index, uint32_t src, uint32_t auxsrc, 
 }
 /// \end::clock_configure[]
 
-void clocks_init(void) {
+// Weak so that user can replace with their own custom version, e.g. if they are not using XOSC
+void __attribute__((weak)) clocks_init(void) {
     // Start tick in watchdog
     watchdog_start_tick(XOSC_MHZ);
 


### PR DESCRIPTION
The `clocks_init` function in the SDK unconditionally sets up the external crystal and PLLs.  This function is called as part of runtime_init before the user's main function.

It would be nice to be able to override this behaviour so that the system could be started from ROSC only, or simply to avoid bringing up the PLLs.  This would make it straightforward to create a project that did not use an external crystal using the standard SDK.

I propose to fix this by making the `clocks_init` function weak.  The user project can then provide their own version that configures ROSC and the clocks they need appropriately, and their version will be preferred by the linker.