### PR TITLE
tcpip_init fix

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch_freertos.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch_freertos.c
@@ -123,9 +123,13 @@ int cyw43_arch_init(void) {
     cyw43_worker_ran_sem = xSemaphoreCreateBinary();
 
 #if CYW43_LWIP
-    SemaphoreHandle_t init_sem = xSemaphoreCreateBinary();
-    tcpip_init(tcpip_init_done, init_sem);
-    xSemaphoreTake(init_sem, portMAX_DELAY);
+    static bool tcpip_init_called = false;
+    if (!tcpip_init_called) {
+      tcpip_init_called = true;
+      SemaphoreHandle_t init_sem = xSemaphoreCreateBinary();
+      tcpip_init(tcpip_init_done, init_sem);
+      xSemaphoreTake(init_sem, portMAX_DELAY);
+    }
 #endif
 
     timer_handle = xTimerCreate(    "cyw43_sleep_timer",       // Just a text name, not used by the kernel.

--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch_threadsafe_background.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch_threadsafe_background.c
@@ -192,7 +192,11 @@ int cyw43_arch_init(void) {
     irq_set_enabled(IO_IRQ_BANK0, true);
 
 #if CYW43_LWIP
-    lwip_init();
+    static bool lwip_init_called = false;
+    if (!lwip_init_called) {
+      lwip_init_called = true;
+      lwip_init();
+    }
 #endif
     // start low priority handler (no background work is done before this)
     bool ok = low_prio_irq_init(PICO_LOWEST_IRQ_PRIORITY);


### PR DESCRIPTION
Fixes #968

It's more a workaround than a proper fix, but I've added a flag to prevent calling `tcpip_init()` multiple times during a single run.

I've added the same workaround to the `threadsafe_background` version for `lwip_init()`, as I've found that the `poll` version also contained it.