### PR TITLE
Don't copy .data for NO_FLASH binaries, as it's loaded in-place

### DIFF
--- a/src/rp2_common/pico_standard_link/crt0.S
+++ b/src/rp2_common/pico_standard_link/crt0.S
@@ -225,6 +225,9 @@ _reset_handler:
     cmp r0, #0
     bne hold_non_core0_in_bootrom
 
+    // In a NO_FLASH binary, don't perform .data copy, since it's loaded
+    // in-place by the SRAM load. Still need to clear .bss
+#if !PICO_NO_FLASH
     adr r4, data_cpy_table
 
     // assume there is at least one entry
@@ -235,6 +238,7 @@ _reset_handler:
     bl data_cpy
     b 1b
 2:
+#endif
 
     // Zero out the BSS
     ldr r1, =__bss_start__
@@ -266,6 +270,7 @@ _exit:
     bkpt #0
     b 1b
 
+#if !PICO_NO_FLASH
 data_cpy_loop:
     ldm r1!, {r0}
     stm r2!, {r0}
@@ -273,6 +278,10 @@ data_cpy:
     cmp r2, r3
     blo data_cpy_loop
     bx lr
+#endif
+
+// Note the data copy table is still included for NO_FLASH builds, even though
+// we skip the copy, because it is listed in binary info
 
 .align 2
 data_cpy_table:


### PR DESCRIPTION
Realised we are doing a redundant copy of `.data` and friends for NO_FLASH builds, even though these sections are already loaded in-place. This patch should save a few bytes, and possibly some thousands of cycles at boot.