### PR TITLE
hardware_adc_headers must depend on hardware_gpio_headers

### DIFF
--- a/src/rp2_common/hardware_adc/CMakeLists.txt
+++ b/src/rp2_common/hardware_adc/CMakeLists.txt
@@ -2,3 +2,5 @@ pico_simple_hardware_target(adc)
 
 # additional library
 target_link_libraries(hardware_adc INTERFACE hardware_resets)
+target_link_libraries(hardware_adc INTERFACE hardware_gpio)
+target_link_libraries(hardware_adc_headers INTERFACE hardware_gpio_headers)


### PR DESCRIPTION
Since [`hardware/adc.h`](https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_adc/include/hardware/adc.h) includes [`hardware/gpio.h`](https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/hardware_gpio/include/hardware/gpio.h), `hardware_adc_headers` must depend on `hardware_gpio_headers`

Fixes #975