### PR TITLE
Make __get_current_exception inline

### DIFF
--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -396,7 +396,11 @@ __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
  *
  * \return the exception number if the CPU is handling an exception, or 0 otherwise
  */
-uint __get_current_exception(void);
+static inline uint __get_current_exception(void) {
+    uint exception;
+    asm ("mrs %0, ipsr" : "=l" (exception));
+    return exception;
+}
 
 #define WRAPPER_FUNC(x) __wrap_ ## x
 #define REAL_FUNC(x) __real_ ## x

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -396,7 +396,7 @@ __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
  *
  * \return the exception number if the CPU is handling an exception, or 0 otherwise
  */
-static inline uint __get_current_exception(void) {
+inline uint __get_current_exception(void) {
     uint exception;
     asm ("mrs %0, ipsr" : "=l" (exception));
     return exception;

--- a/src/rp2_common/pico_standard_link/crt0.S
+++ b/src/rp2_common/pico_standard_link/crt0.S
@@ -8,6 +8,7 @@
 #include "hardware/regs/m0plus.h"
 #include "hardware/regs/addressmap.h"
 #include "hardware/regs/sio.h"
+#include "pico/asm_helper.S"
 #include "pico/binary_info/defs.h"
 
 #ifdef NDEBUG
@@ -325,6 +326,9 @@ hold_non_core0_in_bootrom:
     bl rom_func_lookup
     bx r0
 
+regular_func_with_section __get_current_exception
+    mrs r0, ipsr
+    bx lr
 
 // ----------------------------------------------------------------------------
 // Stack/heap dummies to set size

--- a/src/rp2_common/pico_standard_link/crt0.S
+++ b/src/rp2_common/pico_standard_link/crt0.S
@@ -147,7 +147,7 @@ decl_isr isr_irq31
 .global __unhandled_user_irq
 .thumb_func
 __unhandled_user_irq:
-    bl __get_current_exception
+    mrs  r0, ipsr
     subs r0, #16
 .global unhandled_user_irq_num_in_r0
 unhandled_user_irq_num_in_r0:
@@ -325,12 +325,6 @@ hold_non_core0_in_bootrom:
     bl rom_func_lookup
     bx r0
 
-.global __get_current_exception
-.thumb_func
-__get_current_exception:
-    mrs  r0, ipsr
-    uxtb r0, r0
-    bx   lr
 
 // ----------------------------------------------------------------------------
 // Stack/heap dummies to set size

--- a/src/rp2_common/pico_standard_link/crt0.S
+++ b/src/rp2_common/pico_standard_link/crt0.S
@@ -326,10 +326,6 @@ hold_non_core0_in_bootrom:
     bl rom_func_lookup
     bx r0
 
-regular_func_with_section __get_current_exception
-    mrs r0, ipsr
-    bx lr
-
 // ----------------------------------------------------------------------------
 // Stack/heap dummies to set size
 


### PR DESCRIPTION
Implement __get_current_exception as static inline function using inline assembly. Remove redundant UXTB instruction.

I found only one call site in assembly language in crt0.S, which I replaced with an MRS instruction.

To test changes, I built the SDK and ran pico_sem_test and kitchen_sink in debug and release.