### PR TITLE
Add some optional header includes, to make per-target changes to config easier

### DIFF
--- a/src/common/pico_base/include/pico.h
+++ b/src/common/pico_base/include/pico.h
@@ -22,7 +22,7 @@
 #include "pico/types.h"
 #include "pico/version.h"
 
-// PICO_CONFIG: PICO_CONFIG_HEADER, path to header include in place of the default pico/config.h which may be desirable for build systems which can't easily generate the config_autogen header, type=string, default=none, group=pico_base
+// PICO_CONFIG: PICO_CONFIG_HEADER, unquoted path to header include in place of the default pico/config.h which may be desirable for build systems which can't easily generate the config_autogen header, default=none, group=pico_base
 #ifdef PICO_CONFIG_HEADER
 #include __PICO_XSTRING(PICO_CONFIG_HEADER)
 #else

--- a/src/common/pico_base/include/pico.h
+++ b/src/common/pico_base/include/pico.h
@@ -16,9 +16,18 @@
  * This header may be included by assembly code
 */
 
+#define	__PICO_STRING(x)	#x
+#define	__PICO_XSTRING(x)	__PICO_STRING(x)
+
 #include "pico/types.h"
 #include "pico/version.h"
+
+// PICO_CONFIG: PICO_CONFIG_HEADER, path to header include in place of the default pico/config.h which may be desirable for build systems which can't easily generate the config_autogen header, type=string, default=none, group=pico_base
+#ifdef PICO_CONFIG_HEADER
+#include __PICO_XSTRING(PICO_CONFIG_HEADER)
+#else
 #include "pico/config.h"
+#endif
 #include "pico/platform.h"
 #include "pico/error.h"
 

--- a/src/common/pico_base/include/pico/config.h
+++ b/src/common/pico_base/include/pico/config.h
@@ -18,4 +18,9 @@
 
 #include "pico/config_autogen.h"
 
+// PICO_CONFIG: PICO_CONFIG_RTOS_ADAPTER_HEADER, path to header include in the default pico/config.h for RTOS integration defines that must be included in all sources, type=string, default=none, group=pico_base
+#ifdef PICO_CONFIG_RTOS_ADAPTER_HEADER
+#include __PICO_XSTRING(PICO_CONFIG_RTOS_ADAPTER_HEADER)
+#endif
+
 #endif

--- a/src/common/pico_base/include/pico/config.h
+++ b/src/common/pico_base/include/pico/config.h
@@ -18,7 +18,7 @@
 
 #include "pico/config_autogen.h"
 
-// PICO_CONFIG: PICO_CONFIG_RTOS_ADAPTER_HEADER, path to header include in the default pico/config.h for RTOS integration defines that must be included in all sources, type=string, default=none, group=pico_base
+// PICO_CONFIG: PICO_CONFIG_RTOS_ADAPTER_HEADER, unquoted path to header include in the default pico/config.h for RTOS integration defines that must be included in all sources, default=none, group=pico_base
 #ifdef PICO_CONFIG_RTOS_ADAPTER_HEADER
 #include __PICO_XSTRING(PICO_CONFIG_RTOS_ADAPTER_HEADER)
 #endif


### PR DESCRIPTION
The main motivation here is to allow inclusion of FreeRTOS on a per target basis, rather than as a project wide thing.
It also allows FreeRTOS to be added at any point in the `CMakeLists.txt`s (rather than just before `pico_sdk_init`) which is much more natural if only a sub-part of your project uses it