### PR TITLE
hardware_gpio_headers must depend on hardware_irq_headers

### DIFF
--- a/src/rp2_common/hardware_gpio/CMakeLists.txt
+++ b/src/rp2_common/hardware_gpio/CMakeLists.txt
@@ -1,2 +1,3 @@
 pico_simple_hardware_target(gpio)
 target_link_libraries(hardware_gpio INTERFACE hardware_irq)
+target_link_libraries(hardware_gpio_headers INTERFACE hardware_irq_headers)


### PR DESCRIPTION
Since [`hardware/gpio.h` includes `hardware/irq.h`](https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_gpio/include/hardware/gpio.h#L14), `hardware_gpio_headers` must depend on `hardware_irq_headers` (just like `hardware_gpio` depends on `hardware_irq`).

Fixes #955, fixes #882 partially
