### PR TITLE
Fix #884: widen preprocessor-if to hide unused functions

### DIFF
--- a/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c
+++ b/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c
@@ -12,6 +12,8 @@
 #include "hardware/structs/padsbank0.h"
 #include "pico/fix/rp2040_usb_device_enumeration.h"
 
+#if PICO_RP2040_B0_SUPPORTED || PICO_RP2040_B1_SUPPORTED
+
 #define LS_SE0 0b00
 #define LS_J   0b01
 #define LS_K   0b10
@@ -22,7 +24,6 @@ static void hw_enumeration_fix_force_ls_j(void);
 static void hw_enumeration_fix_finish(void);
 
 void rp2040_usb_device_enumeration_fix(void) {
-#if PICO_RP2040_B0_SUPPORTED || PICO_RP2040_B1_SUPPORTED
     // Actually check for B0/B1 h/w
     if (rp2040_chip_version() == 1) {
         // After coming out of reset, the hardware expects 800us of LS_J (linestate J) time
@@ -36,7 +37,6 @@ void rp2040_usb_device_enumeration_fix(void) {
         // Wait SE0 phase will call force ls_j phase which will call finish phase
         hw_enumeration_fix_wait_se0();
     }
-#endif
 }
 
 static inline uint8_t hw_line_state(void) {
@@ -146,3 +146,10 @@ static void hw_enumeration_fix_finish(void) {
     // Restore the pad ctrl value
     padsbank0_hw->io[dp] = pad_ctrl_prev;
 }
+
+#else
+
+void rp2040_usb_device_enumeration_fix(void) {
+}
+
+#endif // PICO_RP2040_B0_SUPPORTED || PICO_RP2040_B1_SUPPORTED


### PR DESCRIPTION
Cosmetic fix to silence some compiler warnings re unused functions: just ifdef-off more functions.