### PR TITLE
Fix auto_init_recursive_mutex definition for C++

### DIFF
--- a/src/common/pico_sync/include/pico/mutex.h
+++ b/src/common/pico_sync/include/pico/mutex.h
@@ -289,7 +289,7 @@ static inline bool recursive_mutex_is_initialized(recursive_mutex_t *mtx) {
  *
  * But the initialization of the mutex is performed automatically during runtime initialization
  */
-#define auto_init_recursive_mutex(name) static __attribute__((section(".mutex_array"))) recursive_mutex_t name = { .core.spin_lock = (spin_lock_t *)1 /* marker for runtime_init */ }
+#define auto_init_recursive_mutex(name) static __attribute__((section(".mutex_array"))) recursive_mutex_t name = { .core = { .spin_lock = (spin_lock_t *)1 /* marker for runtime_init */ }, .owner = 0, .enter_count = 0 }
 
 #ifdef __cplusplus
 }

--- a/test/kitchen_sink/kitchen_sink.c
+++ b/test/kitchen_sink/kitchen_sink.c
@@ -110,6 +110,9 @@ __force_inline int something_inlined(int x) {
     return x * 2;
 }
 
+auto_init_mutex(mutex);
+auto_init_recursive_mutex(recursive_mutex);
+
 int main(void) {
     spiggle();
 
@@ -118,6 +121,12 @@ int main(void) {
     printf("HI %d\n", something_inlined((int)time_us_32()));
     puts("Hello Everything!");
     puts("Hello Everything2!");
+
+    assert(mutex_try_enter(&mutex, NULL));
+    assert(!mutex_try_enter(&mutex, NULL));
+    assert(recursive_mutex_try_enter(&recursive_mutex, NULL));
+    assert(recursive_mutex_try_enter(&recursive_mutex, NULL));
     // this should compile as we are Cortex M0+
     __asm volatile("SVC #3");
+
 }

--- a/test/kitchen_sink/kitchen_sink.c
+++ b/test/kitchen_sink/kitchen_sink.c
@@ -122,10 +122,10 @@ int main(void) {
     puts("Hello Everything!");
     puts("Hello Everything2!");
 
-    assert(mutex_try_enter(&mutex, NULL));
-    assert(!mutex_try_enter(&mutex, NULL));
-    assert(recursive_mutex_try_enter(&recursive_mutex, NULL));
-    assert(recursive_mutex_try_enter(&recursive_mutex, NULL));
+    hard_assert(mutex_try_enter(&mutex, NULL));
+    hard_assert(!mutex_try_enter(&mutex, NULL));
+    hard_assert(recursive_mutex_try_enter(&recursive_mutex, NULL));
+    hard_assert(recursive_mutex_try_enter(&recursive_mutex, NULL));
     // this should compile as we are Cortex M0+
     __asm volatile("SVC #3");
 


### PR DESCRIPTION
When compiling in C++, the definition of `auto_init_recursive_mutex` fails due to the way nested structures are initialized.

Explicitly initialize the nested structures (and add default values to other fields to avoid uninitialized element warnings).

This change builds fine on both C and C++ and fixes #874 .