### PR TITLE
Add call to tud_task in getchar()

### DIFF
--- a/src/common/pico_sync/critical_section.c
+++ b/src/common/pico_sync/critical_section.c
@@ -21,7 +21,5 @@ void critical_section_init_with_lock_num(critical_section_t *crit_sec, uint lock
 
 void critical_section_deinit(critical_section_t *crit_sec) {
     spin_lock_unclaim(spin_lock_get_num(crit_sec->spin_lock));
-#ifndef NDEBUG
-    crit_sec->spin_lock = (spin_lock_t *)-1;
-#endif
+    crit_sec->spin_lock = NULL;
 }

--- a/src/common/pico_sync/include/pico/critical_section.h
+++ b/src/common/pico_sync/include/pico/critical_section.h
@@ -82,6 +82,16 @@ static inline void critical_section_exit(critical_section_t *crit_sec) {
  */
 void critical_section_deinit(critical_section_t *crit_sec);
 
+/*! \brief Test whether a critical_section has been initialized
+ *  \ingroup mutex
+ *
+ * \param crit_sec Pointer to critical_section structure
+ * \return true if the critical section is initialized, false otherwise
+ */
+static inline bool critical_section_is_initialized(critical_section_t *crit_sec) {
+    return crit_sec->spin_lock != 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/pico_time/include/pico/time.h
+++ b/src/common/pico_time/include/pico/time.h
@@ -404,6 +404,14 @@ alarm_pool_t *alarm_pool_create(uint hardware_alarm_num, uint max_timers);
 uint alarm_pool_hardware_alarm_num(alarm_pool_t *pool);
 
 /**
+ * \brief Return the core number the alarm pool was initialized on (and hence callbacks are called on)
+ * \ingroup alarm
+ * \param pool the pool
+ * \return the core used by the pool
+ */
+uint alarm_pool_core_num(alarm_pool_t *pool);
+
+/**
  * \brief Destroy the alarm pool, cancelling all alarms and freeing up the underlying hardware alarm
  * \ingroup alarm
  * \param pool the pool

--- a/src/common/pico_time/include/pico/time.h
+++ b/src/common/pico_time/include/pico/time.h
@@ -198,7 +198,7 @@ static inline bool is_nil_time(absolute_time_t t) {
  * \note  These functions should not be called from an IRQ handler.
  *
  * \note  Lower powered sleep requires use of the \link alarm_pool_get_default default alarm pool\endlink which may
- * be disabled by the #PICO_TIME_DEFAULT_ALARM_POOL_DISABLED define or currently full in which case these functions
+ * be disabled by the PICO_TIME_DEFAULT_ALARM_POOL_DISABLED #define or currently full in which case these functions
  * become busy waits instead.
  *
  * \note  Whilst \a sleep_ functions are preferable to \a busy_wait functions from a power perspective, the \a busy_wait equivalent function

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -31,6 +31,7 @@ typedef struct alarm_pool {
     uint8_t *entry_ids_high;
     alarm_id_t alarm_in_progress; // this is set during a callback from the IRQ handler... it can be cleared by alarm_cancel to prevent repeats
     uint8_t hardware_alarm_num;
+    uint8_t core_num;
 } alarm_pool_t;
 
 #if !PICO_TIME_DEFAULT_ALARM_POOL_DISABLED
@@ -190,6 +191,7 @@ void alarm_pool_post_alloc_init(alarm_pool_t *pool, uint hardware_alarm_num) {
     hardware_alarm_set_callback(hardware_alarm_num, alarm_pool_alarm_callback);
     pool->lock = spin_lock_instance(next_striped_spin_lock_num());
     pool->hardware_alarm_num = (uint8_t) hardware_alarm_num;
+    pool->core_num = get_core_num();
     pools[hardware_alarm_num] = pool;
 }
 
@@ -284,6 +286,10 @@ bool alarm_pool_cancel_alarm(alarm_pool_t *pool, alarm_id_t alarm_id) {
 
 uint alarm_pool_hardware_alarm_num(alarm_pool_t *pool) {
     return pool->hardware_alarm_num;
+}
+
+uint alarm_pool_core_num(alarm_pool_t *pool) {
+    return pool->core_num;
 }
 
 static void alarm_pool_dump_key(pheap_node_id_t id, void *user_data) {

--- a/src/rp2_common/pico_stdio/include/pico/stdio.h
+++ b/src/rp2_common/pico_stdio/include/pico/stdio.h
@@ -52,9 +52,10 @@ typedef struct stdio_driver stdio_driver_t;
  * When stdio_usb is configured, this method can be optionally made to block, waiting for a connection
  * via the variables specified in \ref stdio_usb_init (i.e. \ref PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS)
  *
+ * \return true if at least one output was successfully initialized, false otherwise.
  * \see stdio_uart, stdio_usb, stdio_semihosting
  */
-void stdio_init_all(void);
+bool stdio_init_all(void);
 
 /*! \brief Initialize all of the present standard stdio types that are linked into the binary.
  * \ingroup pico_stdio

--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -267,20 +267,25 @@ int __printflike(1, 0) WRAPPER_FUNC(printf)(const char* format, ...)
     return ret;
 }
 
-void stdio_init_all(void) {
+bool stdio_init_all(void) {
     // todo add explicit custom, or registered although you can call stdio_enable_driver explicitly anyway
     // These are well known ones
+
+    bool rc = false;
 #if LIB_PICO_STDIO_UART
     stdio_uart_init();
+    rc = true;
 #endif
 
 #if LIB_PICO_STDIO_SEMIHOSTING
     stdio_semihosting_init();
+    rc = true;
 #endif
 
 #if LIB_PICO_STDIO_USB
-    stdio_usb_init();
+    rc |= stdio_usb_init();
 #endif
+    return rc;
 }
 
 int WRAPPER_FUNC(getchar)(void) {

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -38,7 +38,6 @@ static uint8_t low_priority_irq_num;
 #endif
 
 static int64_t timer_task(__unused alarm_id_t id, __unused void *user_data) {
-    assert(stdio_usb_core_num == get_core_num()); // if this fails, you have initialized stdio_usb on the wrong core
     int64_t repeat_time;
     if (critical_section_is_initialized(&one_shot_timer_crit_sec)) {
         critical_section_enter_blocking(&one_shot_timer_crit_sec);
@@ -147,6 +146,12 @@ stdio_driver_t stdio_usb = {
 };
 
 bool stdio_usb_init(void) {
+    if (get_core_num() != alarm_pool_core_num(alarm_pool_get_default())) {
+        // included an assertion here rather than just returning false, as this is likely
+        // a coding bug, rather than anything else.
+        assert(false);
+        return false;
+    }
 #ifndef NDEBUG
     stdio_usb_core_num = (uint8_t)get_core_num();
 #endif

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -19,17 +19,17 @@
 #include "hardware/irq.h"
 
 static mutex_t stdio_usb_mutex;
-// if this crit_sec is initialized, we are not in periodic timer mode, and must make sure
-// we don't either create multiple one shot timers, or miss creating one. this crit_sec
-// is used to protect the one_shot_timer_pending flag
-static critical_section_t one_shot_timer_crit_sec;
-static volatile bool one_shot_timer_pending;
 #ifndef NDEBUG
 static uint8_t stdio_usb_core_num;
 #endif
 
 // when tinyusb_device is explicitly linked we do no background tud processing
 #if !LIB_TINYUSB_DEVICE
+// if this crit_sec is initialized, we are not in periodic timer mode, and must make sure
+// we don't either create multiple one shot timers, or miss creating one. this crit_sec
+// is used to protect the one_shot_timer_pending flag
+static critical_section_t one_shot_timer_crit_sec;
+static volatile bool one_shot_timer_pending;
 #ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
 static_assert(PICO_STDIO_USB_LOW_PRIORITY_IRQ >= NUM_IRQS - NUM_USER_IRQS, "");
 #define low_priority_irq_num PICO_STDIO_USB_LOW_PRIORITY_IRQ
@@ -62,7 +62,7 @@ static void low_priority_worker_irq(void) {
         // it would seem simplest to just let that code call tud_task() at the end, however this
         // code might run during the call to tud_task() and we might miss a necessary tud_task() call
         //
-        // if we are using a periodic timer (crit_sec is not initialzied in this case),
+        // if we are using a periodic timer (crit_sec is not initialized in this case),
         // then we are happy just to wait until the next tick, however when we are not using a periodic timer,
         // we must kick off a one-shot timer to make sure the tud_task() DOES run (this method
         // will be called again as a result, and will try the mutex_try_enter again, and if that fails

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -56,7 +56,6 @@ static void low_priority_worker_irq(void) {
     // if the mutex is already owned, then we are in user code
     // in this file which will do a tud_task itself, so we'll just do nothing
     // until the next tick; we won't starve
-    static int foo;
     if (mutex_try_enter(&stdio_usb_mutex, NULL)) {
         tud_task();
         mutex_exit(&stdio_usb_mutex);

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -97,6 +97,9 @@ int stdio_usb_in_chars(char *buf, int length) {
     if (tud_cdc_connected() && tud_cdc_available()) {
         int count = (int) tud_cdc_read(buf, (uint32_t) length);
         rc =  count ? count : PICO_ERROR_NO_DATA;
+    } else {
+        // because our mutex use may starve out the background task, run tud_task here (we own the mutex)
+        tud_task();
     }
     mutex_exit(&stdio_usb_mutex);
     return rc;


### PR DESCRIPTION
* Depending on USB timing, the low priority may never call `tud_task()` during `getchar()
* Also fixed a 1.4.0 regression which may cause `tud_task()` to not be called after an IRQ if the mutex wasn't available (previously we tried again automatically ever 1ms)