### PR TITLE
Remove implicit grouping for PIO defines

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -73,20 +73,16 @@ typedef pio_hw_t *PIO;
  * e.g. pio_gpio_init(pio0, 5)
  *
  *  \ingroup hardware_pio
- * @{
  */
 #define pio0 pio0_hw
-/** @} */
 
 /** Identifier for the second (PIO 1) hardware PIO instance (for use in PIO functions).
  *
  * e.g. pio_gpio_init(pio1, 5)
  *
  *  \ingroup hardware_pio
- * @{
  */
 #define pio1 pio1_hw
-/** @} */
 
 /** \brief PIO state machine configuration
  *  \defgroup sm_config sm_config


### PR DESCRIPTION
https://www.doxygen.nl/manual/grouping.html says "An explicit \ingroup overrides an implicit grouping definition via @{ @}." and both the defines here already use an explicit `\ingroup`.

This also "fixes" the Doxygen output so that:
![Screenshot from 2022-04-06 11-35-03](https://user-images.githubusercontent.com/476186/161957391-389e90bf-afbe-451a-a14f-46348a205adc.png)

appears like this instead:
![Screenshot from 2022-04-06 11-39-26](https://user-images.githubusercontent.com/476186/161957432-69e1bc22-a4ef-4b5b-8947-41576b7314cf.png)
