### PR TITLE
stdio_usb improvements

### DIFF
--- a/src/rp2_common/hardware_irq/include/hardware/irq.h
+++ b/src/rp2_common/hardware_irq/include/hardware/irq.h
@@ -252,6 +252,14 @@ void irq_add_shared_handler(uint num, irq_handler_t handler, uint8_t order_prior
  */
 void irq_remove_handler(uint num, irq_handler_t handler);
 
+/*! \brief Determine if the current handler for the given number is shared
+ *  \ingroup hardware_irq
+ *
+ * \param num Interrupt number \ref interrupt_nums
+ * \param return true if the specified IRQ has a shared handler
+ */
+bool irq_has_shared_handler(uint num);
+
 /*! \brief Get the current IRQ handler for the specified IRQ from the currently installed hardware vector table (VTOR)
  * of the execution core
  *  \ingroup hardware_irq

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -95,9 +95,20 @@ static int8_t irq_hander_chain_free_slot_head;
 static inline bool is_shared_irq_raw_handler(irq_handler_t raw_handler) {
     return (uintptr_t)raw_handler - (uintptr_t)irq_handler_chain_slots < sizeof(irq_handler_chain_slots);
 }
+
+bool irq_has_shared_handler(uint irq_num) {
+    check_irq_param(irq_num);
+    irq_handler_t handler = irq_get_vtable_handler(irq_num);
+    return handler && is_shared_irq_raw_handler(handler);
+}
+
 #else
 #define is_shared_irq_raw_handler(h) false
+bool irq_has_shared_handler(uint irq_num) {
+    return false;
+}
 #endif
+
 
 irq_handler_t irq_get_vtable_handler(uint num) {
     check_irq_param(num);

--- a/src/rp2_common/pico_stdio_usb/include/tusb_config.h
+++ b/src/rp2_common/pico_stdio_usb/include/tusb_config.h
@@ -29,6 +29,7 @@
 
 #include "pico/stdio_usb.h"
 
+#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
 #define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE)
 
 #define CFG_TUD_CDC             (1)
@@ -37,4 +38,6 @@
 
 // We use a vendor specific interface but with our own driver
 #define CFG_TUD_VENDOR            (0)
+#endif
+
 #endif

--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -7,6 +7,8 @@
 
 #include "pico/bootrom.h"
 
+#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
+
 #if PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE && !(PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL || PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT)
 #warning PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE has been selected but neither PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL nor PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT have been selected.
 #endif
@@ -110,3 +112,4 @@ void tud_cdc_line_coding_cb(__unused uint8_t itf, cdc_line_coding_t const* p_lin
 }
 #endif
 
+#endif

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -112,7 +112,7 @@ stdio_driver_t stdio_usb = {
 
 bool stdio_usb_init(void) {
 #ifndef NDEBUG
-    stdio_usb_core_num = get_core_num();
+    stdio_usb_core_num = (uint8_t)get_core_num();
 #endif
 #if !PICO_NO_BI_STDIO_USB
     bi_decl_if_func_used(bi_program_feature("USB stdin / stdout"));

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -10,7 +10,7 @@
 
 // these may not be set if the user is providing tud support (i.e. LIB_TINYUSB_DEVICE is 1 because
 // the user linked in tinyusb_device) but they haven't selected CDC
-#if CFG_TUD_ENABLED && CFG_TUD_CDC
+#if (CFG_TUD_ENABLED | TUSB_OPT_DEVICE_ENABLED) && CFG_TUD_CDC
 
 #include "pico/binary_info.h"
 #include "pico/time.h"


### PR DESCRIPTION
* Use shared IRQ if available to avoid 1ms timer. 
* Allow use of stdio_usb with user's tinyusb setup if it has CDC