### PR TITLE
Remove 'default=none' from PICO_CONFIG lines

### DIFF
--- a/src/common/pico_base/include/pico.h
+++ b/src/common/pico_base/include/pico.h
@@ -22,7 +22,7 @@
 #include "pico/types.h"
 #include "pico/version.h"
 
-// PICO_CONFIG: PICO_CONFIG_HEADER, unquoted path to header include in place of the default pico/config.h which may be desirable for build systems which can't easily generate the config_autogen header, default=none, group=pico_base
+// PICO_CONFIG: PICO_CONFIG_HEADER, unquoted path to header include in place of the default pico/config.h which may be desirable for build systems which can't easily generate the config_autogen header, group=pico_base
 #ifdef PICO_CONFIG_HEADER
 #include __PICO_XSTRING(PICO_CONFIG_HEADER)
 #else

--- a/src/common/pico_base/include/pico/config.h
+++ b/src/common/pico_base/include/pico/config.h
@@ -18,7 +18,7 @@
 
 #include "pico/config_autogen.h"
 
-// PICO_CONFIG: PICO_CONFIG_RTOS_ADAPTER_HEADER, unquoted path to header include in the default pico/config.h for RTOS integration defines that must be included in all sources, default=none, group=pico_base
+// PICO_CONFIG: PICO_CONFIG_RTOS_ADAPTER_HEADER, unquoted path to header include in the default pico/config.h for RTOS integration defines that must be included in all sources, group=pico_base
 #ifdef PICO_CONFIG_RTOS_ADAPTER_HEADER
 #include __PICO_XSTRING(PICO_CONFIG_RTOS_ADAPTER_HEADER)
 #endif


### PR DESCRIPTION
The `default=none` isn't required, and actually causes an error with `tools/extract_configs.py` currently.