### PR TITLE
Fix typo in SIO register description

### DIFF
--- a/src/rp2040/hardware_regs/include/hardware/regs/sio.h
+++ b/src/rp2040/hardware_regs/include/hardware/regs/sio.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2022 Raspberry Pi (Trading) Ltd.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -344,7 +344,7 @@
 //               q`.
 //               Any operand write starts a new calculation. The results appear
 //               in QUOTIENT, REMAINDER.
-//               UDIVIDEND/SDIVIDEND are aliases of the same internal register.
+//               UDIVISOR/SDIVISOR are aliases of the same internal register.
 //               The U alias starts an
 //               unsigned calculation, and the S alias starts a signed
 //               calculation.

--- a/src/rp2040/hardware_regs/rp2040.svd
+++ b/src/rp2040/hardware_regs/rp2040.svd
@@ -44509,7 +44509,7 @@
           <description>Divider unsigned divisor\n
             Write to the DIVISOR operand of the divider, i.e. the q in `p / q`.\n
             Any operand write starts a new calculation. The results appear in QUOTIENT, REMAINDER.\n
-            UDIVIDEND/SDIVIDEND are aliases of the same internal register. The U alias starts an\n
+            UDIVISOR/SDIVISOR are aliases of the same internal register. The U alias starts an\n
             unsigned calculation, and the S alias starts a signed calculation.</description>
           <name>DIV_UDIVISOR</name>
           <resetValue>0x00000000</resetValue>


### PR DESCRIPTION
Fix description of SIO_DIV_UDIVISOR to talk about UDIVISOR/SDIVISOR instead of UDIVIDEND/SDIVIDEND