### PR TITLE
Fix compile errors when building pioasm with clang x86_64-pc-windows-msvc

### DIFF
--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -36,8 +36,11 @@ endif()
 
 target_include_directories(pioasm PRIVATE ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/gen)
 
-if (MSVC)
+if (MSVC OR
+    (WIN32 AND NOT MINGW AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")))
     target_compile_definitions(pioasm PRIVATE YY_NO_UNISTD_H)
+endif()
+if (MSVC)
     target_compile_options(pioasm PRIVATE "/std:c++latest")
 endif()
 


### PR DESCRIPTION
When building pioasm with clang x86_64-pc-windows-msvc and Windows 10 SDK, the following error occurs.
This PR fixes the errors.

```console
[1/2] Building CXX object CMakeFiles/pioasm.dir/gen/lexer.cpp.obj
FAILED: CMakeFiles/pioasm.dir/gen/lexer.cpp.obj
C:\PROGRA~1\LLVM\bin\CLANG_~1.EXE  -IC:/pico-sdk/tools/pioasm -IC:/pico-sdk/tools/pioasm/gen -g -Xclang -gcodeview -O0 -D_DEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrtd -std=gnu++14 -MD -MT CMakeFiles/pioasm.dir/gen/lexer.cpp.obj -MF CMakeFiles\pioasm.dir\gen\lexer.cpp.obj.d -o CMakeFiles/pioasm.dir/gen/lexer.cpp.obj -c C:/pico-sdk/tools/pioasm/gen/lexer.cpp
lexer.ll:38:10: fatal error: 'unistd.h' file not found
#include <unistd.h>
         ^~~~~~~~~~
1 error generated.
```

Environment details:

clang version 14.0.6
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin

Windows SDK 10.0.17763.0
Microsoft Visual Studio 2017