### PR TITLE
Set CMAKE_MAKE_PROGRAM when building ELF2UF2 and PIOASM

### DIFF
--- a/tools/FindELF2UF2.cmake
+++ b/tools/FindELF2UF2.cmake
@@ -24,8 +24,10 @@ if (NOT ELF2UF2_FOUND)
     if (NOT TARGET ${ELF2UF2_BUILD_TARGET})
         pico_message_debug("ELF2UF2 will need to be built")
         ExternalProject_Add(${ELF2UF2_BUILD_TARGET}
-                PREFIX elf2uf2 SOURCE_DIR ${ELF2UF2_SOURCE_DIR}
+                PREFIX elf2uf2
+                SOURCE_DIR ${ELF2UF2_SOURCE_DIR}
                 BINARY_DIR ${ELF2UF2_BINARY_DIR}
+                CMAKE_ARGS "-DCMAKE_MAKE_PROGRAM:FILEPATH=${CMAKE_MAKE_PROGRAM}"
                 BUILD_ALWAYS 1 # force dependency checking
                 INSTALL_COMMAND ""
                 )

--- a/tools/FindPioasm.cmake
+++ b/tools/FindPioasm.cmake
@@ -25,11 +25,13 @@ if (NOT Pioasm_FOUND)
         pico_message_debug("PIOASM will need to be built")
 #        message("Adding external project ${PioasmBuild_Target} in ${CMAKE_CURRENT_LIST_DIR}}")
         ExternalProject_Add(${PioasmBuild_TARGET}
-                PREFIX pioasm SOURCE_DIR ${PIOASM_SOURCE_DIR}
+                PREFIX pioasm
+                SOURCE_DIR ${PIOASM_SOURCE_DIR}
                 BINARY_DIR ${PIOASM_BINARY_DIR}
+                CMAKE_ARGS "-DCMAKE_MAKE_PROGRAM:FILEPATH=${CMAKE_MAKE_PROGRAM}"
+                CMAKE_CACHE_ARGS "-DPIOASM_EXTRA_SOURCE_FILES:STRING=${PIOASM_EXTRA_SOURCE_FILES}"
                 BUILD_ALWAYS 1 # force dependency checking
                 INSTALL_COMMAND ""
-                CMAKE_CACHE_ARGS "-DPIOASM_EXTRA_SOURCE_FILES:STRING=${PIOASM_EXTRA_SOURCE_FILES}"
                 )
     endif()
 


### PR DESCRIPTION
Fix #934 by propagating `CMAKE_MAKE_PROGRAM` to ELF2UF2 and PIOASM.