### PR TITLE
Suppress false GCC 11 warning on TinyUSB

### DIFF
--- a/src/rp2_common/tinyusb/CMakeLists.txt
+++ b/src/rp2_common/tinyusb/CMakeLists.txt
@@ -45,5 +45,13 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
     pico_add_impl_library(tinyusb_board)
     target_link_libraries(tinyusb_board INTERFACE tinyusb_bsp)
 
+    # Override suppress_tinyusb_warnings to add suppression of (falsely) reported GCC 11.2 warnings
+    function(suppress_tinyusb_warnings)
+        _suppress_tinyusb_warnings()
+        set_source_files_properties(
+                ${PICO_TINYUSB_PATH}/src/portable/raspberrypi/rp2040/rp2040_usb.c
+                PROPERTIES
+                COMPILE_FLAGS "-Wno-stringop-overflow -Wno-array-bounds")
+    endfunction()
     pico_promote_common_scope_vars()
 endif()


### PR DESCRIPTION
Note this should be undone when fixed in upstream TinyUSB