### PR TITLE
Fix typo in binary_info description

### DIFF
--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -131,7 +131,7 @@ static const struct _binary_info_named_group __bi_lineno_var_name = { \
 #define bi_pin_range_with_func(plo, phi, func)       __bi_encoded_pins_with_func(BI_PINS_ENCODING_RANGE | ((func << 3)) | ((plo) << 7) | ((phi) << 12))
 
 #define bi_pin_mask_with_name(pmask, label)          __bi_pins_with_name((pmask), (label))
-// names are seperated by | ... i.e. "name1|name2|name3"
+// names are separated by | ... i.e. "name1|name2|name3"
 #define bi_pin_mask_with_names(pmask, label)          __bi_pins_with_name((pmask), (label))
 #define bi_1pin_with_name(p0, name)                   bi_pin_mask_with_name(1u << (p0), name)
 #define bi_2pins_with_names(p0, name0, p1, name1)     bi_pin_mask_with_names((1u << (p0)) | (1u << (p1)), name0 "|" name1)

--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -131,7 +131,7 @@ static const struct _binary_info_named_group __bi_lineno_var_name = { \
 #define bi_pin_range_with_func(plo, phi, func)       __bi_encoded_pins_with_func(BI_PINS_ENCODING_RANGE | ((func << 3)) | ((plo) << 7) | ((phi) << 12))
 
 #define bi_pin_mask_with_name(pmask, label)          __bi_pins_with_name((pmask), (label))
-// names are sperated by | ... i.e. "name1|name2|name3"
+// names are seperated by | ... i.e. "name1|name2|name3"
 #define bi_pin_mask_with_names(pmask, label)          __bi_pins_with_name((pmask), (label))
 #define bi_1pin_with_name(p0, name)                   bi_pin_mask_with_name(1u << (p0), name)
 #define bi_2pins_with_names(p0, name0, p1, name1)     bi_pin_mask_with_names((1u << (p0)) | (1u << (p1)), name0 "|" name1)


### PR DESCRIPTION
Extremely small correction. Fixed typo in binary_info description. 
Of course, it does not affect the behavior.
