### PR TITLE
Supress -Wunused-parameter when PICO_STDIO_ENABLE_CRLF_SUPPORT is unset

### DIFF
--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -310,6 +310,10 @@ void stdio_set_translate_crlf(stdio_driver_t *driver, bool enabled) {
     }
     driver->crlf_enabled = enabled;
 #else
+    // Suppress -Wunused-parameter
+    (void)driver;
+    (void)enabled;
+    
     panic_unsupported();
 #endif
 }


### PR DESCRIPTION
See #997 for explanation on the problem.

The fix proposed in this PR uses the `(void)variable` syntax to mark the variables as used as explained in <https://stackoverflow.com/a/3599170>. Another option would be to use the `unused` attribute (`__attribute__((unused))`) on both parameters as explained in <https://stackoverflow.com/a/3599203>.

I decided the first approach would better suit this situation as adding the unused attribute would require having the function signature defined twice which could lead to an accidental mismatch if the signature is changed but not tested with `PICO_STDIO_ENABLE_CRLF_SUPPORT` as 0.

Fixes #997