### PR TITLE
fix wconversion warning

### DIFF
--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -191,7 +191,7 @@ void alarm_pool_post_alloc_init(alarm_pool_t *pool, uint hardware_alarm_num) {
     hardware_alarm_set_callback(hardware_alarm_num, alarm_pool_alarm_callback);
     pool->lock = spin_lock_instance(next_striped_spin_lock_num());
     pool->hardware_alarm_num = (uint8_t) hardware_alarm_num;
-    pool->core_num = get_core_num();
+    pool->core_num = (uint8_t) get_core_num();
     pools[hardware_alarm_num] = pool;
 }
 


### PR DESCRIPTION
This PR fix wconversion warning due to implicit cast from uint (32-bit) to uint8_t. This causes 
tinyusb ci (run with pico-sdk develop branch) to fail recently (compiled with gcc11).