### PR TITLE
Add board definition for the RP2040 Stamp Round Carrier

### DIFF
--- a/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
+++ b/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
@@ -26,6 +26,9 @@
 #endif
 
 // --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
 #ifndef PICO_DEFAULT_UART_TX_PIN
 #define PICO_DEFAULT_UART_TX_PIN 16
 #endif
@@ -39,6 +42,9 @@
 #endif
 
 // --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C       0
+#endif
 #ifndef PICO_DEFAULT_I2C_SDA_PIN
 #define PICO_DEFAULT_I2C_SDA_PIN   0
 #endif

--- a/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
+++ b/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
@@ -36,9 +36,14 @@
 #define PICO_DEFAULT_UART_RX_PIN 17
 #endif
 
-// --- Neopixel ---
+// --- Neopixel Ring ---
 #ifndef PICO_DEFAULT_WS2812_PIN
 #define PICO_DEFAULT_WS2812_PIN 24
+#endif
+
+// --- On-Stamp Neopixel ---
+#ifndef PICO_STAMP_WS2812_PIN
+#define PICO_STAMP_WS2812_PIN 21
 #endif
 
 // --- I2C ---

--- a/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
+++ b/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
@@ -42,8 +42,8 @@
 #endif
 
 // --- On-Stamp Neopixel ---
-#ifndef PICO_STAMP_WS2812_PIN
-#define PICO_STAMP_WS2812_PIN 21
+#ifndef SOLDERPARTY_RP2040_STAMP_WS2812_PIN
+#define SOLDERPARTY_RP2040_STAMP_WS2812_PIN 21
 #endif
 
 // --- I2C ---

--- a/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
+++ b/src/boards/include/boards/solderparty_rp2040_stamp_round_carrier.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2022 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+//
+//------------------------------------------------------------------------------------------
+// Board definition for the Solder Party RP2040 Stamp Round Carrier
+//
+// This header may be included by other board headers as "boards/solderparty_rp2040_stamp_round_carrier.h"
+
+#ifndef _BOARDS_SOLDERPARTY_RP2040_STAMP_ROUND_CARRIER_H
+#define _BOARDS_SOLDERPARTY_RP2040_STAMP_ROUND_CARRIER_H
+
+// For board detection
+#define SOLDERPARTY_RP2040_STAMP_ROUND_CARRIER
+
+// --- User LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN   25
+#endif
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 17
+#endif
+
+// --- Neopixel ---
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 24
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN   0
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN   1
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 1
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 10
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 11
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 8
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 9
+#endif
+
+#include "solderparty_rp2040_stamp.h"
+
+#endif


### PR DESCRIPTION
The file modifies a few pins and then includes the stamp board file.

Details about the board available here: https://www.solder.party/docs/rp2040-stamp/round-
carrier/