### PR TITLE
Adapt assembler syntax to eliminate Clang errors. (LLVM 14.0.0)

### DIFF
--- a/src/rp2_common/pico_divider/divider.S
+++ b/src/rp2_common/pico_divider/divider.S
@@ -103,7 +103,7 @@ regular_func div_s32s32
 regular_func divmod_s32s32
 #if !PICO_DIVIDER_DISABLE_INTERRUPTS
     // to support IRQ usage (or context switch) we must save/restore divider state around call if state is dirty
-    ldr r2, =(SIO_BASE)
+    ldr r2, =SIO_BASE
     ldr r3, [r2, #SIO_DIV_CSR_OFFSET]
     lsrs r3, #SIO_DIV_CSR_DIRTY_SHIFT_FOR_CARRY
     bcs divmod_s32s32_savestate
@@ -114,7 +114,7 @@ regular_func divmod_s32s32_unsafe
 // are the hardware_divider functions that can be used instead anyway
 regular_func divmod_s32s32_unsafe
     // to avoid worrying about IRQs (or context switches), simply disable interrupts around call
-    ldr r2, =(SIO_BASE)
+    ldr r2, =SIO_BASE
     mrs r3, PRIMASK
     cpsid i
 #endif /* !PICO_DIVIDER_DISABLE_INTERRUPTS */
@@ -167,7 +167,7 @@ wrapper_func __aeabi_uidiv
 wrapper_func __aeabi_uidivmod
 #if !PICO_DIVIDER_DISABLE_INTERRUPTS
     // to support IRQ usage (or context switch) we must save/restore divider state around call if state is dirty
-    ldr r2, =(SIO_BASE)
+    ldr r2, =SIO_BASE
     ldr r3, [r2, #SIO_DIV_CSR_OFFSET]
     lsrs r3, #SIO_DIV_CSR_DIRTY_SHIFT_FOR_CARRY
     bcs divmod_u32u32_savestate
@@ -178,7 +178,7 @@ regular_func divmod_u32u32_unsafe
 // are the hardware_divider functions that can be used instead anyway
 regular_func divmod_u32u32_unsafe
     // to avoid worrying about IRQs (or context switches), simply disable interrupts around call
-    ldr r2, =(SIO_BASE)
+    ldr r2, =SIO_BASE
     mrs r3, PRIMASK
     cpsid i
 #endif /* !PICO_DIVIDER_DISABLE_INTERRUPTS */
@@ -227,7 +227,7 @@ regular_func divmod_s64s64
 #if !PICO_DIVIDER_DISABLE_INTERRUPTS
     // to support IRQ usage (or context switch) we must save/restore divider state around call if state is dirty
     mov ip, r2
-    ldr r2, =(SIO_BASE)
+    ldr r2, =SIO_BASE
     ldr r2, [r2, #SIO_DIV_CSR_OFFSET]
     lsrs r2, #SIO_DIV_CSR_DIRTY_SHIFT_FOR_CARRY
     mov r2, ip
@@ -255,7 +255,7 @@ regular_func divmod_u64u64
 #if !PICO_DIVIDER_DISABLE_INTERRUPTS
     // to support IRQ usage (or context switch) we must save/restore divider state around call if state is dirty
     mov ip, r2
-    ldr r2, =(SIO_BASE)
+    ldr r2, =SIO_BASE
     ldr r2, [r2, #SIO_DIV_CSR_OFFSET]
     lsrs r2, #SIO_DIV_CSR_DIRTY_SHIFT_FOR_CARRY
     mov r2, ip
@@ -278,7 +278,7 @@ regular_func divmod_u64u64_savestate
 
 .macro dneg lo,hi
  mvns \hi,\hi
- rsbs \lo,#0
+ negs \lo,\lo
  bne l\@_1
  adds \hi,#1
 l\@_1:
@@ -352,7 +352,7 @@ regular_func divmod_u64u64_unsafe
  cmp r2,#0
  beq 2f                    @ x==0?
  mov r12,r7
- ldr r7,=#SIO_BASE
+ ldr r7,=SIO_BASE
  str r0,[r7,#SIO_DIV_UDIVIDEND_OFFSET]
  str r2,[r7,#SIO_DIV_UDIVISOR_OFFSET]
  movs r1,#0
@@ -367,7 +367,7 @@ regular_func divmod_u64u64_unsafe
  cmp r0,#0                 @ y==0?
  beq 3f                    @ then pass 0 to __aeabi_ldiv0
 udiv0:
- ldr r0,=#0xffffffff
+ ldr r0,=0xffffffff
  movs r1,r0                @ pass 2^64-1 to __aeabi_ldiv0
 3:
  push {r14}
@@ -402,7 +402,7 @@ y64:
  cmp r2,#0
  beq udiv0                 @ x==0? exit as with y!=0 case above
  push {r7}
- ldr r7,=#SIO_BASE
+ ldr r7,=SIO_BASE
  str r1,[r7,#SIO_DIV_UDIVIDEND_OFFSET]
  str r2,[r7,#SIO_DIV_UDIVISOR_OFFSET]
  wait_div 4
@@ -464,9 +464,9 @@ y64_x32:
  lsrs r4,r2,#15
  adds r4,#1                @ x1=(x0>>15)+1; 2^16<x1<=2^17
 
- ldr r7,=#SIO_BASE
+ ldr r7,=SIO_BASE
  str r4,[r7,#SIO_DIV_UDIVISOR_OFFSET]
- ldr r4,=#0xffffffff
+ ldr r4,=0xffffffff
  str r4,[r7,#SIO_DIV_UDIVIDEND_OFFSET]
  lsrs r6,r1,#16
  uxth r3,r2                @ x0l
@@ -687,9 +687,9 @@ y64_x48:
  adcs r4,r4
  adds r4,#1                @ x1=(ui32)(x0>>31)+1; // 2^16<x1<=2^17
 
- ldr r7,=#SIO_BASE
+ ldr r7,=SIO_BASE
  str r4,[r7,#SIO_DIV_UDIVISOR_OFFSET]
- ldr r4,=#0xffffffff
+ ldr r4,=0xffffffff
  str r4,[r7,#SIO_DIV_UDIVIDEND_OFFSET]
  lsrs r6,r1,#16
  wait_div 1
@@ -821,7 +821,7 @@ y64_x64:
  adds r5,r3,#1
  beq 1f
 
- ldr r7,=#SIO_BASE
+ ldr r7,=SIO_BASE
  str r5,[r7,#SIO_DIV_UDIVISOR_OFFSET]
  str r1,[r7,#SIO_DIV_UDIVIDEND_OFFSET]
  wait_div 0

--- a/src/rp2_common/pico_double/double_aeabi.S
+++ b/src/rp2_common/pico_double/double_aeabi.S
@@ -290,7 +290,7 @@ wrapper_func __aeabi_cdcmple
 wrapper_func __aeabi_cdcmpeq
  push {r0-r7,r14}
 __aeabi_dfcmple_guts:
- ldr r7,=#0x7ff                @ flush NaNs and denormals
+ ldr r7,=0x7ff                @ flush NaNs and denormals
  lsls r4,r1,#1
  lsrs r4,#21
  beq 1f
@@ -450,7 +450,7 @@ wrapper_func __aeabi_i2d
     lsls r2, r4
     lsls r0, r2, #20
     lsrs r2, #12
-    ldr r1,=#1055
+    ldr r1,=1055
     subs r1, r4
     lsls r1, #20
     orrs r1, r3
@@ -552,7 +552,7 @@ regular_func double2int64_z
     cmp r1, #0
     bmi 1f
     movs r2, #0
-    rsbs r0, #0
+    negs r0, r0
     sbcs r2, r1
     mov r1, r2
     pop {pc}

--- a/src/rp2_common/pico_double/double_v1_rom_shim.S
+++ b/src/rp2_common/pico_double/double_v1_rom_shim.S
@@ -144,7 +144,7 @@ l\@_2:
  lsls \re,#21
  bcc l\@_1                     @ skip on positive
  mvns \rb,\rb                  @ negate mantissa
- rsbs \ra,#0
+ negs \ra,\ra
  bcc l\@_1
  adds \rb,#1
 l\@_1:
@@ -218,7 +218,7 @@ da_pack:
  mvns r1,r1                    @ negate mantissa
  mvns r0,r0
  movs r2,#0
- rsbs r4,#0
+ negs r4,r4
  adcs r0,r2
  adcs r1,r2
 1:
@@ -263,7 +263,7 @@ da_3:
 da_7:
 @ here exponent overflow: return signed infinity
  lsls r1,r3,#31
- ldr r3,=#0x7ff00000
+ ldr r3,=0x7ff00000
  orrs r1,r3
  b 1f
 da_6:
@@ -524,7 +524,7 @@ double_section dmul_shim
  adcs r1,r1
  subs r3,#1                    @ correct exponent
 1:
- ldr r6,=#0x3ff
+ ldr r6,=0x3ff
  subs r3,r6                    @ correct for exponent bias
  lsls r6,#1                    @ 0x7fe
  cmp r3,r6
@@ -811,7 +811,7 @@ dd_1:
  muls r3,r0                    @ zL*xH Q73
  subs r4,r3
  mul32_32_64 r2,r0, r2,r3, r5,r6,r7,r2,r3  @ xL*zL
- rsbs r2,#0                    @ borrow from low half?
+ negs r2,r2                    @ borrow from low half?
  sbcs r4,r3                    @ y-xz Q73 (remainder bits 52..73)
 
  cmp r4,#0
@@ -830,9 +830,9 @@ dd_2:
  mov r2,r12
  lsls r7,r2,#31                @ result sign
  asrs r2,#2                    @ result exponent
- ldr r3,=#0x3fd
+ ldr r3,=0x3fd
  adds r2,r3
- ldr r3,=#0x7fe
+ ldr r3,=0x7fe
  cmp r2,r3
  bhs dd_3                      @ over- or underflow?
  lsls r2,#20
@@ -936,7 +936,7 @@ dq_0:
  b dq_4
 
 dq_3:
- ldr r1,=#0x7ff
+ ldr r1,=0x7ff
  lsls r1,#20                   @ return +Inf
 dq_4:
  movs r0,#0
@@ -949,7 +949,7 @@ regular_func dsqrt_shim
  bcs dq_0                      @ negative?
  lsrs r2,#21                   @ extract exponent
  subs r2,#1
- ldr r3,=#0x7fe
+ ldr r3,=0x7fe
  cmp r2,r3
  bhs dq_2                      @ catches 0 and +Inf
  push {r4-r7,r14}
@@ -968,8 +968,8 @@ regular_func dsqrt_shim
 @ here
 @ r0:r1  y mantissa Q52 [1,4)
 @ r12    result exponent
-
- adr r4,drsqrtapp-8            @ first eight table entries are never accessed because of the mantissa's leading 1
+.equ drsqrtapp_minus_8, (drsqrtapp-8)
+ adr r4,drsqrtapp_minus_8      @ first eight table entries are never accessed because of the mantissa's leading 1
  lsrs r2,r1,#17                @ y Q3
  ldrb r2,[r4,r2]               @ initial approximation to reciprocal square root a0 Q8
  lsrs r3,r1,#4                 @ first Newton-Raphson iteration
@@ -1100,7 +1100,7 @@ dq_5:
  adds r2,r3                    @ r1:r2 a5^2 Q106
  lsls r0,#22                   @ y Q84
 
- rsbs r1,#0
+ negs r1,r1
  sbcs r0,r2                    @ remainder y-a5^2
  bmi 1f                        @ y<a5^2: no need to increment a5
  movs r3,#0
@@ -1290,7 +1290,8 @@ ret_dzero:
  bx r14
  
 .weak d2fix_a // weak because it exists in float code too
-regular_func d2fix_a
+.thumb_func
+d2fix_a:
 @ here
 @ r0:r1 two's complement mantissa
 @ r2    unbaised exponent
@@ -1304,7 +1305,7 @@ regular_func d2fix_a
  movs r4,r0
  lsls r1,r2
  lsls r0,r2
- rsbs r2,#0
+ negs r2,r2
  adds r2,#32                   @ complementary shift
  lsrs r4,r2
  orrs r1,r4
@@ -1319,7 +1320,7 @@ regular_func d2fix_a
  bmi 1f                        @ long shift?
  mov r4,r1
  lsls r4,r2
- rsbs r2,#0
+ negs r2,r2
  adds r2,#32                   @ complementary shift
  asrs r1,r2
  lsrs r0,r2
@@ -1331,7 +1332,7 @@ regular_func d2fix_a
  asrs r1,#31                   @ shift down 32 places
  adds r2,#32
  bmi 1f                        @ very long shift?
- rsbs r2,#0
+ negs r2,r2
  adds r2,#32
  asrs r0,r2
  pop {r4,r15}
@@ -1344,7 +1345,7 @@ double_section double2float_shim
  regular_func double2float_shim
  lsls r2,r1,#1
  lsrs r2,#21                   @ exponent
- ldr r3,=#0x3ff-0x7f
+ ldr r3,=0x3ff-0x7f
  subs r2,r3                    @ fix exponent bias
  ble 1f                        @ underflow or zero
  cmp r2,#0xff
@@ -1432,7 +1433,7 @@ regular_func fix642double_shim
  sbcs r1,r3
 uf2d:
  push {r4,r5,r14}
- ldr r4,=#0x432
+ ldr r4,=0x432
  subs r2,r4,r2                 @ form biased exponent
 @ here
 @ r0:r1 unnormalised mantissa
@@ -1455,7 +1456,7 @@ uf2d:
  lsrs r4,r1,#21
  bcc 5b
 4:
- ldr r4,=#0x7fe
+ ldr r4,=0x7fe
  cmp r2,r4
  bhs 6f                        @ over/underflow? return signed zero/infinity
 7:
@@ -1506,7 +1507,7 @@ uf2d:
 double_section dunpacks
  regular_func dunpacks
  mdunpacks r0,r1,r2,r3,r4
- ldr r3,=#0x3ff
+ ldr r3,=0x3ff
  subs r2,r3                    @ exponent without offset
  bx r14
 
@@ -1572,7 +1573,7 @@ double_section dreduce
  lsrs r3,r0,#24
  orrs r1,r3
  lsls r0,#8                    @ r0:r1 Q60, to be shifted down -r2 places
- rsbs r3,r2,#0
+ negs r3,r2
  adds r2,#32                   @ shift down in r3, complementary shift in r2
  bmi 1f                        @ long shift?
 2:
@@ -1663,13 +1664,13 @@ dsincos_internal:
  bl dreduce
 
  movs r4,#0
- ldr r5,=#0x9df04dbb           @ this value compensates for the non-unity scaling of the CORDIC rotations
- ldr r6,=#0x36f656c5
+ ldr r5,=0x9df04dbb           @ this value compensates for the non-unity scaling of the CORDIC rotations
+ ldr r6,=0x36f656c5
  lsls r2,#31
  bcc 1f
 @ quadrant 2 or 3
  mvns r6,r6
- rsbs r5,r5,#0
+ negs r5,r5
  adcs r6,r4
 1:
  lsls r2,#1
@@ -1757,7 +1758,7 @@ regular_func datan2_shim
 @ r2:r3 x
  push {r4-r7,r14}
  bl push_r8_r11
- ldr r5,=#0x7ff00000
+ ldr r5,=0x7ff00000
  movs r4,r1
  ands r4,r5                    @ y==0?
  beq 1f
@@ -1786,7 +1787,7 @@ regular_func datan2_shim
  eors r3,r5
  eors r1,r5
  bmi 1f                        @ quadrant offset=+2 if y was positive
- rsbs r6,#0                    @ quadrant offset=-2 if y was negative
+ negs r6,r6                    @ quadrant offset=-2 if y was negative
 1:
 @ now in quadrant 0 or 3
  adds r7,r1,r5                 @ r7=-r1
@@ -1895,8 +1896,8 @@ regular_func datan2_shim
 
  cmp r6,#0
  beq 1f
- ldr r4,=#0x885A308D           @ π/2 Q61
- ldr r5,=#0x3243F6A8
+ ldr r4,=0x885A308D           @ π/2 Q61
+ ldr r5,=0x3243F6A8
  bpl 2f
  mvns r4,r4                    @ negative quadrant offset
  mvns r5,r5
@@ -1959,8 +1960,8 @@ regular_func dexp_shim
  bl dreduce
  cmp r1,#0
  bge 1f
- ldr r4,=#0xF473DE6B
- ldr r5,=#0x2C5C85FD           @ ln2 Q62
+ ldr r4,=0xF473DE6B
+ ldr r5,=0x2C5C85FD           @ ln2 Q62
  adds r0,r4
  adcs r1,r5
  subs r2,#1
@@ -1979,7 +1980,7 @@ regular_func dexp_shim
  sbcs r1,r5
  bmi 1f
 
- rsbs r6,r7,#0
+ negs r6,r7
  adds r6,#32                   @ complementary shift
  movs r5,r3
  asrs r5,r7
@@ -2015,7 +2016,7 @@ regular_func dexp_shim
  adcs r1,r3
 
  pop {r2}
- rsbs r2,#0
+ negs r2,r2
  adds r2,#62
  bl fix642double_shim                 @ in principle we can pack faster than this because we know the exponent
  pop {r4-r7,r15}
@@ -2046,7 +2047,7 @@ regular_func dln_shim
  movs r3,#0                    @ y=0 Q62
 
 3:
- rsbs r6,r7,#0
+ negs r6,r7
  adds r6,#32                   @ complementary shift
  movs r5,r1
  asrs r5,r7
@@ -2086,8 +2087,8 @@ regular_func dln_shim
 @ here:
 @ r2:r3 ln m/2 = ln m - ln2 Q62
 @ r7    unbiased exponent
-
- adr r4,dreddata1+4
+.equ dreddata1_plus_4, (dreddata1+4)
+ adr r4,dreddata1_plus_4
  ldmia r4,{r0,r1,r4}
  adds r7,#1
  muls r0,r7                    @ Q62
@@ -2128,12 +2129,12 @@ regular_func dln_shim
  pop {r4-r7,r15}
 
 5:
- ldr r1,=#0xfff00000
+ ldr r1,=0xfff00000
  movs r0,#0
  pop {r4-r7,r15}
 
 6:
- ldr r1,=#0x7ff00000
+ ldr r1,=0x7ff00000
  movs r0,#0
  pop {r4-r7,r15}
 

--- a/src/rp2_common/pico_float/float_aeabi.S
+++ b/src/rp2_common/pico_float/float_aeabi.S
@@ -378,7 +378,7 @@ wrapper_func __aeabi_i2f
         lsrs r1, r0, #31
         lsls r1, #31
         bpl 1f
-        rsbs r0, #0
+        negs r0, r0
 1:
         cmp r0, #0
         beq 7f
@@ -392,7 +392,7 @@ __aeabi_i2f_main:
         pop {r1, r2}
         lsls r1, r0
         subs r0, #158
-        rsbs r0, #0
+        negs r0, r0
 
         adds r1,#0x80  @ rounding
         bcs 5f         @ tripped carry? then have leading 1 in C as required (and result is even so can ignore sticky bits)
@@ -459,7 +459,7 @@ regular_func float2int_z
     bl __aeabi_f2uiz
     cmp r0, #0
     bmi 1f
-    rsbs r0, #0
+    negs r0, r0
     pop {pc}
 1:
     movs r0, #128
@@ -534,7 +534,7 @@ regular_func float2int64_z
     cmp r1, #0
     bmi 1f
     movs r2, #0
-    rsbs r0, #0
+    negs r0, r0
     sbcs r2, r1
     mov r1, r2
     pop {pc}

--- a/src/rp2_common/pico_float/float_v1_rom_shim.S
+++ b/src/rp2_common/pico_float/float_v1_rom_shim.S
@@ -100,7 +100,7 @@ regular_func fix642float_shim
  movs r5,r0
  movs r0,r1
 4:
- rsbs r2,#0
+ negs r2,r2
  adds r2,#32+29
 
  // bl packx
@@ -132,7 +132,7 @@ regular_func fatan2_shim
  bmi 2f         @ force y to 0 proper, so result will be zero
  subs r4,r2,r3  @ calculate shift
  bge 1f         @ ex>=ey?
- rsbs r4,#0     @ make shift positive
+ negs r4,r4     @ make shift positive
  asrs r0,r4
  cmp r4,#28
  blo 3f
@@ -159,8 +159,8 @@ regular_func fatan2_shim
  ldr r3, =0x2cfc         @ &pi_q29, circular coefficients
  cmp r0,#0               @ x negative
  bge 5f
- rsbs r0,#0              @ rotate to 1st/4th quadrants
- rsbs r1,#0
+ negs r0,r0              @ rotate to 1st/4th quadrants
+ negs r1,r1
  ldr r2,[r3]             @ pi Q29
 5:
  movs r4,#1              @ m=1
@@ -272,7 +272,7 @@ d2fix_a:
  movs r4,r0
  lsls r1,r2
  lsls r0,r2
- rsbs r2,#0
+ negs r2,r2
  adds r2,#32                   @ complementary shift
  lsrs r4,r2
  orrs r1,r4
@@ -287,7 +287,7 @@ d2fix_a:
  bmi 1f                        @ long shift?
  mov r4,r1
  lsls r4,r2
- rsbs r2,#0
+ negs r2,r2
  adds r2,#32                   @ complementary shift
  asrs r1,r2
  lsrs r0,r2
@@ -299,7 +299,7 @@ d2fix_a:
  asrs r1,#31                   @ shift down 32 places
  adds r2,#32
  bmi 1f                        @ very long shift?
- rsbs r2,#0
+ negs r2,r2
  adds r2,#32
  asrs r0,r2
  pop {r4,r15}
@@ -329,7 +329,7 @@ regular_func float2double_shim
  cmp r2,#0xff                  @ Inf?
  beq 2f
  lsrs r1,#4                    @ exponent and top 20 bits of mantissa
- ldr r2,=#(0x3ff-0x7f)<<20     @ difference in exponent offsets
+ ldr r2,=(0x3ff-0x7f)<<20     @ difference in exponent offsets
  adds r1,r2
  orrs r1,r3
  lsls r0,#29                   @ bottom 3 bits of mantissa
@@ -340,7 +340,7 @@ regular_func float2double_shim
  movs r0,#0
  bx r14
 2:
- ldr r1,=#0x7ff00000           @ return signed infinity
+ ldr r1,=0x7ff00000           @ return signed infinity
  adds r1,r3
  b 3b
 


### PR DESCRIPTION
Fixes #797

Clang (LLVM 14.0.0) assembler doesn't like some syntax that GCC assembler accepts:
- 'rsbs' instruction not accepted, equivalent 'negs' is.
- Some argument syntax isn't accepted (e.g '=(SIO_BASE)' isn't, '=SIO_BASE' is; '=#blah' isn't, '=blah' is.
- 'adr' argument can't be an expression, but can be a .equ that uses an expression.
- Declaration of 'd2fix_a' shouldn't use 'regular_func' macro, because 'd2fix_a' should be a weak symbol.
