### PR TITLE
Fix up filename displayed by extract_configs.py when an invalid attribute is found

### DIFF
--- a/tools/extract_configs.py
+++ b/tools/extract_configs.py
@@ -38,7 +38,7 @@ all_defines = {}
 
 
 
-def ValidateAttrs(config_attrs):
+def ValidateAttrs(config_attrs, file_path, linenum):
     _type = config_attrs.get('type', 'int')
 
     # Validate attrs
@@ -192,26 +192,31 @@ for d in all_defines:
         if val in all_defines:
             resolved_defines[d] = all_defines[val]
 
-for config_name in all_configs:
+for config_name, config_obj in all_configs.items():
+    file_path = os.path.join(scandir, config_obj['filename'])
+    linenum = config_obj['line_number']
 
-    ValidateAttrs(all_configs[config_name]['attrs'])
+    ValidateAttrs(config_obj['attrs'], file_path, linenum)
 
     # Check that default values match up
-    if 'default' in all_configs[config_name]['attrs']:
+    if 'default' in config_obj['attrs']:
+        config_default = config_obj['attrs']['default']
         if config_name in all_defines:
-            if all_configs[config_name]['attrs']['default'] not in all_defines[config_name] and (config_name not in resolved_defines or all_configs[config_name]['attrs']['default'] not in resolved_defines[config_name]):
-                if '/' in all_configs[config_name]['attrs']['default'] or ' ' in all_configs[config_name]['attrs']['default']:
+            defines_obj = all_defines[config_name]
+            if config_default not in defines_obj and (config_name not in resolved_defines or config_default not in resolved_defines[config_name]):
+                if '/' in config_default or ' ' in config_default:
                     continue
                 # There _may_ be multiple matching defines, but arbitrarily display just one in the error message
-                first_define_value = list(all_defines[config_name].keys())[0]
-                raise Exception('Found {} at {}:{} with a default of {}, but #define says {} (at {}:{})'.format(config_name, os.path.join(scandir, all_configs[config_name]['filename']), all_configs[config_name]['line_number'], all_configs[config_name]['attrs']['default'], first_define_value, all_defines[config_name][first_define_value][0], all_defines[config_name][first_define_value][1]))
+                first_define_value = list(defines_obj.keys())[0]
+                first_define_file_path, first_define_linenum = defines_obj[first_define_value]
+                raise Exception('Found {} at {}:{} with a default of {}, but #define says {} (at {}:{})'.format(config_name, file_path, linenum, config_default, first_define_value, first_define_file_path, first_define_linenum))
         else:
-            raise Exception('Found {} at {}:{} with a default of {}, but no matching #define found'.format(config_name, os.path.join(scandir, all_configs[config_name]['filename']), all_configs[config_name]['line_number'], all_configs[config_name]['attrs']['default']))
+            raise Exception('Found {} at {}:{} with a default of {}, but no matching #define found'.format(config_name, file_path, linenum, config_default))
 
 with open(outfile, 'w', newline='') as csvfile:
     fieldnames = ('name', 'location', 'description', 'type') + tuple(sorted(all_attrs - set(['type'])))
     writer = csv.DictWriter(csvfile, fieldnames=fieldnames, extrasaction='ignore', dialect='excel-tab')
 
     writer.writeheader()
-    for config_name in sorted(all_configs):
-        writer.writerow({'name': config_name, 'location': '{}:{}'.format(all_configs[config_name]['filename'], all_configs[config_name]['line_number']), 'description': all_configs[config_name]['description'], **all_configs[config_name]['attrs']})
+    for config_name, config_obj in sorted(all_configs.items()):
+        writer.writerow({'name': config_name, 'location': '{}:{}'.format(config_obj['filename'], config_obj['line_number']), 'description': config_obj['description'], **config_obj['attrs']})


### PR DESCRIPTION
(and tidy up the code a bit at the same time)

I'd forgotten to pass the `file_path` and `linenum` into the `ValidateAttrs` function :man_facepalming: 