### PR TITLE
C aspects of portability to IAR toolchain

### DIFF
--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -16,7 +16,7 @@
 #include "pico/binary_info/structure.h"
 
 #if !PICO_NO_BINARY_INFO
-#define __bi_decl(name, bi, section_prefix, attr) static const attr __attribute__((section(section_prefix __STRING(name)))) struct _binary_info_core *name = bi
+#define __bi_decl(name, bi, section_prefix, attr) static const attr __attribute__((section(section_prefix __STRING(name)))) struct _binary_info_core *const name = bi
 #define __bi_lineno_var_name __CONCAT(__bi_, __LINE__)
 #define __bi_ptr_lineno_var_name __CONCAT(__bi_ptr, __LINE__)
 #define __bi_enclosure_check_lineno_var_name __CONCAT(_error_bi_is_missing_enclosing_decl_,__LINE__)

--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -21,7 +21,7 @@
 #define __bi_ptr_lineno_var_name __CONCAT(__bi_ptr, __LINE__)
 #define __bi_enclosure_check_lineno_var_name __CONCAT(_error_bi_is_missing_enclosing_decl_,__LINE__)
 #define __bi_mark_enclosure static const __unused int __bi_enclosure_check_lineno_var_name=0;
-#if !defined(__GNUC__) || __cplusplus || __GNUC__ >= 8
+#if __cplusplus || __GNUC__ >= 8
 #define __bi_enclosure_check(x) (x + __bi_enclosure_check_lineno_var_name)
 #else
 // skip the version check on older GCC non C++, as it doesn't compile.. this is only here to catch the

