### PR TITLE
Use system include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,7 +102,7 @@ macro(pico_simple_hardware_headers_target NAME)
     if (NOT TARGET hardware_${NAME}_headers)
         add_library(hardware_${NAME}_headers INTERFACE)
 
-        target_include_directories(hardware_${NAME}_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+        target_include_directories(hardware_${NAME}_headers SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
         target_link_libraries(hardware_${NAME}_headers INTERFACE pico_base_headers)
         if (NOT PICO_NO_HARDWARE)
             target_link_libraries(hardware_${NAME}_headers INTERFACE hardware_structs hardware_claim_headers)

--- a/src/common/pico_base/CMakeLists.txt
+++ b/src/common/pico_base/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (NOT TARGET pico_base_headers)
     pico_add_library(pico_base NOFLAG)
-    target_include_directories(pico_base_headers INTERFACE include ${CMAKE_BINARY_DIR}/generated/pico_base)
+    target_include_directories(pico_base_headers SYSTEM INTERFACE include ${CMAKE_BINARY_DIR}/generated/pico_base)
 
     # PICO_BUILD_DEFINE: PICO_BOARD, Name of board, type=string, default=CMake PICO_BOARD variable, group=pico_base
     target_compile_definitions(pico_base_headers INTERFACE


### PR DESCRIPTION
Currently all include directories are added as none system include directories. This might causes warnings and errors when compiling user code.

Fixes #82 and #924 
