### PR TITLE
Call `cyw43_deinit()` from `cyw43_arch_deinit()` to release the DMA channels and power off the WLAN chip

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch_freertos.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch_freertos.c
@@ -168,6 +168,7 @@ void cyw43_arch_deinit(void) {
     }
     gpio_set_irq_enabled(CYW43_PIN_WL_HOST_WAKE, GPIO_IRQ_LEVEL_HIGH, false);
     gpio_remove_raw_irq_handler(IO_IRQ_BANK0, gpio_irq_handler);
+    cyw43_deinit(&cyw43_state);
 }
 
 void cyw43_post_poll_hook(void) {

--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch_threadsafe_background.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch_threadsafe_background.c
@@ -211,6 +211,7 @@ void cyw43_arch_deinit(void) {
     gpio_set_irq_enabled(CYW43_PIN_WL_HOST_WAKE, GPIO_IRQ_LEVEL_HIGH, false);
     gpio_remove_raw_irq_handler(IO_IRQ_BANK0, gpio_irq_handler);
     low_prio_irq_deinit();
+    cyw43_deinit(&cyw43_state);
 }
 
 void cyw43_post_poll_hook(void) {


### PR DESCRIPTION
Fixes #964

After calling `cyw43_arch_enable_sta_mode()`, the application got into an infinite loop waiting for the DMA channels in `cyw43_spi_transfer()`.
Calling `cyw43_deinit()` from `cyw43_arch_deinit()` fixes the issue.