### PR TITLE
Fix cyw43_driver build

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/include/cyw43_configport.h
+++ b/src/rp2_common/pico_cyw43_arch/include/cyw43_configport.h
@@ -70,4 +70,8 @@
 #define CYW43_SPI_PIO 1
 #endif
 
+#ifndef CYW43_WIFI_NVRAM_INCLUDE_FILE
+#define CYW43_WIFI_NVRAM_INCLUDE_FILE "wifi_nvram_43439.h"
+#endif
+
 #endif


### PR DESCRIPTION
The latest version of the cyw43-driver fails to build with the pico-sdk
Caused by CYW43_WIFI_NVRAM_INCLUDE_FILE which requires the parent of the
firmware folder to be on the include path.

Fixes https://github.com/raspberrypi/pico-sdk/issues/1000
