### PR TITLE
Enable/disable connection check made with DTR

### DIFF
--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
@@ -97,6 +97,11 @@
 #define PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS 100
 #endif
 
+// PICO_CONFIG: PICO_STDIO_USB_CONNECTION_CHECK_WITH_DTR, Enable/disable connection check made with DTR checking, type=bool, default=1, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_CONNECTION_CHECK_WITH_DTR
+#define PICO_STDIO_USB_CONNECTION_CHECK_WITH_DTR 1
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -60,7 +60,7 @@ static void stdio_usb_out_chars(const char *buf, int length) {
         if (owner == get_core_num()) return; // would deadlock otherwise
         mutex_enter_blocking(&stdio_usb_mutex);
     }
-    if (tud_cdc_connected()) {
+    if (stdio_usb_connected()) {
         for (int i = 0; i < length;) {
             int n = length - i;
             int avail = (int) tud_cdc_write_available();
@@ -74,7 +74,7 @@ static void stdio_usb_out_chars(const char *buf, int length) {
             } else {
                 tud_task();
                 tud_cdc_write_flush();
-                if (!tud_cdc_connected() ||
+                if (!stdio_usb_connected() ||
                     (!tud_cdc_write_available() && time_us_64() > last_avail_time + PICO_STDIO_USB_STDOUT_TIMEOUT_US)) {
                     break;
                 }
@@ -94,7 +94,7 @@ int stdio_usb_in_chars(char *buf, int length) {
         mutex_enter_blocking(&stdio_usb_mutex);
     }
     int rc = PICO_ERROR_NO_DATA;
-    if (tud_cdc_connected() && tud_cdc_available()) {
+    if (stdio_usb_connected() && tud_cdc_available()) {
         int count = (int) tud_cdc_read(buf, (uint32_t) length);
         rc =  count ? count : PICO_ERROR_NO_DATA;
     }
@@ -166,7 +166,11 @@ bool stdio_usb_init(void) {
 }
 
 bool stdio_usb_connected(void) {
+#if PICO_STDIO_USB_CONNECTION_CHECK_WITH_DTR
     return tud_cdc_connected();
+#else
+    return true;
+#endif
 }
 #else
 #warning stdio USB was configured along with user use of TinyUSB device mode, but CDC is not enabled


### PR DESCRIPTION
This gives users the option to disable DTR check.
this fixes issues #906, #921

### Problem:

tud_cdc_connected is using DTR bit. If not set by host (PC terminal or other device), we can't send anything. 

[src/class/cdc/cdc_device.h](https://github.com/hathach/tinyusb/blob/master/src/class/cdc/cdc_device.h)
```
static inline bool tud_cdc_connected (void)
{
  return tud_cdc_n_connected(0);
}
```

[src/class/cdc/cdc_device.h](https://github.com/hathach/tinyusb/blob/master/src/class/cdc/cdc_device.c)

```
bool tud_cdc_n_connected(uint8_t itf)
{
  // DTR (bit 0) active  is considered as connected
  return tud_ready() && tu_bit_test(_cdcd_itf[itf].line_state, 0);
}
```

### how to fix
PICO_STDIO_USB_CONNECTION_CHECK_WITH_DTR option added to config file for who needs to enable.
It doesn't change current behavior because it's enabled by default. Just gives user to option to disable it.

### Usage
add this to your cmake file and DTR check will be disabled.
add_definitions(-DPICO_STDIO_USB_CONNECTION_CHECK_WITH_DTR=0)


