### PR TITLE
Fix GPIO # callback parameter

### DIFF
--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -152,7 +152,7 @@ static void gpio_default_irq_handler(void) {
             if (events && !(raw_irq_mask[core] & (1u << i))) {
                 gpio_acknowledge_irq(i, events);
                 if (callback) {
-                    callback(gpio, events);
+                    callback(i, events);
                 }
             }
             events8 >>= 4;


### PR DESCRIPTION
Fixes #879

Correctly returns `i`, the actual GPIO number, and not the GPIO set-of-8 we're scanning.

Tested to fix https://github.com/earlephilhower/arduino-pico/issues/651