### PR TITLE
Fix unexpected (CMake) behavior with PICO_BOARD variable.

### DIFF
--- a/src/boards/generic_board.cmake
+++ b/src/boards/generic_board.cmake
@@ -21,5 +21,3 @@ else()
     string(CONCAT msg ${msg} "   Looked for ${PICO_BOARD}.cmake in ${DIRS} (additional paths specified by PICO_BOARD_CMAKE_DIRS)")
     message(FATAL_ERROR ${msg})
 endif()
-
-set(PICO_CYW43_SUPPORTED "0" CACHE INTERNAL "Exclude support for PICO_CYW43")

--- a/src/boards/generic_board.cmake
+++ b/src/boards/generic_board.cmake
@@ -21,3 +21,5 @@ else()
     string(CONCAT msg ${msg} "   Looked for ${PICO_BOARD}.cmake in ${DIRS} (additional paths specified by PICO_BOARD_CMAKE_DIRS)")
     message(FATAL_ERROR ${msg})
 endif()
+
+set(PICO_CYW43_SUPPORTED "0" CACHE INTERNAL "Exclude support for PICO_CYW43")

--- a/src/boards/pico_w.cmake
+++ b/src/boards/pico_w.cmake
@@ -1,2 +1,3 @@
+set(PICO_CYW43_SUPPORTED "1")
+pico_register_common_scope_var(PICO_CYW43_SUPPORTED)
 include(${CMAKE_CURRENT_LIST_DIR}/generic_board.cmake)
-set(PICO_CYW43_SUPPORTED "1" CACHE INTERNAL "Try to add support for PICO_CYW43")

--- a/src/boards/pico_w.cmake
+++ b/src/boards/pico_w.cmake
@@ -1,2 +1,2 @@
-set(PICO_CYW43_SUPPORTED "1" CACHE INTERNAL "Try to add support for PICO_CYW43")
 include(${CMAKE_CURRENT_LIST_DIR}/generic_board.cmake)
+set(PICO_CYW43_SUPPORTED "1" CACHE INTERNAL "Try to add support for PICO_CYW43")


### PR DESCRIPTION
Changing PICO_BOARD value from "pico_w" to "pico" did not unset PICO_CYW43_SUPPORTED variable. Which could lead CYW43 driver included in builds for "pico".  (See issue https://github.com/raspberrypi/pico-sdk/issues/1046)

_Instructions: (please delete)_
 - _please do not submit against `master`, use `develop` instead_
 - _please make sure there is an associated issue for your PR, and reference it via "Fixes #num" in the description_
 - _please enter a detailed description_
