### PR TITLE
Make sure OUT_STICKY is not set when setting pins / pindirs

### DIFF
--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -158,7 +158,7 @@ void pio_sm_set_pins(PIO pio, uint sm, uint32_t pins) {
     check_sm_param(sm);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
     uint32_t execctrl_saved = pio->sm[sm].execctrl;
-    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
+    hw_clear_bits(&pio->sm[sm].execctrl, 1u << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     uint remaining = 32;
     uint base = 0;
     while (remaining) {
@@ -180,7 +180,7 @@ void pio_sm_set_pins_with_mask(PIO pio, uint sm, uint32_t pinvals, uint32_t pin_
     check_sm_param(sm);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
     uint32_t execctrl_saved = pio->sm[sm].execctrl;
-    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
+    hw_clear_bits(&pio->sm[sm].execctrl, 1u << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     while (pin_mask) {
         uint base = (uint)__builtin_ctz(pin_mask);
         pio->sm[sm].pinctrl =
@@ -198,7 +198,7 @@ void pio_sm_set_pindirs_with_mask(PIO pio, uint sm, uint32_t pindirs, uint32_t p
     check_sm_param(sm);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
     uint32_t execctrl_saved = pio->sm[sm].execctrl;
-    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
+    hw_clear_bits(&pio->sm[sm].execctrl, 1u << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     while (pin_mask) {
         uint base = (uint)__builtin_ctz(pin_mask);
         pio->sm[sm].pinctrl =
@@ -217,7 +217,7 @@ void pio_sm_set_consecutive_pindirs(PIO pio, uint sm, uint pin, uint count, bool
     valid_params_if(PIO, pin < 32u);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
     uint32_t execctrl_saved = pio->sm[sm].execctrl;
-    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
+    hw_clear_bits(&pio->sm[sm].execctrl, 1u << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     uint pindir_val = is_out ? 0x1f : 0;
     while (count > 5) {
         pio->sm[sm].pinctrl = (5u << PIO_SM0_PINCTRL_SET_COUNT_LSB) | (pin << PIO_SM0_PINCTRL_SET_BASE_LSB);

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -157,6 +157,8 @@ void pio_sm_set_pins(PIO pio, uint sm, uint32_t pins) {
     check_pio_param(pio);
     check_sm_param(sm);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
+    uint32_t execctrl_saved = pio->sm[sm].execctrl;
+    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     uint remaining = 32;
     uint base = 0;
     while (remaining) {
@@ -170,12 +172,15 @@ void pio_sm_set_pins(PIO pio, uint sm, uint32_t pins) {
         pins >>= 5;
     }
     pio->sm[sm].pinctrl = pinctrl_saved;
+    pio->sm[sm].execctrl = execctrl_saved;
 }
 
 void pio_sm_set_pins_with_mask(PIO pio, uint sm, uint32_t pinvals, uint32_t pin_mask) {
     check_pio_param(pio);
     check_sm_param(sm);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
+    uint32_t execctrl_saved = pio->sm[sm].execctrl;
+    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     while (pin_mask) {
         uint base = (uint)__builtin_ctz(pin_mask);
         pio->sm[sm].pinctrl =
@@ -185,12 +190,15 @@ void pio_sm_set_pins_with_mask(PIO pio, uint sm, uint32_t pinvals, uint32_t pin_
         pin_mask &= pin_mask - 1;
     }
     pio->sm[sm].pinctrl = pinctrl_saved;
+    pio->sm[sm].execctrl = execctrl_saved;
 }
 
 void pio_sm_set_pindirs_with_mask(PIO pio, uint sm, uint32_t pindirs, uint32_t pin_mask) {
     check_pio_param(pio);
     check_sm_param(sm);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
+    uint32_t execctrl_saved = pio->sm[sm].execctrl;
+    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     while (pin_mask) {
         uint base = (uint)__builtin_ctz(pin_mask);
         pio->sm[sm].pinctrl =
@@ -200,6 +208,7 @@ void pio_sm_set_pindirs_with_mask(PIO pio, uint sm, uint32_t pindirs, uint32_t p
         pin_mask &= pin_mask - 1;
     }
     pio->sm[sm].pinctrl = pinctrl_saved;
+    pio->sm[sm].execctrl = execctrl_saved;
 }
 
 void pio_sm_set_consecutive_pindirs(PIO pio, uint sm, uint pin, uint count, bool is_out) {
@@ -207,6 +216,8 @@ void pio_sm_set_consecutive_pindirs(PIO pio, uint sm, uint pin, uint count, bool
     check_sm_param(sm);
     valid_params_if(PIO, pin < 32u);
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
+    uint32_t execctrl_saved = pio->sm[sm].execctrl;
+    pio->sm[sm].execctrl = pio->sm[sm].execctrl & ~(1 << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
     uint pindir_val = is_out ? 0x1f : 0;
     while (count > 5) {
         pio->sm[sm].pinctrl = (5u << PIO_SM0_PINCTRL_SET_COUNT_LSB) | (pin << PIO_SM0_PINCTRL_SET_BASE_LSB);
@@ -217,6 +228,7 @@ void pio_sm_set_consecutive_pindirs(PIO pio, uint sm, uint pin, uint count, bool
     pio->sm[sm].pinctrl = (count << PIO_SM0_PINCTRL_SET_COUNT_LSB) | (pin << PIO_SM0_PINCTRL_SET_BASE_LSB);
     pio_sm_exec(pio, sm, pio_encode_set(pio_pindirs, pindir_val));
     pio->sm[sm].pinctrl = pinctrl_saved;
+    pio->sm[sm].execctrl = execctrl_saved;
 }
 
 void pio_sm_init(PIO pio, uint sm, uint initial_pc, const pio_sm_config *config) {


### PR DESCRIPTION
To avoid the issue described in #988, temporarily clear the OUT_STICKY bit in the affected functions, and restore the value later.
(Note that I didn't test this fix with the C SDK. It's a port of https://github.com/rp-rs/rp-hal/pull/432 which was tested on real hardware, but I might have introduced bugs when porting it to C - my C has become quite rusty, pun intended... Please review carefully)

Fixes #988