### PR TITLE
Only include mutex header if necessary

### DIFF
--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -9,7 +9,9 @@
 #include <stdarg.h>
 
 #include "pico.h"
+#if PICO_STDOUT_MUTEX
 #include "pico/mutex.h"
+#endif
 #if LIB_PICO_PRINTF_PICO
 #include "pico/printf.h"
 #endif

--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -9,15 +9,15 @@
 #include <stdarg.h>
 
 #include "pico.h"
-#if PICO_STDOUT_MUTEX
-#include "pico/mutex.h"
-#endif
 #if LIB_PICO_PRINTF_PICO
 #include "pico/printf.h"
 #endif
 #include "pico/stdio.h"
 #include "pico/stdio/driver.h"
 #include "pico/time.h"
+#if PICO_STDOUT_MUTEX
+#include "pico/mutex.h"
+#endif
 
 #if LIB_PICO_STDIO_UART
 #include "pico/stdio_uart.h"


### PR DESCRIPTION
Fixes #990.
Put include guard around including pico/mutex.h.