### PR TITLE
Suppress fopen deprecated warning when building ELF2UF2

### DIFF
--- a/tools/elf2uf2/CMakeLists.txt
+++ b/tools/elf2uf2/CMakeLists.txt
@@ -6,4 +6,7 @@ set(CMAKE_CXX_STANDARD 14)
 add_subdirectory(../../src/common/boot_uf2 boot_uf2_headers)
 
 add_executable(elf2uf2 main.cpp)
+if (WIN32 AND NOT MINGW AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+    target_compile_definitions(elf2uf2 PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()
 target_link_libraries(elf2uf2 boot_uf2_headers)


### PR DESCRIPTION
When building elf2uf2 with clang x86_64-pc-windows-msvc and Windows 10 SDK, the following warning occurs.
This PR suppresses the warnings.

```console
[1/2] Building CXX object CMakeFiles/elf2uf2.dir/main.cpp.obj
C:/pico-sdk/tools/elf2uf2/main.cpp:359:16: warning: 'fopen' is deprecated: This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [-Wdeprecated-declarations]
    FILE *in = fopen(in_filename, "rb");
               ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.17763.0\ucrt\stdio.h:207:20: note: 'fopen' has been explicitly marked deprecated here
    _Check_return_ _CRT_INSECURE_DEPRECATE(fopen_s)
                   ^
C:\Program Files (x86)\Microsoft Visual Studio\2017\WDExpress\VC\Tools\MSVC\14.16.27023\include\vcruntime.h:255:55: note: expanded from macro '_CRT_INSECURE_DEPRECATE'
        #define _CRT_INSECURE_DEPRECATE(_Replacement) _CRT_DEPRECATE_TEXT(    \
                                                      ^
C:\Program Files (x86)\Microsoft Visual Studio\2017\WDExpress\VC\Tools\MSVC\14.16.27023\include\vcruntime.h:245:47: note: expanded from macro '_CRT_DEPRECATE_TEXT'
#define _CRT_DEPRECATE_TEXT(_Text) __declspec(deprecated(_Text))
                                              ^
```

Environment details:

clang version 14.0.6
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin

Windows SDK 10.0.17763.0
Microsoft Visual Studio 2017