### PR TITLE
Wrap realloc() call with malloc_mutex in multicore

### DIFF
--- a/src/rp2_common/pico_malloc/CMakeLists.txt
+++ b/src/rp2_common/pico_malloc/CMakeLists.txt
@@ -10,6 +10,7 @@ if (NOT TARGET pico_malloc)
 
     pico_wrap_function(pico_malloc malloc)
     pico_wrap_function(pico_malloc calloc)
+    pico_wrap_function(pico_malloc realloc)
     pico_wrap_function(pico_malloc free)
 
     target_link_libraries(pico_malloc INTERFACE pico_sync)


### PR DESCRIPTION
Protect against heap corruption by mutex-protecting the realloc() call
(like malloc/free are already).

Fixes #863
Fixes https://github.com/maxgerhardt/platform-raspberrypi/issues/7
Fixes https://github.com/earlephilhower/arduino-pico/issues/614