### PR TITLE
Properly terminate cyw43 task when `cyw43_arch_deinit()` is called

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch_freertos.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch_freertos.c
@@ -101,6 +101,7 @@ static void cyw43_task(__unused void *param) {
         xSemaphoreGive(cyw43_worker_ran_sem);
         __sev(); // it is possible regular code is waiting on a WFE on the other core
     } while (true);
+    vTaskDelete(NULL);
 }
 
 static void tcpip_init_done(void *param) {


### PR DESCRIPTION
Fixes #961