### PR TITLE
add mqtt

### DIFF
--- a/src/rp2_common/pico_lwip/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/CMakeLists.txt
@@ -224,6 +224,12 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # MQTT client files
+    add_library(pico_lwip_mqtt INTERFACE)
+    target_sources(pico_lwip_mqtt INTERFACE
+            ${PICO_LWIP_PATH}/src/apps/mqtt/mqtt.c
+            )
+
+    # MBEDTLS client files
     add_library(pico_lwip_mbedtls INTERFACE)
     target_sources(pico_lwip_mbedtls INTERFACE
             ${PICO_LWIP_PATH}/src/apps/altcp_tls/altcp_tls_mbedtls.c


### PR DESCRIPTION
it seems MQTT was mixed up with MBEDTLS, this meant the app/mqtt was never made availible.

no code change, just a tweek to the cmake to add mqtt code under pico_lwip_mqtt