### PR TITLE
Add gpio_deinit

### DIFF
--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -217,6 +217,10 @@ void gpio_init(uint gpio) {
     gpio_set_function(gpio, GPIO_FUNC_SIO);
 }
 
+void gpio_deinit(uint gpio) {
+    gpio_set_function(gpio, GPIO_FUNC_NULL);
+}
+
 void gpio_init_mask(uint gpio_mask) {
     for(uint i=0;i<32;i++) {
         if (gpio_mask & 1) {

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -414,6 +414,13 @@ void gpio_acknowledge_irq(uint gpio, uint32_t events);
  */
 void gpio_init(uint gpio);
 
+/*! \brief Resets a GPIO back to the NULL function, i.e. disables it.
+ *  \ingroup hardware_gpio
+ *
+ * \param gpio GPIO number
+ */
+void gpio_deinit(uint gpio);
+
 /*! \brief Initialise multiple GPIOs (enabled I/O and set func to GPIO_FUNC_SIO)
  *  \ingroup hardware_gpio
  *


### PR DESCRIPTION
Add a `gpio_deinit(pin)`, for symmetry with `gpio_init(pin)` and similarity to `i2c_deinit()`.

Fixes #792.