### PR TITLE
move get_core_num() into platform.h

### DIFF
--- a/src/host/hardware_sync/include/hardware/sync.h
+++ b/src/host/hardware_sync/include/hardware/sync.h
@@ -86,8 +86,6 @@ bool is_spin_locked(const spin_lock_t *lock);
 
 void spin_unlock(spin_lock_t *lock, uint32_t saved_irq);
 
-uint get_core_num();
-
 spin_lock_t *spin_lock_init(uint lock_num);
 
 void clear_spin_locks(void);

--- a/src/host/pico_platform/include/pico/platform.h
+++ b/src/host/pico_platform/include/pico/platform.h
@@ -139,6 +139,9 @@ static inline int32_t __mul_instruction(int32_t a,int32_t b)
 
 static inline void __compiler_memory_barrier(void) {
 }
+
+uint get_core_num();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/hardware_sync/include/hardware/sync.h
+++ b/src/rp2_common/hardware_sync/include/hardware/sync.h
@@ -304,15 +304,6 @@ __force_inline static void spin_unlock(spin_lock_t *lock, uint32_t saved_irq) {
     restore_interrupts(saved_irq);
 }
 
-/*! \brief Get the current core number
- *  \ingroup hardware_sync
- *
- * \return The core number the call was made from
- */
-__force_inline static uint get_core_num(void) {
-    return (*(uint32_t *) (SIO_BASE + SIO_CPUID_OFFSET));
-}
-
 /*! \brief Initialise a spin lock
  *  \ingroup hardware_sync
  *

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -17,6 +17,8 @@
  */
 
 #include "hardware/platform_defs.h"
+#include "hardware/regs/addressmap.h"
+#include "hardware/regs/sio.h"
 
 // Marker for builds targeting the RP2040
 #define PICO_RP2040 1
@@ -421,6 +423,15 @@ static inline void busy_wait_at_least_cycles(uint32_t minimum_cycles) {
         "bcs 1b\n"
         : "+r" (minimum_cycles) : : "memory"
     );
+}
+
+/*! \brief Get the current core number
+ *  \ingroup hardware_sync
+ *
+ * \return The core number the call was made from
+ */
+__force_inline static uint get_core_num(void) {
+    return (*(uint32_t *) (SIO_BASE + SIO_CPUID_OFFSET));
 }
 
 #else // __ASSEMBLER__


### PR DESCRIPTION
It was previously in hardware_sync because it was believed to be only used for inter core stuff, but it is also useful elsewhere