### PR TITLE
PLL REFDIV values > 1 considered by vcocalc.py (#951)

### DIFF
--- a/src/rp2_common/hardware_clocks/scripts/vcocalc.py
+++ b/src/rp2_common/hardware_clocks/scripts/vcocalc.py
@@ -4,6 +4,7 @@ import argparse
 
 parser = argparse.ArgumentParser(description="PLL parameter calculator")
 parser.add_argument("--input", "-i", default=12, help="Input (reference) frequency. Default 12 MHz", type=float)
+parser.add_argument("--ref-min", default=5, help="Override minimum reference frequency. Default 5 MHz", type=float)
 parser.add_argument("--vco-max", default=1600, help="Override maximum VCO frequency. Default 1600 MHz", type=float)
 parser.add_argument("--vco-min", default=750, help="Override minimum VCO frequency. Default 750 MHz", type=float)
 parser.add_argument("--low-vco", "-l", action="store_true", help="Use a lower VCO frequency when possible. This reduces power consumption, at the cost of increased jitter")
@@ -13,25 +14,32 @@ args = parser.parse_args()
 # Fixed hardware parameters
 fbdiv_range = range(16, 320 + 1)
 postdiv_range = range(1, 7 + 1)
+ref_min = 5
+refdiv_min = 1
+refdiv_max = 63
 
-best = (0, 0, 0, 0)
+refdiv_range = range(refdiv_min, max(refdiv_min, min(refdiv_max, int(args.input / args.ref_min))) + 1)
+
+best = (0, 0, 0, 0, 0)
 best_margin = args.output
 
-for fbdiv in (fbdiv_range if args.low_vco else reversed(fbdiv_range)):
-	vco = args.input * fbdiv
-	if vco < args.vco_min or vco > args.vco_max:
-		continue
-	# pd1 is inner loop so that we prefer higher ratios of pd1:pd2
-	for pd2 in postdiv_range:
-		for pd1 in postdiv_range:
-			out = vco / pd1 / pd2
-			margin = abs(out - args.output)
-			if margin < best_margin:
-				best = (out, fbdiv, pd1, pd2)
-				best_margin = margin
+for refdiv in refdiv_range:
+	for fbdiv in (fbdiv_range if args.low_vco else reversed(fbdiv_range)):
+		vco = args.input / refdiv * fbdiv
+		if vco < args.vco_min or vco > args.vco_max:
+			continue
+		# pd1 is inner loop so that we prefer higher ratios of pd1:pd2
+		for pd2 in postdiv_range:
+			for pd1 in postdiv_range:
+				out = vco / pd1 / pd2
+				margin = abs(out - args.output)
+				if margin < best_margin:
+					best = (out, fbdiv, pd1, pd2, refdiv)
+					best_margin = margin
 
 print("Requested: {} MHz".format(args.output))
 print("Achieved: {} MHz".format(best[0]))
-print("FBDIV: {} (VCO = {} MHz)".format(best[1], args.input * best[1]))
+print("REFDIV: {}".format(best[4]))
+print("FBDIV: {} (VCO = {} MHz)".format(best[1], args.input / best[4] * best[1]))
 print("PD1: {}".format(best[2]))
 print("PD2: {}".format(best[3]))


### PR DESCRIPTION
Prior to this change, the vcocalc.py script only considered PLL configurations with REFDIV = 1. Sometimes it is beneficial to use PLL configurations with REFDIV > 1.

The new version of the script considers all REFDIVs that would yield a valid reference frequency, that is, a reference frequency >=5MHz. So for a 12MHz crystal, valid REFDIVs are 1 and 2.

I added a --ref-min option, consistent with --vco-min and--vco-max, allowing a more conservative minimum reference frequency, such as 6MHz to be specified.

REFDIVs are considered in ascending order so that, if the best match is achievable using multiple REFDIVs, the lowest REFDIV is selected. This is motivated by the set_sys_clock_pll() SDK function, which only supports REFDIV = 1.

Examples of new script output:

 ```
; 133MHz is achievable with REFDIV of 1 or 2 but 1 preferred by script
>python vcocalc.py 133
Requested: 133.0 MHz
Achieved: 133.0 MHz
REFDIV: 1
FBDIV: 133 (VCO = 1596.0 MHz)
PD1: 6
PD2: 2

 ; 12.288MHz is a good crystal for audio applications but 48MHz USB clock is only achievable with REFDIV = 2
>python vcocalc.py --input 12.288 48
Requested: 48.0 MHz
Achieved: 48.0 MHz
REFDIV: 2
FBDIV: 125 (VCO = 768.0 MHz)
PD1: 4
PD2: 4

 ; Clocks suitable for 44.1kHz audio applications with 12MHz crystal are easier with REFDIV = 2
>python vcocalc.py 88.2
Requested: 88.2 MHz
Achieved: 88.2 MHz
REFDIV: 2
FBDIV: 147 (VCO = 882.0 MHz)
PD1: 5
PD2: 2

```