### PR TITLE
Add packet "build-essential" to required packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
 
 1. Install CMake (at least version 3.13), and GCC cross compiler
    ```
-   sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+   sudo apt install cmake build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
    ```
 1. Set up your project to point to use the Raspberry Pi Pico SDK
 


### PR DESCRIPTION
`hello_world.c` tutorial fails on a fresh installed Debian machine becurse no compiler is installed, so CMake complains about `No CMAKE_CXX_COMPILER could be found. `

The packet build-essential contains gcc/g++ and with it installed the Kids in the programming course can start without any error on their Laptops. ;-)