### PR TITLE
Fix various typos in CMake CONFIG lines

### DIFF
--- a/cmake/pico_pre_load_platform.cmake
+++ b/cmake/pico_pre_load_platform.cmake
@@ -13,7 +13,7 @@ endif ()
 
 set(PICO_PLATFORM ${PICO_PLATFORM} CACHE STRING "PICO Build platform (e.g. rp2040, host)")
 
-# PICO_CMAKE_CONFIG: PICO_CMAKE_RELOAD_PLATFORM_FILE, custom CMake file to use to set up the platform environment, default=none, group=build
+# PICO_CMAKE_CONFIG: PICO_CMAKE_PRELOAD_PLATFORM_FILE, custom CMake file to use to set up the platform environment, default=none, group=build
 set(PICO_CMAKE_PRELOAD_PLATFORM_FILE "" CACHE INTERNAL "")
 set(PICO_CMAKE_PRELOAD_PLATFORM_DIR "${CMAKE_CURRENT_LIST_DIR}/preload/platforms" CACHE INTERNAL "")
 

--- a/pico_sdk_version.cmake
+++ b/pico_sdk_version.cmake
@@ -1,18 +1,18 @@
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_MAJOR, SDK major version number, type=int, group=pico_base
-# PICO_CONFIG: PICO_SDK_VERSION_MAJOR, SDK major version number, type=int, group=pico_base
+# PICO_CMAKE_CONFIG: PICO_SDK_VERSION_MAJOR, SDK major version number, type=int, group=pico_base
 set(PICO_SDK_VERSION_MAJOR 1)
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_MINOR, SDK minor version number, type=int, group=pico_base
-# PICO_CONFIG: PICO_SDK_VERSION_MINOR, SDK minor version number, type=int, group=pico_base
+# PICO_CMAKE_CONFIG: PICO_SDK_VERSION_MINOR, SDK minor version number, type=int, group=pico_base
 set(PICO_SDK_VERSION_MINOR 4)
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_REVISION, SDK version revision, type=int, group=pico_base
-# PICO_CONFIG: PICO_SDK_VERSION_REVISION, SDK version revision, type=int, group=pico_base
+# PICO_CMAKE_CONFIG: PICO_SDK_VERSION_REVISION, SDK version revision, type=int, group=pico_base
 set(PICO_SDK_VERSION_REVISION 1)
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_PRE_RELEASE_ID, optional SDK pre-release version identifier, type=string, group=pico_base
-# PICO_CONFIG: PICO_SDK_VERSION_PRE_RELEASE_ID, optional SDK pre-release version identifier, type=string, group=pico_base
+# PICO_CMAKE_CONFIG: PICO_SDK_VERSION_PRE_RELEASE_ID, optional SDK pre-release version identifier, type=string, group=pico_base
 set(PICO_SDK_VERSION_PRE_RELEASE_ID develop)
 
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_STRING, SDK version, type=string, group=pico_base
-# PICO_CONFIG: PICO_SDK_VERSION_STRING, SDK version, type=string, group=pico_base
+# PICO_CMAKE_CONFIG: PICO_SDK_VERSION_STRING, SDK version, type=string, group=pico_base
 set(PICO_SDK_VERSION_STRING "${PICO_SDK_VERSION_MAJOR}.${PICO_SDK_VERSION_MINOR}.${PICO_SDK_VERSION_REVISION}")
 
 if (PICO_SDK_VERSION_PRE_RELEASE_ID)

--- a/src/common/pico_base/generate_config_header.cmake
+++ b/src/common/pico_base/generate_config_header.cmake
@@ -13,8 +13,8 @@ endmacro()
 # PICO_CMAKE_CONFIG: PICO_CONFIG_HEADER_FILES, List of extra header files to include from pico/config.h for all platforms, type=list, default="", group=pico_base
 add_header_content_from_var(PICO_CONFIG_HEADER_FILES)
 
