### PR TITLE
Avoid compound assignment with volatile left operand as described in #1017

### DIFF
--- a/src/rp2_common/hardware_interp/include/hardware/interp.h
+++ b/src/rp2_common/hardware_interp/include/hardware/interp.h
@@ -296,7 +296,7 @@ static inline void interp_set_config(interp_hw_t *interp, uint lane, interp_conf
  */
 static inline void interp_set_force_bits(interp_hw_t *interp, uint lane, uint bits) {
     // note cannot use hw_set_bits on SIO
-    interp->ctrl[lane] |= (bits << SIO_INTERP0_CTRL_LANE0_FORCE_MSB_LSB);
+    interp->ctrl[lane] = interp->ctrl[lane] | (bits << SIO_INTERP0_CTRL_LANE0_FORCE_MSB_LSB);
 }
 
 typedef struct {

--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -580,7 +580,7 @@ static inline void pio_set_sm_mask_enabled(PIO pio, uint32_t mask, bool enabled)
 static inline void pio_sm_restart(PIO pio, uint sm) {
     check_pio_param(pio);
     check_sm_param(sm);
-    pio->ctrl = pio->ctrl | (1u << (PIO_CTRL_SM_RESTART_LSB + sm));
+    hw_set_bits(&pio->ctrl, 1u << (PIO_CTRL_SM_RESTART_LSB + sm));
 }
 
 /*! \brief Restart multiple state machine with a known state
@@ -595,7 +595,7 @@ static inline void pio_sm_restart(PIO pio, uint sm) {
 static inline void pio_restart_sm_mask(PIO pio, uint32_t mask) {
     check_pio_param(pio);
     check_sm_mask(mask);
-    pio->ctrl = pio->ctrl | ((mask << PIO_CTRL_SM_RESTART_LSB) & PIO_CTRL_SM_RESTART_BITS);
+    hw_set_bits(&pio->ctrl, (mask << PIO_CTRL_SM_RESTART_LSB) & PIO_CTRL_SM_RESTART_BITS);
 }
 
 /*! \brief Restart a state machine's clock divider from a phase of 0
@@ -622,7 +622,7 @@ static inline void pio_restart_sm_mask(PIO pio, uint32_t mask) {
 static inline void pio_sm_clkdiv_restart(PIO pio, uint sm) {
     check_pio_param(pio);
     check_sm_param(sm);
-    pio->ctrl = pio->ctrl | (1u << (PIO_CTRL_CLKDIV_RESTART_LSB + sm));
+    hw_set_bits(&pio->ctrl, 1u << (PIO_CTRL_CLKDIV_RESTART_LSB + sm));
 }
 
 /*! \brief Restart multiple state machines' clock dividers from a phase of 0.
@@ -657,7 +657,7 @@ static inline void pio_sm_clkdiv_restart(PIO pio, uint sm) {
 static inline void pio_clkdiv_restart_sm_mask(PIO pio, uint32_t mask) {
     check_pio_param(pio);
     check_sm_mask(mask);
-    pio->ctrl = pio->ctrl | ((mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS);
+    hw_set_bits(&pio->ctrl, (mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS);
 }
 
 /*! \brief Enable multiple PIO state machines synchronizing their clock dividers
@@ -674,9 +674,9 @@ static inline void pio_clkdiv_restart_sm_mask(PIO pio, uint32_t mask) {
 static inline void pio_enable_sm_mask_in_sync(PIO pio, uint32_t mask) {
     check_pio_param(pio);
     check_sm_mask(mask);
-    pio->ctrl = pio->ctrl |
-                (((mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS) |
-                ((mask << PIO_CTRL_SM_ENABLE_LSB) & PIO_CTRL_SM_ENABLE_BITS));
+    hw_set_bits(&pio->ctrl,
+        ((mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS) |
+        ((mask << PIO_CTRL_SM_ENABLE_LSB) & PIO_CTRL_SM_ENABLE_BITS));
 }
 
 /*! \brief PIO interrupt source numbers for pio related IRQs

--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -580,7 +580,7 @@ static inline void pio_set_sm_mask_enabled(PIO pio, uint32_t mask, bool enabled)
 static inline void pio_sm_restart(PIO pio, uint sm) {
     check_pio_param(pio);
     check_sm_param(sm);
-    pio->ctrl |= 1u << (PIO_CTRL_SM_RESTART_LSB + sm);
+    pio->ctrl = pio->ctrl | (1u << (PIO_CTRL_SM_RESTART_LSB + sm));
 }
 
 /*! \brief Restart multiple state machine with a known state
@@ -595,7 +595,7 @@ static inline void pio_sm_restart(PIO pio, uint sm) {
 static inline void pio_restart_sm_mask(PIO pio, uint32_t mask) {
     check_pio_param(pio);
     check_sm_mask(mask);
-    pio->ctrl |= (mask << PIO_CTRL_SM_RESTART_LSB) & PIO_CTRL_SM_RESTART_BITS;
+    pio->ctrl = pio->ctrl | ((mask << PIO_CTRL_SM_RESTART_LSB) & PIO_CTRL_SM_RESTART_BITS);
 }
 
 /*! \brief Restart a state machine's clock divider from a phase of 0
@@ -622,7 +622,7 @@ static inline void pio_restart_sm_mask(PIO pio, uint32_t mask) {
 static inline void pio_sm_clkdiv_restart(PIO pio, uint sm) {
     check_pio_param(pio);
     check_sm_param(sm);
-    pio->ctrl |= 1u << (PIO_CTRL_CLKDIV_RESTART_LSB + sm);
+    pio->ctrl = pio->ctrl | (1u << (PIO_CTRL_CLKDIV_RESTART_LSB + sm));
 }
 
 /*! \brief Restart multiple state machines' clock dividers from a phase of 0.
@@ -657,7 +657,7 @@ static inline void pio_sm_clkdiv_restart(PIO pio, uint sm) {
 static inline void pio_clkdiv_restart_sm_mask(PIO pio, uint32_t mask) {
     check_pio_param(pio);
     check_sm_mask(mask);
-    pio->ctrl |= (mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS;
+    pio->ctrl = pio->ctrl | ((mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS);
 }
 
 /*! \brief Enable multiple PIO state machines synchronizing their clock dividers
@@ -674,8 +674,9 @@ static inline void pio_clkdiv_restart_sm_mask(PIO pio, uint32_t mask) {
 static inline void pio_enable_sm_mask_in_sync(PIO pio, uint32_t mask) {
     check_pio_param(pio);
     check_sm_mask(mask);
-    pio->ctrl |= ((mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS) |
-                 ((mask << PIO_CTRL_SM_ENABLE_LSB) & PIO_CTRL_SM_ENABLE_BITS);
+    pio->ctrl = pio->ctrl |
+                (((mask << PIO_CTRL_CLKDIV_RESTART_LSB) & PIO_CTRL_CLKDIV_RESTART_BITS) |
+                ((mask << PIO_CTRL_SM_ENABLE_LSB) & PIO_CTRL_SM_ENABLE_BITS));
 }
 
 /*! \brief PIO interrupt source numbers for pio related IRQs


### PR DESCRIPTION
Fixes #1017

Checked by compiling a C++ file that includes all the same files included by `kitchen_sink.c`.