### PR TITLE
Add stdio_uart_deinit()

### DIFF
--- a/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
+++ b/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
@@ -63,6 +63,13 @@ void stdin_uart_init(void);
  */
 void stdio_uart_init_full(uart_inst_t *uart, uint baud_rate, int tx_pin, int rx_pin);
 
+/*! \brief Disables the UART driver and resets UART.
+ *  \ingroup pico_stdio_uart
+ *
+ * Does not touch the pins passed to stdio_uart_init_full(). You should reset those yourself.
+ */
+void stdio_uart_deinit();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
+++ b/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
@@ -66,9 +66,17 @@ void stdio_uart_init_full(uart_inst_t *uart, uint baud_rate, int tx_pin, int rx_
 /*! \brief Disables the UART driver and resets UART.
  *  \ingroup pico_stdio_uart
  *
- * Does not touch the pins passed to stdio_uart_init_full(). You should reset those yourself.
+ * Resets the default UART pins PICO_DEFAULT_UART_TX_PIN and PICO_DEFAULT_UART_RX_PIN.
+ * If you have customised your pin via \ref stdio_uart_init_full() then use \ref stdio_uart_deinit_full() instead.
  */
 void stdio_uart_deinit(void);
+
+/*! \brief Disables the UART driver and resets UART.
+ *  \ingroup pico_stdio_uart
+ *
+ * In addition to resetting the UART, it also resets pins to the NULL function.
+ */
+void stdio_uart_deinit_full(int tx_pin, int rx_pin);
 
 #ifdef __cplusplus
 }

--- a/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
+++ b/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
@@ -68,7 +68,7 @@ void stdio_uart_init_full(uart_inst_t *uart, uint baud_rate, int tx_pin, int rx_
  *
  * Does not touch the pins passed to stdio_uart_init_full(). You should reset those yourself.
  */
-void stdio_uart_deinit();
+void stdio_uart_deinit(void);
 
 #ifdef __cplusplus
 }

--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -80,6 +80,7 @@ void stdio_uart_deinit() {
     if (uart_instance != NULL)
     {
         stdio_set_driver_enabled(&stdio_uart, false);
+        uart_tx_wait_blocking(uart_instance);
         uart_deinit(uart_instance);
         uart_instance = NULL;
     }

--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -9,7 +9,7 @@
 #include "pico/binary_info.h"
 #include "hardware/gpio.h"
 
-static uart_inst_t *uart_instance;
+static uart_inst_t *uart_instance = NULL;
 
 #if PICO_NO_BI_STDIO_UART
 #define stdio_bi_decl_if_func_used(x)
@@ -74,6 +74,15 @@ void stdio_uart_init_full(struct uart_inst *uart, uint baud_rate, int tx_pin, in
     if (tx_pin >= 0) gpio_set_function((uint)tx_pin, GPIO_FUNC_UART);
     if (rx_pin >= 0) gpio_set_function((uint)rx_pin, GPIO_FUNC_UART);
     stdio_set_driver_enabled(&stdio_uart, true);
+}
+
+void stdio_uart_deinit() {
+    if (uart_instance != NULL)
+    {
+        stdio_set_driver_enabled(&stdio_uart, false);
+        uart_deinit(uart_instance);
+        uart_instance = NULL;
+    }
 }
 
 static void stdio_uart_out_chars(const char *buf, int length) {

--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -77,12 +77,30 @@ void stdio_uart_init_full(struct uart_inst *uart, uint baud_rate, int tx_pin, in
 }
 
 void stdio_uart_deinit() {
+    int tx_pin = -1;
+    int rx_pin = -1;
+#ifdef PICO_DEFAULT_UART_TX_PIN
+    tx_pin = PICO_DEFAULT_UART_TX_PIN;
+#endif
+#ifdef PICO_DEFAULT_UART_RX_PIN
+    rx_pin = PICO_DEFAULT_UART_RX_PIN;
+#endif
+    stdio_uart_deinit_full(tx_pin, rx_pin);
+}
+
+void stdio_uart_deinit_full(int tx_pin, int rx_pin)
+{
     if (uart_instance != NULL)
     {
         stdio_set_driver_enabled(&stdio_uart, false);
         uart_tx_wait_blocking(uart_instance);
         uart_deinit(uart_instance);
         uart_instance = NULL;
+
+        if (tx_pin != -1)
+            gpio_deinit(tx_pin);
+        if (rx_pin != -1)
+            gpio_deinit(rx_pin);
     }
 }
 

--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -97,10 +97,10 @@ void stdio_uart_deinit_full(int tx_pin, int rx_pin)
         uart_deinit(uart_instance);
         uart_instance = NULL;
 
-        if (tx_pin != -1)
-            gpio_deinit(tx_pin);
-        if (rx_pin != -1)
-            gpio_deinit(rx_pin);
+        if (tx_pin >= 0)
+            gpio_deinit((uint)tx_pin);
+        if (rx_pin >= 0)
+            gpio_deinit((uint)rx_pin);
     }
 }
 


### PR DESCRIPTION
Fixes #810 by adding stdio_uart_deinit.

I would have liked to undo the pin init from `stdio_uart_init_full()` as well but we dont keep track of the pins. Could probably go through all pins, check which ones have uart as function and deinit those. But is that something we want?