### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 cmake-*
 .DS_Store
 build
+examples


### PR DESCRIPTION
Exclude the examples folder from the base project.
(This way you don't have to deal with +++ "modified" files in github desktop and the likes)

I guess another solution would be to just include the examples repo as a submodule?