### PR TITLE
pioasm: python no longer incorrectly renders `mov x, ~x` as `nop()`

### DIFF
--- a/tools/pioasm/python_output.cpp
+++ b/tools/pioasm/python_output.cpp
@@ -255,7 +255,7 @@ struct python_output : public output_format {
                 if (source.empty() || dest.empty() || operation == 3) {
                     invalid = true;
                 }
-                if (dest == source && (arg1 == 1 || arg2 == 2)) {
+                if (dest == source && (arg1 == 1 || arg2 == 2) && operation == 0) {
                     op("nop");
                     op_guts("");
                 } else {


### PR DESCRIPTION
pioasm python output no longer incorrectly renders `mov x, ~x` as `nop()` but as the correct `mov(x, invert(x))`

This affects all move operations where source and destination are the same, but with an operation applied, ex: `mov y, ::y`, `mov osr, ~osr`, etc

Fixes #1052