--- a/src/common/pico_sync/sem.c
+++ b/src/common/pico_sync/sem.c
@@ -15,7 +15,11 @@ void sem_init(semaphore_t *sem, int16_t initial_permits, int16_t max_permits) {
 }
 
 int __time_critical_func(sem_available)(semaphore_t *sem) {
-    return *(volatile typeof(sem->permits) *) &sem->permits;
+#ifdef __GNUC__
+    #define IS_INT16(x) _Generic((x), int16_t: 1, default: 0)
+	static_assert(IS_INT16((typeof(sem->permits))0));
+#endif
+    return *(volatile int16_t *) &sem->permits;
 }
 
 void __time_critical_func(sem_acquire_blocking)(semaphore_t *sem) {

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -22,7 +22,7 @@ typedef struct alarm_pool_entry {
     void *user_data;
 } alarm_pool_entry_t;
 
-typedef struct alarm_pool {
+struct alarm_pool {
     pheap_t *heap;
     spin_lock_t *lock;
     alarm_pool_entry_t *entries;
@@ -32,7 +32,7 @@ typedef struct alarm_pool {
     alarm_id_t alarm_in_progress; // this is set during a callback from the IRQ handler... it can be cleared by alarm_cancel to prevent repeats
     uint8_t hardware_alarm_num;
     uint8_t core_num;
-} alarm_pool_t;
+};
 
 #if !PICO_TIME_DEFAULT_ALARM_POOL_DISABLED
 // To avoid bringing in calloc, we statically allocate the arrays and the heap

--- a/src/common/pico_util/include/pico/util/queue.h
+++ b/src/common/pico_util/include/pico/util/queue.h
@@ -59,7 +59,7 @@ void queue_init_with_spinlock(queue_t *q, uint element_size, uint element_count,
  * \param element_count Maximum number of entries in the queue
  */
 static inline void queue_init(queue_t *q, uint element_size, uint element_count) {
-    return queue_init_with_spinlock(q, element_size, element_count, next_striped_spin_lock_num());
+    queue_init_with_spinlock(q, element_size, element_count, next_striped_spin_lock_num());
 }
 
 /*! \brief Destroy the specified queue.

--- a/src/rp2_common/hardware_base/include/hardware/address_mapped.h
+++ b/src/rp2_common/hardware_base/include/hardware/address_mapped.h
@@ -105,12 +105,21 @@ static __force_inline uint32_t xip_alias_check_addr(const void *addr) {
 #define xip_nocache_noalloc_alias_untyped(addr) ((void *)(XIP_NOCACHE_NOALLOC_BASE | xip_alias_check_addr(addr)))
 
 // Typed conversion alias pointer generation macros
+#ifdef __GNUC__
 #define hw_set_alias(p) ((typeof(p))hw_set_alias_untyped(p))
 #define hw_clear_alias(p) ((typeof(p))hw_clear_alias_untyped(p))
 #define hw_xor_alias(p) ((typeof(p))hw_xor_alias_untyped(p))
 #define xip_noalloc_alias(p) ((typeof(p))xip_noalloc_alias_untyped(p))
 #define xip_nocache_alias(p) ((typeof(p))xip_nocache_alias_untyped(p))
 #define xip_nocache_noalloc_alias(p) ((typeof(p))xip_nocache_noalloc_alias_untyped(p))
+#else
+#define hw_set_alias(p) hw_set_alias_untyped(p)
+#define hw_clear_alias(p) hw_clear_alias_untyped(p)
+#define hw_xor_alias(p) hw_xor_alias_untyped(p)
+#define xip_noalloc_alias(p) xip_noalloc_alias_untyped(p)
+#define xip_nocache_alias(p) xip_nocache_alias_untyped(p)
+#define xip_nocache_noalloc_alias(p) xip_nocache_noalloc_alias_untyped(p)
+#endif
 
 /*! \brief Atomically set the specified bits to 1 in a HW register
  *  \ingroup hardware_base

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -78,7 +78,7 @@ bool clock_configure(enum clock_index clk_index, uint32_t src, uint32_t auxsrc, 
             // Note XOSC_COUNT is not helpful here because XOSC is not
             // necessarily running, nor is timer... so, 3 cycles per loop:
             uint delay_cyc = configured_freq[clk_sys] / configured_freq[clk_index] + 1;
-            asm volatile (
+            __asm volatile (
                 ".syntax unified \n\t"
                 "1: \n\t"
                 "subs %0, #1 \n\t"

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -79,7 +79,9 @@ bool clock_configure(enum clock_index clk_index, uint32_t src, uint32_t auxsrc, 
             // necessarily running, nor is timer... so, 3 cycles per loop:
             uint delay_cyc = configured_freq[clk_sys] / configured_freq[clk_index] + 1;
             __asm volatile (
+#ifdef __GNUC__
                 ".syntax unified \n\t"
+#endif
                 "1: \n\t"
                 "subs %0, #1 \n\t"
                 "bne 1b"

--- a/src/rp2_common/hardware_divider/include/hardware/divider.h
+++ b/src/rp2_common/hardware_divider/include/hardware/divider.h
@@ -85,7 +85,7 @@ static inline void hw_divider_wait_ready(void) {
     // we use one less register and instruction than gcc which uses a TST instruction
 
     uint32_t tmp; // allow compiler to pick scratch register
-    asm volatile (
+    __asm volatile (
     "hw_divider_result_loop_%=:"
     "ldr %0, [%1, %2]\n\t"
     "lsr %0, #1\n\t"
@@ -295,7 +295,7 @@ static inline int32_t hw_divider_remainder_s32(int32_t a, int32_t b) {
  *  \ingroup hardware_divider
  */
 static inline void hw_divider_pause(void) {
-    asm volatile (
+    __asm volatile (
     "b _1_%=\n"
     "_1_%=:\n"
     "b _2_%=\n"

--- a/src/rp2_common/hardware_divider/include/hardware/divider.h
+++ b/src/rp2_common/hardware_divider/include/hardware/divider.h
@@ -108,7 +108,8 @@ static inline void hw_divider_wait_ready(void) {
  */
 static inline divmod_result_t hw_divider_result_nowait(void) {
     // as ugly as this looks it is actually quite efficient
-    divmod_result_t rc = (((divmod_result_t) sio_hw->div_remainder) << 32u) | sio_hw->div_quotient;
+    divmod_result_t rc = ((divmod_result_t) sio_hw->div_remainder) << 32u;
+    rc |= sio_hw->div_quotient;
     return rc;
 }
 

--- a/src/rp2_common/hardware_divider/include/hardware/divider.h
+++ b/src/rp2_common/hardware_divider/include/hardware/divider.h
@@ -86,9 +86,12 @@ static inline void hw_divider_wait_ready(void) {
 
     uint32_t tmp; // allow compiler to pick scratch register
     __asm volatile (
+#ifdef __GNUC__
+    ".syntax unified\n"
+#endif
     "hw_divider_result_loop_%=:"
     "ldr %0, [%1, %2]\n\t"
-    "lsr %0, #1\n\t"
+    "lsrs %0, #1\n\t"
     "bcc hw_divider_result_loop_%=\n\t"
     : "=&l" (tmp)
     : "l" (sio_hw), "I" (SIO_DIV_CSR_OFFSET)

--- a/src/rp2_common/hardware_divider/include/hardware/divider.h
+++ b/src/rp2_common/hardware_divider/include/hardware/divider.h
@@ -91,7 +91,7 @@ static inline void hw_divider_wait_ready(void) {
 #endif
     "hw_divider_result_loop_%=:"
     "ldr %0, [%1, %2]\n\t"
-    "lsrs %0, #1\n\t"
+    "lsrs %0, %0, #1\n\t"
     "bcc hw_divider_result_loop_%=\n\t"
     : "=&l" (tmp)
     : "l" (sio_hw), "I" (SIO_DIV_CSR_OFFSET)

--- a/src/rp2_common/hardware_dma/dma.c
+++ b/src/rp2_common/hardware_dma/dma.c
@@ -13,8 +13,8 @@ check_hw_size(dma_channel_hw_t, DMA_CHAN_STRIDE);
 check_hw_layout(dma_hw_t, abort, DMA_CHAN_ABORT_OFFSET);
 
 // sanity check
-static_assert(__builtin_offsetof(dma_hw_t, ch[0].ctrl_trig) == DMA_CH0_CTRL_TRIG_OFFSET, "hw mismatch");
-static_assert(__builtin_offsetof(dma_hw_t, ch[1].ctrl_trig) == DMA_CH1_CTRL_TRIG_OFFSET, "hw mismatch");
+static_assert(offsetof(dma_hw_t, ch[0].ctrl_trig) == DMA_CH0_CTRL_TRIG_OFFSET, "hw mismatch");
+static_assert(offsetof(dma_hw_t, ch[1].ctrl_trig) == DMA_CH1_CTRL_TRIG_OFFSET, "hw mismatch");
 
 static_assert(NUM_DMA_CHANNELS <= 16, "");
 static uint16_t _claimed;

--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -41,7 +41,7 @@ static void __no_inline_not_in_flash_func(flash_init_boot2_copyout)(void) {
 }
 
 static void __no_inline_not_in_flash_func(flash_enable_xip_via_boot2)(void) {
-    ((void (*)(void))boot2_copyout+1)();
+    ((void (*)(void))((intptr_t)boot2_copyout+1))();
 }
 
 #else

--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -25,11 +25,13 @@ static inline void i2c_unreset(i2c_inst_t *i2c) {
     unreset_block_wait(i2c == i2c0 ? RESETS_RESET_I2C0_BITS : RESETS_RESET_I2C1_BITS);
 }
 
+#ifndef NDEBUG
 // Addresses of the form 000 0xxx or 111 1xxx are reserved. No slave should
 // have these addresses.
 static inline bool i2c_reserved_addr(uint8_t addr) {
     return (addr & 0x78) == 0 || (addr & 0x78) == 0x78;
 }
+#endif
 
 uint i2c_init(i2c_inst_t *i2c, uint baudrate) {
     i2c_reset(i2c);

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -211,9 +211,9 @@ void irq_add_shared_handler(uint num, irq_handler_t handler, uint8_t order_prior
         // start new chain
         hard_assert(vtable_handler == __unhandled_user_irq);
         struct irq_handler_chain_slot slot_data = {
-                .inst1 = 0xa100,                                                    // add r1, pc, #0
-                .inst2 = make_branch(&slot->inst2, irq_handler_chain_first_slot),   // b irq_handler_chain_first_slot
-                .inst3 = 0xbd01,                                                    // pop {r0, pc}
+                .inst1 = 0xa100,                                                             // add r1, pc, #0
+                .inst2 = make_branch(&slot->inst2, (void *) irq_handler_chain_first_slot),   // b irq_handler_chain_first_slot
+                .inst3 = 0xbd01,                                                             // pop {r0, pc}
                 .link = -1,
                 .priority = order_priority,
                 .handler = handler
@@ -223,7 +223,7 @@ void irq_add_shared_handler(uint num, irq_handler_t handler, uint8_t order_prior
     } else {
         assert(!((((uintptr_t)vtable_handler) - ((uintptr_t)irq_handler_chain_slots) - 1)%sizeof(struct irq_handler_chain_slot)));
         struct irq_handler_chain_slot *prev_slot = NULL;
-        struct irq_handler_chain_slot *existing_vtable_slot = remove_thumb_bit(vtable_handler);
+        struct irq_handler_chain_slot *existing_vtable_slot = remove_thumb_bit((void *) vtable_handler);
         struct irq_handler_chain_slot *cur_slot = existing_vtable_slot;
         while (cur_slot->priority > order_priority) {
             prev_slot = cur_slot;
@@ -249,9 +249,9 @@ void irq_add_shared_handler(uint num, irq_handler_t handler, uint8_t order_prior
         } else {
             // update with new chain head
             struct irq_handler_chain_slot slot_data = {
-                    .inst1 = 0xa100,                                                    // add r1, pc, #0
-                    .inst2 = make_branch(&slot->inst2, irq_handler_chain_first_slot),   // b irq_handler_chain_first_slot
-                    .inst3 = make_branch(&slot->inst3, existing_vtable_slot),           // b existing_slot
+                    .inst1 = 0xa100,                                                             // add r1, pc, #0
+                    .inst2 = make_branch(&slot->inst2, (void *) irq_handler_chain_first_slot),   // b irq_handler_chain_first_slot
+                    .inst3 = make_branch(&slot->inst3, existing_vtable_slot),                    // b existing_slot
                     .link = get_slot_index(existing_vtable_slot),
                     .priority = order_priority,
                     .handler = handler
@@ -299,7 +299,7 @@ void irq_remove_handler(uint num, irq_handler_t handler) {
             hard_assert(!exception || exception == num + 16);
 
             struct irq_handler_chain_slot *prev_slot = NULL;
-            struct irq_handler_chain_slot *existing_vtable_slot = remove_thumb_bit(vtable_handler);
+            struct irq_handler_chain_slot *existing_vtable_slot = remove_thumb_bit((void *) vtable_handler);
             struct irq_handler_chain_slot *to_free_slot = existing_vtable_slot;
             while (to_free_slot->handler != handler) {
                 prev_slot = to_free_slot;
@@ -344,7 +344,7 @@ void irq_remove_handler(uint num, irq_handler_t handler) {
                         // it to bl to irq_handler_chain_remove_tail which will remove the slot.
                         // NOTE THAT THIS TRASHES PRIORITY AND LINK SINCE THIS IS A 4 BYTE INSTRUCTION
                         //      BUT THEY ARE NOT NEEDED NOW
-                        insert_branch_and_link(&to_free_slot->inst3, irq_handler_chain_remove_tail);
+                        insert_branch_and_link(&to_free_slot->inst3, (void *) irq_handler_chain_remove_tail);
                     }
                 }
             } else {

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -176,7 +176,7 @@ static inline int8_t slot_diff(struct irq_handler_chain_slot *to, struct irq_han
     int32_t result = 0xaaaa;
     // return (to - from);
     // note this implementation has limited range, but is fine for plenty more than -128->127 result
-    asm (".syntax unified\n"
+    __asm (".syntax unified\n"
          "subs %1, %2\n"
          "adcs %1, %1\n" // * 2 (and + 1 if negative for rounding)
          "muls %0, %1\n"

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -176,7 +176,10 @@ static inline int8_t slot_diff(struct irq_handler_chain_slot *to, struct irq_han
     int32_t result = 0xaaaa;
     // return (to - from);
     // note this implementation has limited range, but is fine for plenty more than -128->127 result
-    __asm (".syntax unified\n"
+    __asm (
+#ifdef __GNUC__
+         ".syntax unified\n"
+#endif
          "subs %1, %2\n"
          "adcs %1, %1\n" // * 2 (and + 1 if negative for rounding)
          "muls %0, %1\n"

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -183,7 +183,7 @@ static inline int8_t slot_diff(struct irq_handler_chain_slot *to, struct irq_han
          "subs %1, %2\n"
          "adcs %1, %1\n" // * 2 (and + 1 if negative for rounding)
          "muls %0, %1\n"
-         "lsrs %0, 20\n"
+         "lsrs %0, %0, #20\n"
          : "+l" (result), "+l" (to)
          : "l" (from)
          :

--- a/src/rp2_common/hardware_sync/include/hardware/sync.h
+++ b/src/rp2_common/hardware_sync/include/hardware/sync.h
@@ -249,7 +249,15 @@ __force_inline static void spin_lock_unsafe_blocking(spin_lock_t *lock) {
     // Note we don't do a wfe or anything, because by convention these spin_locks are VERY SHORT LIVED and NEVER BLOCK and run
     // with INTERRUPTS disabled (to ensure that)... therefore nothing on our core could be blocking us, so we just need to wait on another core
     // anyway which should be finished soon
-    while (__builtin_expect(!*lock, 0));
+    while (
+#ifdef __GNUC__
+        __builtin_expect(
+#endif
+        !*lock
+#ifdef __GNUC__
+        , 0)
+#endif
+        );
     __mem_fence_acquire();
 }
 

--- a/src/rp2_common/pico_bootrom/bootrom.c
+++ b/src/rp2_common/pico_bootrom/bootrom.c
@@ -8,10 +8,6 @@
 
 /// \tag::table_lookup[]
 
-// Bootrom function: rom_table_lookup
-// Returns the 32 bit pointer into the ROM if found or NULL otherwise.
-typedef void *(*rom_table_lookup_fn)(uint16_t *table, uint32_t code);
-
 void *rom_func_lookup(uint32_t code) {
     return rom_func_lookup_inline(code);
 }

--- a/src/rp2_common/pico_double/double_init_rom.c
+++ b/src/rp2_common/pico_double/double_init_rom.c
@@ -47,7 +47,7 @@ void __aeabi_double_init(void) {
 #endif
     if (rom_version >= 2) {
         void *rom_table = rom_data_lookup(rom_table_code('S', 'D'));
-        assert(*((uint8_t *)(((void *)rom_data_lookup(rom_table_code('S', 'F')))-2)) * 4 >= SF_TABLE_V2_SIZE);
+        assert(*((uint8_t *)rom_data_lookup(rom_table_code('S', 'F'))-2) * 4 >= SF_TABLE_V2_SIZE);
         memcpy(&sd_table, rom_table, SF_TABLE_V2_SIZE);
         if (rom_version == 2) {
 #ifndef NDEBUG

--- a/src/rp2_common/pico_double/double_math.c
+++ b/src/rp2_common/pico_double/double_math.c
@@ -9,10 +9,12 @@
 #include "pico/double.h"
 #include "pico/platform.h"
 
+#ifdef __GNUC__
 // opened a separate issue https://github.com/raspberrypi/pico-sdk/issues/166 to deal with these warnings if at all
 _Pragma("GCC diagnostic push")
 _Pragma("GCC diagnostic ignored \"-Wconversion\"")
 _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
+#endif
 
 typedef uint64_t ui64;
 typedef uint32_t ui32;
@@ -421,10 +423,14 @@ static double dpowint_0(double x,int y) {
 }
 
 double WRAPPER_FUNC(powint)(double x,int y) {
+#ifdef __GNUC__
     _Pragma("GCC diagnostic push")
     _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
+#endif
     if(x==1.0||y==0) return 1;
+#ifdef __GNUC__
     _Pragma("GCC diagnostic pop")
+#endif
     check_nan_d1(x);
     if(diszero(x)) {
         if(y>0) {
@@ -470,13 +476,17 @@ static double dpow_0(double x,double y) {
 }
 
 double WRAPPER_FUNC(pow)(double x,double y) {
+#ifdef __GNUC__
     _Pragma("GCC diagnostic push")
     _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
+#endif
 
     if(x==1.0||diszero(y)) return 1;
     check_nan_d2(x, y);
     if(x==-1.0&&disinf(y)) return 1;
+#ifdef __GNUC__
     _Pragma("GCC diagnostic pop")
+#endif
 
     if(diszero(x)) {
         if(!disneg(y)) {
@@ -623,4 +633,6 @@ double WRAPPER_FUNC(drem)(double x,double y) { check_nan_d2(x, y); return remquo
 
 double WRAPPER_FUNC(remainder)(double x,double y) { check_nan_d2(x, y); return remquo(x,y,0); }
 
+#ifdef __GNUC__
 _Pragma("GCC diagnostic pop") // conversion
+#endif

--- a/src/rp2_common/pico_double/double_math.c
+++ b/src/rp2_common/pico_double/double_math.c
@@ -60,11 +60,13 @@ static inline ui64 double2ui64(double d) {
     return tmp.ix;
 }
 
+#if 0
 static inline bool disnan(double x) {
     ui64 ix= double2ui64(x);
     // checks the top bit of the low 32 bit of the NAN, but it I think that is ok
     return ((uint32_t)(ix >> 31)) > 0xffe00000u;
 }
+#endif
 
 #if PICO_DOUBLE_PROPAGATE_NANS
 #define check_nan_d1(x) if (disnan((x))) return (x)
@@ -113,8 +115,10 @@ double WRAPPER_FUNC(copysign)(double x, double y) {
     return dcopysign(x, y);
 }
 static inline int diszero(double x)  { return dgetexp    (x)==0; }
+#if 0
 static inline int dispzero(double x) { return dgetsignexp(x)==0; }
 static inline int dismzero(double x) { return dgetsignexp(x)==0x800; }
+#endif
 static inline int disinf(double x)   { return dgetexp    (x)==0x7ff; }
 static inline int dispinf(double x)  { return dgetsignexp(x)==0x7ff; }
 static inline int disminf(double x)  { return dgetsignexp(x)==0xfff; }

--- a/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c
+++ b/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/rp2040_usb_device_enumeration.c
@@ -110,8 +110,9 @@ static void hw_enumeration_fix_force_ls_j(void) {
     gpio_set_inover(dp, GPIO_OVERRIDE_HIGH);
 
     // Force PHY pull up to stay before switching away from the phy
-    hw_set_alias(usb_hw)->phy_direct = USB_USBPHY_DIRECT_DP_PULLUP_EN_BITS;
-    hw_set_alias(usb_hw)->phy_direct_override = USB_USBPHY_DIRECT_OVERRIDE_DP_PULLUP_EN_OVERRIDE_EN_BITS;
+    usb_hw_t *usb_hw_set = hw_set_alias(usb_hw);
+    usb_hw_set->phy_direct = USB_USBPHY_DIRECT_DP_PULLUP_EN_BITS;
+    usb_hw_set->phy_direct_override = USB_USBPHY_DIRECT_OVERRIDE_DP_PULLUP_EN_OVERRIDE_EN_BITS;
 
     // Switch to GPIO phy with LS_J forced
     usb_hw->muxing = USB_USB_MUXING_TO_DIGITAL_PAD_BITS | USB_USB_MUXING_SOFTCON_BITS;
@@ -138,7 +139,8 @@ static void hw_enumeration_fix_finish(void) {
     usb_hw->muxing = USB_USB_MUXING_TO_PHY_BITS | USB_USB_MUXING_SOFTCON_BITS;
 
     // Get rid of DP pullup override
-    hw_clear_alias(usb_hw)->phy_direct_override = USB_USBPHY_DIRECT_OVERRIDE_DP_PULLUP_EN_OVERRIDE_EN_BITS;
+    usb_hw_t *usb_hw_clear = hw_clear_alias(usb_hw);
+    usb_hw_clear->phy_direct_override = USB_USBPHY_DIRECT_OVERRIDE_DP_PULLUP_EN_OVERRIDE_EN_BITS;
 
     // Finally, restore the gpio ctrl value back to GPIO15
     iobank0_hw->io[dp].ctrl = gpio_ctrl_prev;

--- a/src/rp2_common/pico_float/float_init_rom.c
+++ b/src/rp2_common/pico_float/float_init_rom.c
@@ -63,7 +63,7 @@ void __aeabi_float_init(void) {
     }
 #endif
     if (rom_version >= 2) {
-        assert(*((uint8_t *)(rom_table-2)) * 4 >= SF_TABLE_V2_SIZE);
+        assert(*((uint8_t *)rom_table-2) * 4 >= SF_TABLE_V2_SIZE);
         memcpy(&sf_table, rom_table, SF_TABLE_V2_SIZE);
     }
     sf_clz_func = rom_func_lookup(ROM_FUNC_CLZ32);

--- a/src/rp2_common/pico_float/float_math.c
+++ b/src/rp2_common/pico_float/float_math.c
@@ -8,10 +8,12 @@
 #include "pico/float.h"
 #include "pico/platform.h"
 
+#ifdef __GNUC__
 // opened a separate issue https://github.com/raspberrypi/pico-sdk/issues/166 to deal with these warnings if at all
 _Pragma("GCC diagnostic push")
 _Pragma("GCC diagnostic ignored \"-Wconversion\"")
 _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")
+#endif
 
 typedef uint32_t ui32;
 typedef int32_t i32;
@@ -379,8 +381,10 @@ static float fpowint_0(float x,int y) {
 }
 
 float WRAPPER_FUNC(powintf)(float x,int y) {
+#ifdef __GNUC__
     _Pragma("GCC diagnostic push")
     _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
+#endif
     if(x==1.0f||y==0) return 1;
     if(x==0.0f) {
         if(y>0) {
@@ -390,7 +394,9 @@ float WRAPPER_FUNC(powintf)(float x,int y) {
         if((y&1)) return fcopysign(FPINF,x);
         return FPINF;
     }
+#ifdef __GNUC__
     _Pragma("GCC diagnostic pop")
+#endif
     check_nan_f1(x);
     if(fispinf(x)) {
         if(y<0) return 0;
@@ -428,12 +434,16 @@ static float fpow_0(float x,float y) {
 }
 
 float WRAPPER_FUNC(powf)(float x,float y) {
+#ifdef __GNUC__
     _Pragma("GCC diagnostic push")
     _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
+#endif
     if(x==1.0f||fiszero(y)) return 1;
     check_nan_f2(x,y);
     if(x==-1.0f&&fisinf(y)) return 1;
+#ifdef __GNUC__
     _Pragma("GCC diagnostic pop")
+#endif
     if(fiszero(x)) {
         if(!fisneg(y)) {
             if(fisoddint(y)) return x;
@@ -581,4 +591,6 @@ float WRAPPER_FUNC(dremf)(float x,float y) { check_nan_f2(x,y); return remquof(x
 
 float WRAPPER_FUNC(remainderf)(float x,float y) { check_nan_f2(x,y); return remquof(x,y,0); }
 
+#ifdef __GNUC__
 _Pragma("GCC diagnostic pop") // conversion
+#endif

--- a/src/rp2_common/pico_float/float_math.c
+++ b/src/rp2_common/pico_float/float_math.c
@@ -58,10 +58,12 @@ static inline ui32 float2ui32(float f) {
     return tmp.ix;
 }
 
+#if 0
 static inline bool fisnan(float x) {
     ui32 ix=float2ui32(x);
     return ix * 2 > 0xff000000u;
 }
+#endif
 
 #if PICO_FLOAT_PROPAGATE_NANS
 #define check_nan_f1(x) if (fisnan((x))) return (x)
@@ -110,8 +112,10 @@ float WRAPPER_FUNC(copysignf)(float x, float y) {
 }
 
 static inline int fiszero(float x)  { return fgetexp    (x)==0; }
+#if 0
 static inline int fispzero(float x) { return fgetsignexp(x)==0; }
 static inline int fismzero(float x) { return fgetsignexp(x)==0x100; }
+#endif
 static inline int fisinf(float x)   { return fgetexp    (x)==0xff; }
 static inline int fispinf(float x)  { return fgetsignexp(x)==0xff; }
 static inline int fisminf(float x)  { return fgetsignexp(x)==0x1ff; }

--- a/src/rp2_common/pico_malloc/pico_malloc.c
+++ b/src/rp2_common/pico_malloc/pico_malloc.c
@@ -8,16 +8,17 @@
 #include <stdio.h>
 #include "pico.h"
 #include "pico/malloc.h"
+#include "pico/platform.h"
 
 #if PICO_USE_MALLOC_MUTEX
 #include "pico/mutex.h"
 auto_init_mutex(malloc_mutex);
 #endif
 
-extern void *__real_malloc(size_t size);
-extern void *__real_calloc(size_t count, size_t size);
-extern void *__real_realloc(void *mem, size_t size);
-extern void __real_free(void *mem);
+extern void *REAL_FUNC(malloc)(size_t size);
+extern void *REAL_FUNC(calloc)(size_t count, size_t size);
+extern void *REAL_FUNC(realloc)(void *mem, size_t size);
+extern void REAL_FUNC(free)(void *mem);
 
 extern char __StackLimit; /* Set by linker.  */
 
@@ -29,11 +30,11 @@ static inline void check_alloc(__unused void *mem, __unused uint size) {
 #endif
 }
 
-void *__wrap_malloc(size_t size) {
+void *WRAPPER_FUNC(malloc)(size_t size) {
 #if PICO_USE_MALLOC_MUTEX
     mutex_enter_blocking(&malloc_mutex);
 #endif
-    void *rc = __real_malloc(size);
+    void *rc = REAL_FUNC(malloc)(size);
 #if PICO_USE_MALLOC_MUTEX
     mutex_exit(&malloc_mutex);
 #endif
@@ -46,11 +47,11 @@ void *__wrap_malloc(size_t size) {
     return rc;
 }
 
-void *__wrap_calloc(size_t count, size_t size) {
+void *WRAPPER_FUNC(calloc)(size_t count, size_t size) {
 #if PICO_USE_MALLOC_MUTEX
     mutex_enter_blocking(&malloc_mutex);
 #endif
-    void *rc = __real_calloc(count, size);
+    void *rc = REAL_FUNC(calloc)(count, size);
 #if PICO_USE_MALLOC_MUTEX
     mutex_exit(&malloc_mutex);
 #endif
@@ -63,11 +64,11 @@ void *__wrap_calloc(size_t count, size_t size) {
     return rc;
 }
 
-void *__wrap_realloc(void *mem, size_t size) {
+void *WRAPPER_FUNC(realloc)(void *mem, size_t size) {
 #if PICO_USE_MALLOC_MUTEX
     mutex_enter_blocking(&malloc_mutex);
 #endif
-    void *rc = __real_realloc(mem, size);
+    void *rc = REAL_FUNC(realloc)(mem, size);
 #if PICO_USE_MALLOC_MUTEX
     mutex_exit(&malloc_mutex);
 #endif
@@ -80,11 +81,11 @@ void *__wrap_realloc(void *mem, size_t size) {
     return rc;
 }
 
-void __wrap_free(void *mem) {
+void WRAPPER_FUNC(free)(void *mem) {
 #if PICO_USE_MALLOC_MUTEX
     mutex_enter_blocking(&malloc_mutex);
 #endif
-    __real_free(mem);
+    REAL_FUNC(free)(mem);
 #if PICO_USE_MALLOC_MUTEX
     mutex_exit(&malloc_mutex);
 #endif

--- a/src/rp2_common/pico_malloc/pico_malloc.h
+++ b/src/rp2_common/pico_malloc/pico_malloc.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* To support IAR's runtime library, which features multiple link-time
+ * selectable heap implementations, this file is designed to be
+ * multiply included with PREFIX set to the appropriate function name
+ * prefix (if any) */
+
+extern void *REAL_FUNC_EXP(__CONCAT(PREFIX,malloc))(size_t size);
+extern void *REAL_FUNC_EXP(__CONCAT(PREFIX,calloc))(size_t count, size_t size);
+extern void *REAL_FUNC_EXP(__CONCAT(PREFIX,realloc))(void *mem, size_t size);
+extern void REAL_FUNC_EXP(__CONCAT(PREFIX,free))(void *mem);
+
+void *WRAPPER_FUNC_EXP(__CONCAT(PREFIX,malloc))(size_t size) {
+#if PICO_USE_MALLOC_MUTEX
+    mutex_enter_blocking(&malloc_mutex);
+#endif
+    void *rc = REAL_FUNC_EXP(__CONCAT(PREFIX,malloc))(size);
+#if PICO_USE_MALLOC_MUTEX
+    mutex_exit(&malloc_mutex);
+#endif
+#if PICO_DEBUG_MALLOC
+    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
+        printf("malloc %d %p->%p\n", (uint) size, rc, ((uint8_t *) rc) + size);
+    }
+#endif
+    check_alloc(rc, size);
+    return rc;
+}
+
+void *WRAPPER_FUNC_EXP(__CONCAT(PREFIX,calloc))(size_t count, size_t size) {
+#if PICO_USE_MALLOC_MUTEX
+    mutex_enter_blocking(&malloc_mutex);
+#endif
+    void *rc = REAL_FUNC_EXP(__CONCAT(PREFIX,calloc))(count, size);
+#if PICO_USE_MALLOC_MUTEX
+    mutex_exit(&malloc_mutex);
+#endif
+#if PICO_DEBUG_MALLOC
+    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
+        printf("calloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
+    }
+#endif
+    check_alloc(rc, size);
+    return rc;
+}
+
+void *WRAPPER_FUNC_EXP(__CONCAT(PREFIX,realloc))(void *mem, size_t size) {
+#if PICO_USE_MALLOC_MUTEX
+    mutex_enter_blocking(&malloc_mutex);
+#endif
+    void *rc = REAL_FUNC_EXP(__CONCAT(PREFIX,realloc))(mem, size);
+#if PICO_USE_MALLOC_MUTEX
+    mutex_exit(&malloc_mutex);
+#endif
+#if PICO_DEBUG_MALLOC
+    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
+        printf("realloc %p %d->%p\n", mem, (uint) size, rc);
+    }
+#endif
+    check_alloc(rc, size);
+    return rc;
+}
+
+void WRAPPER_FUNC_EXP(__CONCAT(PREFIX,free))(void *mem) {
+#if PICO_USE_MALLOC_MUTEX
+    mutex_enter_blocking(&malloc_mutex);
+#endif
+    REAL_FUNC_EXP(__CONCAT(PREFIX,free))(mem);
+#if PICO_USE_MALLOC_MUTEX
+    mutex_exit(&malloc_mutex);
+#endif
+}

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -455,6 +455,16 @@ __INLINE_PICO_PLATFORM uint __get_current_exception(void) {
 #define WRAPPER_FUNC(x) __wrap_ ## x
 #define REAL_FUNC(x) __real_ ## x
 
+#ifdef __ICCARM__
+/* Compatible definitions of GCC builtins */
+
+static inline uint __builtin_ctz(uint x) {
+  extern uint32_t __ctzsi2(uint32_t);
+  return __ctzsi2(x);
+}
+
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -316,7 +316,7 @@ extern "C" {
  *  \ingroup pico_platform
  */
 static inline void __breakpoint(void) {
-    __asm__("bkpt #0");
+    __asm ("bkpt #0");
 }
 
 /*! \brief Ensure that the compiler does not move memory access across this method call
@@ -332,7 +332,7 @@ static inline void __breakpoint(void) {
  * might - even above the memory store!)
  */
 __force_inline static void __compiler_memory_barrier(void) {
-    __asm__ volatile ("" : : : "memory");
+    __asm volatile ("" : : : "memory");
 }
 
 /*! \brief Macro for converting memory addresses to 32 bit addresses suitable for DMA
@@ -412,7 +412,7 @@ static __force_inline void tight_loop_contents(void) {}
  * \return a * b
  */
 __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
-    asm ("mul %0, %1" : "+l" (a) : "l" (b) : );
+    __asm ("mul %0, %1" : "+l" (a) : "l" (b) : );
     return a;
 }
 

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -386,10 +386,14 @@ uint8_t rp2040_chip_version(void);
  * @return the RP2040 rom version number (1 for RP2040-B0, 2 for RP2040-B1, 3 for RP2040-B2)
  */
 static inline uint8_t rp2040_rom_version(void) {
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     return *(uint8_t*)0x13;
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 }
 
 /*! \brief No-op function for the body of tight loops

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -205,12 +205,12 @@ extern "C" {
  *
  *     uint32_t __uninitialized_ram("my_group_name") foo;
  *
- * The section attribute is `.uninitialized_ram.<group>`
+ * The section attribute is `.uninitialized_data.<group>`
  *
  * \param group a string suffix to use in the section name to distinguish groups that can be linker
  *              garbage-collected independently
  */
-#define __uninitialized_ram(group) __attribute__((section(".uninitialized_ram." #group))) group
+#define __uninitialized_ram(group) __attribute__((section(".uninitialized_data." #group))) group
 
 /*! \brief Section attribute macro for placement in flash even in a COPY_TO_RAM binary
  *  \ingroup pico_platform

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -68,7 +68,43 @@
 
 #ifndef __ASSEMBLER__
 
+#if defined __GNUC__
 #include <sys/cdefs.h>
+#elif defined __ICCARM__
+#ifndef __aligned
+#define __aligned(x)	__attribute__((__aligned__(x)))
+#endif
+#ifndef __always_inline
+#define __always_inline __attribute__((__always_inline__))
+#endif
+#ifndef __noinline
+#define __noinline      __attribute__((__noinline__))
+#endif
+#ifndef __packed
+#define __packed        __attribute__((__packed__))
+#endif
+#ifndef __printflike
+#define __printflike(a, b)
+#endif
+#ifndef __unused
+#define __unused        __attribute__((__unused__))
+#endif
+#ifndef __used
+#define __used          __attribute__((__used__))
+#endif
+#ifndef __CONCAT1
+#define __CONCAT1(a, b) a ## b
+#endif
+#ifndef __CONCAT
+#define __CONCAT(a, b)  __CONCAT1(a, b)
+#endif
+#ifndef __STRING
+#define __STRING(a)     #a
+#endif
+#else
+#error Unsupported toolchain
+#endif
+
 #include "pico/types.h"
 
 #ifdef __cplusplus

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -111,6 +111,20 @@
 extern "C" {
 #endif
 
+// Support for inline functions which we want to be inlinable by any file
+// that #includes this header, but where we need a definition to be emitted
+// in one object file (for example because it might have been called from
+// assembly). The rules for this differ between default GCC and vanilla C99
+// compilers. The macro is namespaced so that we can use the same trick for
+// different header/object file combinations if necessary.
+#ifndef __INLINE_PICO_PLATFORM
+#if __GNUC__ && !__GNUC_STDC_INLINE__
+#define __INLINE_PICO_PLATFORM extern inline
+#else
+#define __INLINE_PICO_PLATFORM inline
+#endif
+#endif
+
 /*! \brief Marker for an interrupt handler
  *  \ingroup pico_platform
  * For example an IRQ handler function called my_interrupt_handler:
@@ -432,7 +446,7 @@ __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
  *
  * \return the exception number if the CPU is handling an exception, or 0 otherwise
  */
-inline uint __get_current_exception(void) {
+__INLINE_PICO_PLATFORM uint __get_current_exception(void) {
     uint exception;
     asm ("mrs %0, ipsr" : "=l" (exception));
     return exception;

--- a/src/rp2_common/pico_platform/platform.c
+++ b/src/rp2_common/pico_platform/platform.c
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#define __INLINE_PICO_PLATFORM
+#include "pico/platform.h"
+
 #include "pico.h"
 #include "hardware/address_mapped.h"
 #include "hardware/regs/tbman.h"

--- a/src/rp2_common/pico_printf/printf.c
+++ b/src/rp2_common/pico_printf/printf.c
@@ -108,6 +108,7 @@
 
 #endif
 
+#if LIB_PICO_PRINTF_PICO && !PICO_PRINTF_ALWAYS_INCLUDED
 /**
  * Output a character to a custom device like UART, used by the printf() function
  * This function is declared here only. You have to write your custom implementation somewhere
@@ -116,6 +117,7 @@
 static void _putchar(char character) {
     putchar(character);
 }
+#endif
 
 // output function type
 typedef void (*out_fct_type)(char character, void *buffer, size_t idx, size_t maxlen);
@@ -149,6 +151,7 @@ static inline void _out_null(char character, void *buffer, size_t idx, size_t ma
     (void) maxlen;
 }
 
+#if LIB_PICO_PRINTF_PICO && !PICO_PRINTF_ALWAYS_INCLUDED
 // internal _putchar wrapper
 static inline void _out_char(char character, void *buffer, size_t idx, size_t maxlen) {
     (void) buffer;
@@ -158,6 +161,7 @@ static inline void _out_char(char character, void *buffer, size_t idx, size_t ma
         _putchar(character);
     }
 }
+#endif
 
 
 // internal output function wrapper

--- a/src/rp2_common/pico_printf/printf.c
+++ b/src/rp2_common/pico_printf/printf.c
@@ -33,6 +33,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <math.h>
 
 #include "pico/platform.h"
 #include "pico/printf.h"
@@ -336,7 +337,13 @@ static size_t _etoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, d
                     unsigned int width, unsigned int flags);
 #endif
 
+#if defined __GNUC__
 #define is_nan __builtin_isnan
+#elif defined __ICCARM__
+#define is_nan __iar_isnan
+#else
+#error Unsupported toolchain
+#endif
 
 // internal ftoa for fixed decimal floating point
 static size_t _ftoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, double value, unsigned int prec,

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 #include "pico.h"
 
 #include "hardware/regs/m0plus.h"
@@ -141,6 +142,9 @@ void runtime_init(void) {
     }
 
 #if !(PICO_NO_RAM_VECTOR_TABLE || PICO_NO_FLASH)
+#ifndef __GNUC__
+#define __builtin_memcpy memcpy
+#endif
     __builtin_memcpy(ram_vector_table, (uint32_t *) scb_hw->vtor, sizeof(ram_vector_table));
     scb_hw->vtor = (uintptr_t) ram_vector_table;
 #endif

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -111,8 +111,9 @@ void runtime_init(void) {
 
 #if !PICO_IE_26_29_UNCHANGED_ON_RESET
     // after resetting BANK0 we should disable IE on 26-29
-    hw_clear_alias(padsbank0_hw)->io[26] = hw_clear_alias(padsbank0_hw)->io[27] =
-            hw_clear_alias(padsbank0_hw)->io[28] = hw_clear_alias(padsbank0_hw)->io[29] = PADS_BANK0_GPIO0_IE_BITS;
+    padsbank0_hw_t *padsbank0_hw_clear = hw_clear_alias(padsbank0_hw);
+    padsbank0_hw_clear->io[26] = padsbank0_hw_clear->io[27] =
+            padsbank0_hw_clear->io[28] = padsbank0_hw_clear->io[29] = PADS_BANK0_GPIO0_IE_BITS;
 #endif
 
     // this is an array of either mutex_t or recursive_mutex_t (i.e. not necessarily the same size)

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -197,7 +197,15 @@ void *_sbrk(int incr) {
     prev_heap_end = heap_end;
     char *next_heap_end = heap_end + incr;
 
-    if (__builtin_expect(next_heap_end > (&__StackLimit), false)) {
+    if (
+#ifdef __GNUC__
+        __builtin_expect(
+#endif
+        next_heap_end > (&__StackLimit)
+#ifdef __GNUC__
+        , false)
+#endif
+        ) {
 #if PICO_USE_OPTIMISTIC_SBRK
         if (heap_end == &__StackLimit) {
 //        errno = ENOMEM;

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -230,9 +230,11 @@ void exit(int status) {
     _exit(status);
 }
 
+#ifdef __GNUC__
 // incorrect warning from GCC 6
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=format"
+#endif
 void __assert_func(const char *file, int line, const char *func, const char *failedexpr) {
     weak_raw_printf("assertion \"%s\" failed: file \"%s\", line %d%s%s\n",
            failedexpr, file, line, func ? ", function: " : "",
@@ -241,7 +243,9 @@ void __assert_func(const char *file, int line, const char *func, const char *fai
     _exit(1);
 }
 
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 void __attribute__((noreturn)) panic_unsupported() {
     panic("not supported");

--- a/src/rp2_common/pico_standard_link/new_delete.cpp
+++ b/src/rp2_common/pico_standard_link/new_delete.cpp
@@ -9,6 +9,10 @@
 
 #include <cstdlib>
 
+#ifndef __unused
+#define __unused __attribute__((__unused__))
+#endif
+
 void *operator new(std::size_t n) {
     return std::malloc(n);
 }

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -154,6 +154,7 @@ bool stdio_usb_init(void) {
     }
 #ifndef NDEBUG
     stdio_usb_core_num = (uint8_t)get_core_num();
+    (void) stdio_usb_core_num;
 #endif
 #if !PICO_NO_BI_STDIO_USB
     bi_decl_if_func_used(bi_program_feature("USB stdin / stdout"));

--- a/test/pico_divider_test/pico_divider_test.c
+++ b/test/pico_divider_test/pico_divider_test.c
@@ -193,7 +193,7 @@ void test_random() {
 #endif
 
 uint32_t __attribute__((naked)) time_32(uint32_t a, uint32_t b, uint32_t (*func)(uint32_t a, uint32_t b)) {
-    asm(
+    __asm(
         ".syntax unified\n"
         "push {r4, r5, lr}\n"
         "ldr r4, =#0xe000e018\n"
@@ -208,7 +208,7 @@ uint32_t __attribute__((naked)) time_32(uint32_t a, uint32_t b, uint32_t (*func)
 }
 
 uint32_t __attribute__((naked)) time_64(uint64_t a, uint64_t b, uint64_t (*func64)(uint64_t a, uint64_t b)) {
-    asm(
+    __asm(
     ".syntax unified\n"
     "push {r4-r6, lr}\n"
     "ldr r6, [sp, #16]\n"

--- a/test/pico_divider_test/pico_divider_test.c
+++ b/test/pico_divider_test/pico_divider_test.c
@@ -194,7 +194,9 @@ void test_random() {
 
 uint32_t __attribute__((naked)) time_32(uint32_t a, uint32_t b, uint32_t (*func)(uint32_t a, uint32_t b)) {
     __asm(
+#ifdef __GNUC__
         ".syntax unified\n"
+#endif
         "push {r4, r5, lr}\n"
         "ldr r4, =#0xe000e018\n"
         "ldr r5, [r4]\n"
@@ -209,7 +211,9 @@ uint32_t __attribute__((naked)) time_32(uint32_t a, uint32_t b, uint32_t (*func)
 
 uint32_t __attribute__((naked)) time_64(uint64_t a, uint64_t b, uint64_t (*func64)(uint64_t a, uint64_t b)) {
     __asm(
+#ifdef __GNUC__
     ".syntax unified\n"
+#endif
     "push {r4-r6, lr}\n"
     "ldr r6, [sp, #16]\n"
     "ldr r4, =#0xe000e018\n"


### PR DESCRIPTION
This PR represents the bulk of the changes to C source files required to permit the SDK to build with the IAR toolchain (as verified with the pico-examples repository). Where possible, code has been refactored to use generic ISO C, but in other places I have used conditional compilation, based on either the `__GNUC__` or `__ICCARM__` preprocessor predefines.

I have tried to roughly group similar issues either into the same commit or into nearby commits in the history, and issues are generally ranked according to the severity of the build failure caused with IAR, from more to less serious. I'm aiming to have all the example projects building cleanly, without any warnings being emitted.

Partially addresses #1021.
