### PR TITLE
Added int_frac function for configuring PWM

### DIFF
--- a/src/rp2_common/hardware_pwm/include/hardware/pwm.h
+++ b/src/rp2_common/hardware_pwm/include/hardware/pwm.h
@@ -146,6 +146,7 @@ static inline void pwm_config_set_clkdiv_int(pwm_config *c, uint div) {
  * before passing them on to the PWM counter.
  */
 static inline void pwm_config_set_clkdiv_int_frac(pwm_config *c, uint8_t integer, uint8_t fract) {
+    valid_params_if(PWM, fract < 16);
     c->div = (((uint)integer) << PWM_CH0_DIV_INT_LSB) | (((uint)fract) << PWM_CH0_DIV_FRAC_LSB);
 }
 

--- a/src/rp2_common/hardware_pwm/include/hardware/pwm.h
+++ b/src/rp2_common/hardware_pwm/include/hardware/pwm.h
@@ -134,6 +134,21 @@ static inline void pwm_config_set_clkdiv_int(pwm_config *c, uint div) {
     c->div = div << PWM_CH0_DIV_INT_LSB;
 }
 
+/** \brief Set PWM clock divider in a PWM configuration using an 8:4 fractional value
+ *  \ingroup hardware_pwm
+ *
+ * \param c PWM configuration struct to modify
+ * \param integer 8 bit integer part of the clock divider. Must be greater than or equal to 1.
+ * \param fract 4 bit the fractional part of the clock divider
+ *
+ * If the divide mode is free-running, the PWM counter runs at clk_sys / div.
+ * Otherwise, the divider reduces the rate of events seen on the B pin input (level or edge)
+ * before passing them on to the PWM counter.
+ */
+static inline void pwm_config_set_clkdiv_int_frac(pwm_config *c, uint8_t integer, uint8_t fract) {
+    c->div = (((uint)integer) << PWM_CH0_DIV_INT_LSB) | (((uint)fract) << PWM_CH0_DIV_FRAC_LSB);
+}
+
 /** \brief Set PWM counting mode in a PWM configuration
  *  \ingroup hardware_pwm
  *

--- a/src/rp2_common/hardware_pwm/include/hardware/pwm.h
+++ b/src/rp2_common/hardware_pwm/include/hardware/pwm.h
@@ -139,7 +139,7 @@ static inline void pwm_config_set_clkdiv_int(pwm_config *c, uint div) {
  *
  * \param c PWM configuration struct to modify
  * \param integer 8 bit integer part of the clock divider. Must be greater than or equal to 1.
- * \param fract 4 bit the fractional part of the clock divider
+ * \param fract 4 bit fractional part of the clock divider
  *
  * If the divide mode is free-running, the PWM counter runs at clk_sys / div.
  * Otherwise, the divider reduces the rate of events seen on the B pin input (level or edge)


### PR DESCRIPTION
It's a bit late, but finally got around to raising a PR for issue https://github.com/raspberrypi/pico-sdk/issues/734. 

I've done some testing, but perhaps worth your team testing too before merging.

Also, I don't know whether its worth mirroring the `pwm_config_set_clkdiv_int` with a `pwm_set_clkdiv_int` too? As mentioned in the issue, it seems somewhat redundant, since PIO only has the `int_frac` version.
