### PR TITLE
Add pico_lwip_mqtt library

### DIFF
--- a/src/rp2_common/pico_lwip/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/CMakeLists.txt
@@ -223,7 +223,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             ${PICO_LWIP_PATH}/src/apps/tftp/tftp.c
             )
 
-    # MQTT client files
+    # Mbed TLS files
     add_library(pico_lwip_mbedtls INTERFACE)
     target_sources(pico_lwip_mbedtls INTERFACE
             ${PICO_LWIP_PATH}/src/apps/altcp_tls/altcp_tls_mbedtls.c

--- a/src/rp2_common/pico_lwip/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/CMakeLists.txt
@@ -231,6 +231,11 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             ${PICO_LWIP_PATH}/src/apps/snmp/snmpv3_mbedtls.c
             )
 
+    # MQTT client files
+    add_library(pico_lwip_mqtt INTERFACE)
+    target_sources(pico_lwip_mqtt INTERFACE
+            ${PICO_LWIP_PATH}/src/apps/mqtt/mqtt.c
+            )
 
     # All LWIP files without apps
     add_library(pico_lwip INTERFACE)

--- a/src/rp2_common/pico_lwip/doc.h
+++ b/src/rp2_common/pico_lwip/doc.h
@@ -24,6 +24,7 @@
  * * \c \b pico_lwip_netbios - 
  * * \c \b pico_lwip_tftp - 
  * * \c \b pico_lwip_mbedtls -
+ * * \c \b pico_lwip_mqtt -
  *
  * The SDK Provides a common set of functionality in \c \p pico_lwip which aggregates:
  *


### PR DESCRIPTION
When trying to use the [LwIP MQTT client application library ](https://www.nongnu.org/lwip/2_1_x/group__mqtt.html)I observed the required source files were not built, which causes linking errors. This PR adds the `pico_lwip_mqtt` library which builds the LwIP mqtt source. This means a user of the `pico-sdk` can include `"lwip/apps/mqtt.h"` and link `pico_lwip_mqtt` against their desired project.

I believe this PR address issue #944 
