### PR TITLE
Print registers, stack & other details on unhandled exception

### DIFF
--- a/src/rp2_common/CMakeLists.txt
+++ b/src/rp2_common/CMakeLists.txt
@@ -42,6 +42,7 @@ if (NOT PICO_BARE_METAL)
     pico_add_subdirectory(pico_unique_id)
 
     pico_add_subdirectory(pico_bit_ops)
+    pico_add_subdirectory(pico_debug)
     pico_add_subdirectory(pico_divider)
     pico_add_subdirectory(pico_double)
     pico_add_subdirectory(pico_int64_ops)

--- a/src/rp2_common/pico_debug/CMakeLists.txt
+++ b/src/rp2_common/pico_debug/CMakeLists.txt
@@ -1,0 +1,10 @@
+pico_add_impl_library(pico_debug)
+
+target_sources(pico_debug INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/print_exception.c
+        ${CMAKE_CURRENT_LIST_DIR}/debug_exception.S
+)
+
+target_link_libraries(pico_debug INTERFACE
+        pico_printf
+        )

--- a/src/rp2_common/pico_debug/debug_exception.S
+++ b/src/rp2_common/pico_debug/debug_exception.S
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico/asm_helper.S"
+
+regular_func debug_unhandled_exception
+    // On entry, the exception machinery has already pushed R0-R3, R12, LR, return address (PC) and XPSR on either the process or main stack.
+    // All the other registers are saved on the main stack here following the layout of the sw_saved_regs_t struct so pico_print_exception()
+    // can read their values later.
+
+    // Save registers
+    mrs r1, primask
+    mrs r2, psp
+    movs r3, sp      // always MSP
+    push {lr}
+    push {r1-r7}     // pushes 7 words
+    movs r2, r8
+    movs r3, r9
+    movs r4, r10
+    movs r5, r11
+    push {r2-r5}     // pushes 4 words
+
+    // debug_print_exception(exc_return, ipsr, sw_saved_regs)
+    // R0 holds the EXC_RETURN, which identifies which stack R0-R3, etc were saved on.
+    mrs r1, ipsr
+    mov r2, sp
+    bl debug_print_exception
+
+    add sp, sp, #(4+7)*4
+    pop {pc}

