### PR TITLE
Add DatanoiseTV DSP Board.

### DIFF
--- a/src/boards/include/boards/datanoisetv_rp2040_dsp.h
+++ b/src/boards/include/boards/datanoisetv_rp2040_dsp.h
@@ -20,17 +20,6 @@
 // For board detection
 #define DATANOISETV_RP2040_DSP
 
-// --- UART ---
-#ifndef PICO_DEFAULT_UART
-#define PICO_DEFAULT_UART 0
-#endif
-#ifndef PICO_DEFAULT_UART_TX_PIN
-#define PICO_DEFAULT_UART_TX_PIN 0
-#endif
-#ifndef PICO_DEFAULT_UART_RX_PIN
-#define PICO_DEFAULT_UART_RX_PIN 1
-#endif
-
 // --- I2C ---
 #ifndef PICO_DEFAULT_I2C
 #define PICO_DEFAULT_I2C       0

--- a/src/boards/include/boards/datanoisetv_rp2040_dsp.h
+++ b/src/boards/include/boards/datanoisetv_rp2040_dsp.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+//
+//------------------------------------------------------------------------------------------
+// Board definition for the DatanoiseTV RP2040 DSP Board
+//
+// This header may be included by other board headers as "boards/datanoisetv_rp2040_dsp.h"
+
+#ifndef _BOARDS_DATANOISETV_RP2040_DSP_H
+#define _BOARDS_DATANOISETV_RP2040_DSP_H
+
+// For board detection
+#define DATANOISETV_RP2040_DSP
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C       0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN   24 
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN   25
+#endif
+
+// -- FLASH --
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+
+// --- I2S ---
+#ifndef PICO_AUDIO_I2S_DATA_PIN
+#define PICO_AUDIO_I2S_DATA_PIN 16
+#endif
+#ifndef PICO_AUDIO_I2S_CLOCK_PIN_BASE
+#define PICO_AUDIO_I2S_CLOCK_PIN_BASE 17
+#endif
+
+#include "boards/pico.h"
+
+#endif


### PR DESCRIPTION
Adds the DatanoiseTV RP2040 Audio DSP board.
https://twitter.com/DatanoiseTV/status/1536705299964481540