-# PICO_CMAKE_CONFIG: PICO_CONFIG_RP2040_HEADER_FILES, List of extra header files to include from pico/config.h for rp2040 platform, type=list, default="", group=pico_base
-# PICO_CMAKE_CONFIG: PICO_CONFIG_HOST_HEADER_FILES, List of extra header files to include from pico/config.h for host platform, type=list, default="", group=pico_base
+# PICO_CMAKE_CONFIG: PICO_RP2040_CONFIG_HEADER_FILES, List of extra header files to include from pico/config.h for rp2040 platform, type=list, default="", group=pico_base
+# PICO_CMAKE_CONFIG: PICO_HOST_CONFIG_HEADER_FILES, List of extra header files to include from pico/config.h for host platform, type=list, default="", group=pico_base
 add_header_content_from_var(PICO_${PICO_PLATFORM_UPPER}_CONFIG_HEADER_FILES)
 
 file(GENERATE

--- a/src/rp2_common.cmake
+++ b/src/rp2_common.cmake
@@ -49,11 +49,11 @@ endfunction()
 add_subdirectory(common)
 add_subdirectory(rp2_common)
 
-# PICO_CMAKE_CONFIG: PICO_NO_HARDWARE, OPTION: Whether the build is not targeting an RP2040 device,  type=bool, default=1 for PICO_PLATFORM=host 0 otherwise, group=build
-# PICO_BUILD_DEFINE: PICO_NO_HARDWARE, Whether the build is not targeting an RP2040 device,  type=bool, default=1 for PICO_PLATFORM=host 0 otherwise, group=build
+# PICO_CMAKE_CONFIG: PICO_NO_HARDWARE, OPTION: Whether the build is not targeting an RP2040 device, type=bool, default=1 when PICO_PLATFORM is host, 0 otherwise, group=build
+# PICO_BUILD_DEFINE: PICO_NO_HARDWARE, Whether the build is not targeting an RP2040 device, type=bool, default=1 when PICO_PLATFORM is host, 0 otherwise, group=build
 set(PICO_NO_HARDWARE "0" CACHE INTERNAL "")
-# PICO_CMAKE_CONFIG: PICO_ON_DEVICE, OPTION: Whether the build is targeting an RP2040 device,  type=bool, default=0 for PICO_PLATFORM=host 1 otherwise, group=build
-# PICO_BUILD_DEFIN: PICO_ON_DEVICE, Whether the build is targeting an RP2040 device,  type=bool, default=0 for PICO_PLATFORM=host 1 otherwise, group=build
+# PICO_CMAKE_CONFIG: PICO_ON_DEVICE, OPTION: Whether the build is targeting an RP2040 device, type=bool, default=0 when PICO_PLATFORM is host, 1 otherwise, group=build
+# PICO_BUILD_DEFINE: PICO_ON_DEVICE, Whether the build is targeting an RP2040 device, type=bool, default=0 when PICO_PLATFORM is host, 1 otherwise, group=build
 set(PICO_ON_DEVICE "1" CACHE INTERNAL "")
 
 set(CMAKE_EXECUTABLE_SUFFIX .elf PARENT_SCOPE)

--- a/src/rp2_common/pico_standard_link/CMakeLists.txt
+++ b/src/rp2_common/pico_standard_link/CMakeLists.txt
@@ -62,7 +62,7 @@ if (NOT TARGET pico_standard_link)
     # PICO_BUILD_DEFINE: PICO_NO_FLASH, whether this is a 'no_flash' build, type=bool, default=0, but dependent on CMake options, group=pico_standard_link
     target_compile_definitions(pico_standard_link INTERFACE PICO_NO_FLASH=$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_BINARY_TYPE>,no_flash>,1,$<AND:$<BOOL:${PICO_NO_FLASH}>,$<STREQUAL:,$<TARGET_PROPERTY:PICO_TARGET_BINARY_TYPE>>>>)
     # PICO_USE_BLOCKED_RAM will be set based on PICO_TARGET_BUILD_TYPE target property being equal to use_blocked_ram if set, otherwise to the value of the PICO_USE_BLOCKED_RAM cmake variable unless PICO_TARGET_TYPE is set to something else
-    # PICO_BUILD_DEFINE: PICO_USE_BLOCKS_RAM, whether this is a 'blocked_ram' build, type=bool, default=0, but dependent on CMake options, group=pico_standard_link
+    # PICO_BUILD_DEFINE: PICO_USE_BLOCKED_RAM, whether this is a 'blocked_ram' build, type=bool, default=0, but dependent on CMake options, group=pico_standard_link
     target_compile_definitions(pico_standard_link INTERFACE PICO_USE_BLOCKED_RAM=$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_BINARY_TYPE>,use_blocked_ram>,1,$<AND:$<BOOL:${PICO_USE_BLOCKED_RAM}>,$<STREQUAL:,$<TARGET_PROPERTY:PICO_TARGET_BINARY_TYPE>>>>)
     # PICO_COPY_TO_RAM will be set based on PICO_TARGET_BUILD_TYPE target property being equal to copy_to_ram if set, otherwise to the value of the PICO_COPY_TO_RAM cmake variable unless PICO_TARGET_TYPE is set to something else
     # PICO_BUILD_DEFINE: PICO_COPY_TO_RAM, whether this is a 'copy_to_ram' build, type=bool, default=0, but dependent on CMake options, group=pico_standard_link
@@ -89,7 +89,7 @@ if (NOT TARGET pico_standard_link)
     # this line occasionally useful for debugging ... todo maybe make a PICO_ var
     # target_compile_options(pico_standard_link INTERFACE --save-temps) #debugging only
 
-    # PICO_CMAKE_CONFIG: PICO_NO_GC_SECTIONS, Disable -ffunction-sections -fdata-sections, and --gc-sections, type=bool, default=0, advanced=true, group=pico_standard_link
+    # PICO_CMAKE_CONFIG: PICO_NO_GC_SECTIONS, Disable -ffunction-sections -fdata-sections and --gc-sections, type=bool, default=0, advanced=true, group=pico_standard_link
     if (NOT PICO_NO_GC_SECTIONS)
         target_compile_options(pico_standard_link INTERFACE -ffunction-sections -fdata-sections)
         target_link_options(pico_standard_link INTERFACE "LINKER:--gc-sections")

--- a/src/rp2_common/pico_stdlib/CMakeLists.txt
+++ b/src/rp2_common/pico_stdlib/CMakeLists.txt
@@ -2,8 +2,8 @@
 option(PICO_STDIO_UART "Globablly enable stdio UART" 1)
 # PICO_CMAKE_CONFIG: PICO_STDIO_USB, OPTION: Globally enable stdio USB, default=0, group=pico_stdlib
 option(PICO_STDIO_USB "Globablly enable stdio USB" 0)
-# PICO_CMAKE_CONFIG: PICO_STDIO_USB, OPTIONS: Globally enable stdio semihosting, default=0, group=pico_stdlib
-option(PICO_STDIO_USB "Globablly enable stdio semihosting " 0)
+# PICO_CMAKE_CONFIG: PICO_STDIO_SEMIHOSTING, OPTION: Globally enable stdio semihosting, default=0, group=pico_stdlib
+option(PICO_STDIO_SEMIHOSTING "Globablly enable stdio semihosting" 0)
 
 if (NOT TARGET pico_stdlib)
     pico_add_impl_library(pico_stdlib)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,7 @@ function(_pico_init_pioasm)
     find_package(Pioasm REQUIRED)
 endfunction()
 
-# PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, default output format used by pioasm when using pico_generate_pio_header, default=c-sdk, group=build
+# PICO_CMAKE_CONFIG: PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, default output format used by pioasm when using pico_generate_pio_header, default=c-sdk, group=build
 function(pico_generate_pio_header TARGET PIO)
     _pico_init_pioasm()
     cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR" "" ${ARGN} )

--- a/tools/check_configs.sh
+++ b/tools/check_configs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Little script to find possibly-misnamed CONFIG lines
+for CONF in PICO_CONFIG PICO_CMAKE_CONFIG PICO_BUILD_DEFINE; do
+  for DEF in $(git grep "$CONF:" | sed -n "s/.*$CONF: \+\(\w\+\).*/\1/p"); do
+    if [ $(git grep "$DEF" | wc -l) -lt 2 ]; then
+        echo "$CONF: $DEF only appears once"
+    fi
+  done
+done


### PR DESCRIPTION
Also add a script that found some of these errors.

The only bit I wasn't sure about was whether `PICO_DEFAULT_PIOASM_OUTPUT_FORMAT` should be a `PICO_CMAKE_CONFIG:` or a `PICO_BUILD_DEFINE:` ?