--- a/src/rp2_common/pico_debug/print_exception.c
+++ b/src/rp2_common/pico_debug/print_exception.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico/stdio.h"
+
+#include "hardware/address_mapped.h"
+#include "hardware/structs/mpu.h"
+
+#include <stdio.h>
+
+struct hw_saved_regs_t {
+    // These are volatile because want to verify their addresses before accessing them.
+    volatile uint r0;
+    volatile uint r1;
+    volatile uint r2;
+    volatile uint r3;
+    volatile uint r12;
+    volatile uint lr;
+    volatile uint pc;
+    volatile uint xpsr;
+};
+
+struct sw_saved_regs_t {
+    uint r8;
+    uint r9;
+    uint r10;
+    uint r11;
+    uint primask;
+    uint psp;
+    uint msp;
+    uint r4;
+    uint r5;
+    uint r6;
+    uint r7;
+};
+
+static const char* const exception_names[] = {
+    0,
+    "Reset",
+    "NMI",
+    "Hard Fault",
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    "SVCall",
+    0,
+    0,
+    "PendSV",
+    "SysTick",
+
+    "TIMER_IRQ_0",  // 16
+    "TIMER_IRQ_1",
+    "TIMER_IRQ_2",
+    "TIMER_IRQ_3",
+    "PWM_IRQ_WRAP",
+    "USBCTRL_IRQ",
+    "XIP_IRQ",
+    "PIO0_IRQ_0",
+    "PIO0_IRQ_1",
+    "PIO1_IRQ_0",
+    "PIO1_IRQ_1",
+    "DMA_IRQ_0",
+    "DMA_IRQ_1",
+    "IO_IRQ_BANK0",
+    "IO_IRQ_QSPI",
+    "SIO_IRQ_PROC0",
+
+    "SIO_IRQ_PROC1",  // 32
+    "CLOCKS_IRQ",
+    "SPI0_IRQ",
+    "SPI1_IRQ",
+    "UART0_IRQ",
+    "UART1_IRQ",
+    "ADC_IRQ_FIFO",
+    "I2C0_IRQ",
+    "I2C1_IRQ",
+    "RTC_IRQ",
+    "USER_IRQ_0",
+    "USER_IRQ_1",
+    "USER_IRQ_2",
+    "USER_IRQ_3",
+    "USER_IRQ_4",
+    "USER_IRQ_5",
+};
+
+static_assert(count_of(exception_names) == 16 + 32);
+
+static bool verify_stack_address(uint address) {
+    if ((address & 3) != 0) return false;
+
+    // Check SP falls in SRAM banks 0-3, either the striped or unstriped aliases, or in SRAM banks 4 or 5.
+    return (address >= SRAM_BASE && address < SRAM_END) || (address >= SRAM0_BASE && address < (SRAM3_BASE + 0x10000));
+}
+
+static uint safe_read_stack(const volatile uint* address) {
+    if (verify_stack_address((uint) address)) {
+        return *address;
+    } else {
+        return 0;
+    }
+}
+
+void debug_print_exception(uint exc_return, uint ipsr, const struct sw_saved_regs_t* sw_saved_regs) {
+    static const char* const separator = "***********************************************************\r\n";
+
+    // Stack bounds are unknown - an RTOS might have put it anywhere in static RAM - so there is a danger of accidentally hitting an
+    // MPU region. It might be worth verifying stack addresses against each enabled MPU region but not clear why. Until someone
+    // complains, just disable the MPU.
+    mpu_hw->ctrl = 0;
+
+    printf("\r\n");
+    printf(separator);
+    printf("Unhandled %s exception on core %d\r\n", exception_names[ipsr], get_core_num());
+    printf(separator);
+    
+    // Recover registers saved by hardware and determine stack pointer register values
+    // prior to exception entry.
+    uint msp = sw_saved_regs->msp;
+    uint psp = sw_saved_regs->psp;
+    uint sp;
+    const struct hw_saved_regs_t* hw_saved_regs;
+    if ((exc_return & 0xF) == 0xD) {
+        // Be RTOS friendly by checking to see if state was saved on the process stack rather than the main stack.
+        hw_saved_regs = (const struct hw_saved_regs_t*) psp;
+        psp += sizeof(*hw_saved_regs);
+        sp = psp;
+    } else {
+        hw_saved_regs = (const struct hw_saved_regs_t*) msp;
+        msp += sizeof(*hw_saved_regs);
+        sp = msp;
+    }
+
+    printf("  R0: %08x   R1: %08x   R2: %08x   R3: %08x\r\n", safe_read_stack(&hw_saved_regs->r0), safe_read_stack(&hw_saved_regs->r1),
+                                                              safe_read_stack(&hw_saved_regs->r2), safe_read_stack(&hw_saved_regs->r3));
+    printf("  R4: %08x   R5: %08x   R6: %08x   R7: %08x\r\n", sw_saved_regs->r4, sw_saved_regs->r5, sw_saved_regs->r6, sw_saved_regs->r7);
+    printf("  R8: %08x   R9: %08x  R10: %08x  R11: %08x\r\n", sw_saved_regs->r8, sw_saved_regs->r9, sw_saved_regs->r10, sw_saved_regs->r11);
+    printf(" R12: %08x   SP: %08x   LR: %08x   PC: %08x\r\n", safe_read_stack(&hw_saved_regs->r12), sp,
+                                                              safe_read_stack(&hw_saved_regs->lr), safe_read_stack(&hw_saved_regs->pc));
+    printf("               XPSR: %08x  PSP: %08x  MSP: %08x\r\n", safe_read_stack(&hw_saved_regs->xpsr), psp, msp);
+    printf("         EXC_RETURN: %08x             PRIMASK: %08x\r\n", exc_return, sw_saved_regs->primask);
+    printf(separator);
+
+    for (int i = 0; i < 32; i += 4) {
+        printf("%08x:", sp);
+        for (int j = 0; j < 4; ++j) {
+            if (verify_stack_address(sp)) {
+                printf(" %08x", *(uint*)sp);
+            } else {
+                printf(" BAD ADDR");
+            }
+            sp += 4;
+        }
+        printf("\r\n");
+    }
+}

--- a/src/rp2_common/pico_standard_link/crt0.S
+++ b/src/rp2_common/pico_standard_link/crt0.S
@@ -76,13 +76,13 @@ __vectors:
 .word isr_irq30
 .word isr_irq31
 
-// all default exception handlers do nothing, and we can check for them being set to our
-// default values by seeing if they point to somewhere between __defaults_isrs_start and __default_isrs_end
+// We can check for exception handlers being set to our default values by seeing if they point to somewhere
+// between __defaults_isrs_start and __default_isrs_end
 .global __default_isrs_start
 __default_isrs_start:
 
 // Declare a weak symbol for each ISR.
