### PR TITLE
Rename FLASH_BLOCK_SIZE to prevent conflict with CYW43xx driver. Fixes #900

### DIFF
--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -78,7 +78,7 @@ void __no_inline_not_in_flash_func(flash_range_erase)(uint32_t flash_offs, size_
 
     connect_internal_flash();
     flash_exit_xip();
-    flash_range_erase(flash_offs, count, FLASH_BLOCK_SIZE, FLASH_BLOCK_ERASE_CMD);
+    flash_range_erase(flash_offs, count, PICO_FLASH_BLOCK_SIZE, FLASH_BLOCK_ERASE_CMD);
     flash_flush_cache(); // Note this is needed to remove CSn IO force as well as cache flushing
     flash_enable_xip_via_boot2();
 }

--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -40,7 +40,7 @@
 
 #define FLASH_PAGE_SIZE (1u << 8)
 #define FLASH_SECTOR_SIZE (1u << 12)
-#define FLASH_BLOCK_SIZE (1u << 16)
+#define PICO_FLASH_BLOCK_SIZE (1u << 16)
 
 #define FLASH_UNIQUE_ID_SIZE_BYTES 8
 


### PR DESCRIPTION
See #900 for full description. This PR is a simple rename of the `FLASH_BLOCK_SIZE` macro to `PICO_FLASH_BLOCK_SIZE`. I considered `RP2_FLASH_BLOCK_SIZE` too, but there is already a `PICO_FLASH_SIZE_BYTES` macro, so `PICO_FLASH_BLOCK_SIZE` seemed most appropriate.