### PR TITLE
Implement LWIP ntohl() and ntohs() with rev and rev16 instructions. Fixes #913

### DIFF
--- a/src/rp2_common/pico_lwip/include/arch/cc.h
+++ b/src/rp2_common/pico_lwip/include/arch/cc.h
@@ -32,6 +32,8 @@
 #ifndef __CC_H__
 #define __CC_H__
 
+#include <stdint.h>
+
 #if NO_SYS
 // todo really we should just not allow SYS_LIGHTWEIGHT_PROT for nosys mode (it doesn't do anything anyway)
 typedef int sys_prot_t;
@@ -76,4 +78,22 @@ unsigned int pico_lwip_rand(void);
 // Use ROSC based random number generation, more for the fact that rand() may not be seeded, than anything else
 #define LWIP_RAND pico_lwip_rand
 #endif
+
+static inline uint16_t rp2040_htons(uint16_t x) {
+    __asm ("rev16 %0, %0" : "+l" (x) : : );
+    return x;
+}
+
+static inline uint32_t rp2040_htonl(uint32_t x) {
+    __asm ("rev %0, %0" : "+l" (x) : : );
+    return x;
+}
+
+#define lwip_htons(x) (rp2040_htons(x))
+#define lwip_htonl(x) (rp2040_htonl(x))
+#define htons(x)      (rp2040_htons(x))
+#define htonl(x)      (rp2040_htonl(x))
+
+#define LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS
+
 #endif /* __CC_H__ */


### PR DESCRIPTION
With `rev` and `rev16`, byte swapping for network order is done in one cycle, rather than the 3 to 7 cycles or thereabouts needed for bit twiddling.

I tested the patch by building examples for pico_w in pico-examples. In particular, the test in the tcp_server example is successful, and iperf shows bandwidth results with few or no TCP retries.

Unfortunately I can't evaluate the impact on performance, since my home WiFi is not lab conditions. (The PicoW's bandwidth appears to be overwhelmingly affected by how many other devices are also connected to the 2.4 GHz network, and what they're doing.) The iperf bandwidth results with the patch are at any rate not worse, but if there is an improvement, I'm not seeing it as so impactful that it overcomes all of the other factors.

Nevertheless I think the patch makes sense, because `rev` and `rev16` are there for just this sort of thing.

Fixes #913