-// By default, they will fall through to the undefined IRQ handler below (breakpoint),
+// By default, they will fall through to the undefined exception handler below,
 // but can be overridden by C functions with correct name.
 
 .macro decl_isr_bkpt name
@@ -90,16 +90,22 @@ __default_isrs_start:
 .type \name,%function
 .thumb_func
 \name:
-    bkpt #0
 .endm
 
 // these are separated out for clarity
-decl_isr_bkpt isr_invalid
-decl_isr_bkpt isr_nmi
-decl_isr_bkpt isr_hardfault
-decl_isr_bkpt isr_svcall
-decl_isr_bkpt isr_pendsv
-decl_isr_bkpt isr_systick
+decl_isr_bkpt isr_invalid       // 1
+decl_isr_bkpt isr_nmi           // 2
+decl_isr_bkpt isr_hardfault     // 3
+decl_isr_bkpt isr_svcall        // 11
+decl_isr_bkpt isr_pendsv        // 14
+decl_isr_bkpt isr_systick       // 15
+    mov r0, lr
+    bl debug_unhandled_exception
+
+.global unhandled_exception_num_in_r0
+unhandled_exception_num_in_r0:
+    mrs r0, ipsr
+    bkpt #0
 
 .global __default_isrs_end
 __default_isrs_end:
@@ -148,11 +154,19 @@ decl_isr isr_irq31
 .global __unhandled_user_irq
 .thumb_func
 __unhandled_user_irq:
-    mrs  r0, ipsr
+    mov r0, lr
+    bl debug_unhandled_exception
+
+    mrs r0, ipsr
     subs r0, #16
 .global unhandled_user_irq_num_in_r0
 unhandled_user_irq_num_in_r0:
     bkpt #0
+
+// pico_debug intercepts unhandled exceptions by replacing this routine.
+regular_func debug_unhandled_exception
+.weak debug_unhandled_exception
+    bx lr
 
 // ----------------------------------------------------------------------------
 

--- a/test/kitchen_sink/CMakeLists.txt
+++ b/test/kitchen_sink/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(kitchen_sink_libs INTERFACE
     pico_bit_ops
     pico_bootrom
     pico_bootsel_via_double_reset
+    pico_debug
     pico_divider
     pico_double
     pico_fix_rp2040_usb_device_enumeration


### PR DESCRIPTION
This partially fixes issue #228.

If (and only if) pico_debug is linked with a target, when an unhandled exception occurs, before executing BKPT #0, dump some useful state to stdout. This information includes the processor core number, the exception type, most ARM registers and the top few words of the stack, as they were before entry to the exception.

Probably the most useful information are in the PC register, which indicates which function was executing when the exception happened, and LR, which indicates which function called that function. The hex values can be looked up in the generated .elf.map files. Although most people are probably using GDB for that kind of thing, GDB isn't always possible.

It is RTOS friendly in that it checks whether a process stack is being used or not and doesn't make any assumptions about the location of the stack.

The exception handler still eventually does BKPT #0, so it works well with or without a debugger attached.

Example output:
```
***********************************************************
Unhandled SVCall exception on core 0
***********************************************************
  R0: 00000001   R1: 00000000   R2: 00000000   R3: d0000144
  R4: 1000026c   R5: 20041f01   R6: 18000000   R7: 00000000
  R8: ffffffff   R9: ffffffff  R10: ffffffff  R11: ffffffff
 R12: 00000000   SP: 20041ff8   LR: 100003af   PC: 100003b4
               XPSR: 21000000  PSP: fffffffc  MSP: 20041ff8
         EXC_RETURN: fffffff9             PRIMASK: 00000000
***********************************************************
20041ff8: 1000026c 1000022b BAD ADDR BAD ADDR
20042008: BAD ADDR BAD ADDR BAD ADDR BAD ADDR
20042018: BAD ADDR BAD ADDR BAD ADDR BAD ADDR
20042028: BAD ADDR BAD ADDR BAD ADDR BAD ADDR
20042038: BAD ADDR BAD ADDR BAD ADDR BAD ADDR
20042048: BAD ADDR BAD ADDR BAD ADDR BAD ADDR
20042058: BAD ADDR BAD ADDR BAD ADDR BAD ADDR
20042068: BAD ADDR BAD ADDR BAD ADDR BAD ADDR
```
Above, "BAD ADDR" is output for locations that do not fall in static RAM.