### PR TITLE
Pass PIOASM_EXTRA_SOURCE_FILES to Pioasm sub-cmake and add OUTPUT_FORMAT option (fixes #827)

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,14 +4,15 @@ function(_pico_init_pioasm)
     find_package(Pioasm REQUIRED)
 endfunction()
 
+# PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, default output format used by pioasm when using pico_generate_pio_header, group=build
 function(pico_generate_pio_header TARGET PIO)
     _pico_init_pioasm()
     cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR" "" ${ARGN} )
 
     if (pico_generate_pio_header_OUTPUT_FORMAT)
         set(OUTPUT_FORMAT "${pico_generate_pio_header_OUTPUT_FORMAT}")
-    elseif(DEFINED PIOASM_DEFAULT_OUTPUT_FORMAT)
-        set(OUTPUT_FORMAT "${PIOASM_DEFAULT_OUTPUT_FORMAT}")
+    elseif(DEFINED PICO_DEFAULT_PIOASM_OUTPUT_FORMAT)
+        set(OUTPUT_FORMAT "${PICO_DEFAULT_PIOASM_OUTPUT_FORMAT}")
     else()
         set(OUTPUT_FORMAT "c-sdk")
     endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,7 +6,13 @@ endfunction()
 
 function(pico_generate_pio_header TARGET PIO)
     _pico_init_pioasm()
-    cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_DIR" "" ${ARGN} )
+    cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR" "" ${ARGN} )
+
+    if (pico_generate_pio_header_OUTPUT_FORMAT)
+        set(OUTPUT_FORMAT "${pico_generate_pio_header_OUTPUT_FORMAT}")
+    else()
+        set(OUTPUT_FORMAT "c-sdk")
+    endif()
 
     if (pico_generate_pio_header_OUTPUT_DIR)
         get_filename_component(HEADER_DIR ${pico_generate_pio_header_OUTPUT_DIR} ABSOLUTE)
@@ -23,7 +29,7 @@ function(pico_generate_pio_header TARGET PIO)
 
     add_custom_command(OUTPUT ${HEADER}
             DEPENDS ${PIO}
-            COMMAND Pioasm -o c-sdk ${PIO} ${HEADER}
+            COMMAND Pioasm -o ${OUTPUT_FORMAT} ${PIO} ${HEADER}
             )
     add_dependencies(${TARGET} ${HEADER_GEN_TARGET})
     get_target_property(target_type ${TARGET} TYPE)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,7 @@ function(_pico_init_pioasm)
     find_package(Pioasm REQUIRED)
 endfunction()
 
-# PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, default output format used by pioasm when using pico_generate_pio_header, group=build
+# PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, default output format used by pioasm when using pico_generate_pio_header, default=c-sdk, group=build
 function(pico_generate_pio_header TARGET PIO)
     _pico_init_pioasm()
     cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR" "" ${ARGN} )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,8 @@ function(pico_generate_pio_header TARGET PIO)
 
     if (pico_generate_pio_header_OUTPUT_FORMAT)
         set(OUTPUT_FORMAT "${pico_generate_pio_header_OUTPUT_FORMAT}")
+    elseif(DEFINED PIOASM_DEFAULT_OUTPUT_FORMAT)
+        set(OUTPUT_FORMAT "${PIOASM_DEFAULT_OUTPUT_FORMAT}")
     else()
         set(OUTPUT_FORMAT "c-sdk")
     endif()

--- a/tools/FindPioasm.cmake
+++ b/tools/FindPioasm.cmake
@@ -29,6 +29,7 @@ if (NOT Pioasm_FOUND)
                 BINARY_DIR ${PIOASM_BINARY_DIR}
                 BUILD_ALWAYS 1 # force dependency checking
                 INSTALL_COMMAND ""
+                CMAKE_CACHE_ARGS "-DPIOASM_EXTRA_SOURCE_FILES:STRING=${PIOASM_EXTRA_SOURCE_FILES}"
                 )
     endif()
 


### PR DESCRIPTION
This PR changes `FindPioasm.cmake` to pass through the PIOASM_EXTRA_SOURCE_FILES variable, so that it is actually able to be changed by users of the SDK without modifying it.

This PR also adds an OUTPUT_FORMAT option to `pico_generate_pio_header` that sets the output format used so users can also easily use their custom output formats.

Example usage:
```
file(GLOB pioasm-sources pioasm-extensions/*.cpp)
set(PIOASM_EXTRA_SOURCE_FILES ${pioasm-sources})

pico_generate_pio_header(my-target thing.pio OUTPUT_FORMAT sdk-custom)
```