### PR TITLE
Remove incorrect override for LWIP_PLATFORM_ASSERT

### DIFF
--- a/src/rp2_common/pico_lwip/include/arch/cc.h
+++ b/src/rp2_common/pico_lwip/include/arch/cc.h
@@ -69,8 +69,6 @@ typedef int sys_prot_t;
 
 #endif
 
-#define LWIP_PLATFORM_ASSERT(x) do { if(!(x)) while(1); } while(0)
-
 unsigned int pico_lwip_rand(void);
 #ifndef LWIP_RAND
 // Use ROSC based random number generation, more for the fact that rand() may not be seeded, than anything else

--- a/src/rp2_common/pico_lwip/include/arch/cc.h
+++ b/src/rp2_common/pico_lwip/include/arch/cc.h
@@ -69,6 +69,11 @@ typedef int sys_prot_t;
 
 #endif
 
+#ifndef LWIP_PLATFORM_ASSERT
+void panic(const char *fmt, ...);
+#define LWIP_PLATFORM_ASSERT(x) panic(x)
+#endif
+
 unsigned int pico_lwip_rand(void);
 #ifndef LWIP_RAND
 // Use ROSC based random number generation, more for the fact that rand() may not be seeded, than anything else


### PR DESCRIPTION
`LWIP_PLATFORM_ASSERT` macro is used by `lwip` driver implementations to specify the behavior of the assertions in `lwip` code.

The previous override of this macro incorrectly assumed that the parameter to the function macro was the _condition_ to check. However this is incorrect. The parameter is actually a _message string_ defining what failed. (See usage [here](https://github.com/lwip-tcpip/lwip/blob/master/src/include/lwip/debug.h#L115-L120)). i.e. this macro is called after a failure has been detected.

This mistake caused all assertions to be ignored. ( and myself to loose many hours of debugging time )

By removing this, we restore the default behavior specified by `lwip` which is to use `printf(format, ...)` to log the message. I haven't figured out the original intent. Perhaps the printf code in the original bloats the code? In this case perhaps we can substitute an infinite loop? 
