### PR TITLE
pico_sdk_import: don't recurse git submodules

### DIFF
--- a/external/pico_sdk_import.cmake
+++ b/external/pico_sdk_import.cmake
@@ -29,11 +29,22 @@ if (NOT PICO_SDK_PATH)
         if (PICO_SDK_FETCH_FROM_GIT_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
-        FetchContent_Declare(
-                pico_sdk
-                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                GIT_TAG master
-        )
+        # GIT_SUBMODULES_RECURSE was added in 3.17
+        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+                    GIT_SUBMODULES_RECURSE FALSE
+            )
+        else ()
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG master
+            )
+        endif ()
+
         if (NOT pico_sdk)
             message("Downloading Raspberry Pi Pico SDK")
             FetchContent_Populate(pico_sdk)


### PR DESCRIPTION
When cloning the pico-sdk repo manually, one normally would do
`git submodule update --init`, which is non-recursive. However, when
cloning automatically, CMake will recursively update submodules by
default. Updating all of tiny-usb's submodules takes an extremely long
time. Luckily, CMake 3.17 added an option we can specify for
FetchContent to tell it not to recursively update submodules. Older
CMake versions will not use this flag.

Fixes #771.