### PR TITLE
Apply change for #974 to PIO for consistency

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -818,7 +818,7 @@ static inline bool pio_interrupt_get(PIO pio, uint pio_interrupt_num) {
 static inline void pio_interrupt_clear(PIO pio, uint pio_interrupt_num) {
     check_pio_param(pio);
     invalid_params_if(PIO, pio_interrupt_num >= 8);
-    hw_set_bits(&pio->irq, (1u << pio_interrupt_num));
+    pio->irq = (1u << pio_interrupt_num);
 }
 
 /*! \brief Return the current program counter for a state machine


### PR DESCRIPTION
It is not known if this is required. This is done for consistency purposes. Related to #974 

Another instance of all WC was found in PIO.h. What is the recommendation for registers with multiple WC with RW? I saw one register with a single WC and multiple RW, which should be fine. However, if there are multiple WC there could be an issue.
