### PR TITLE
Fix for cyw43 driver working with SMs other than 0

### DIFF
--- a/src/rp2_common/cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/cyw43_driver/cyw43_bus_pio_spi.c
@@ -260,14 +260,14 @@ int cyw43_spi_transfer(cyw43_int_t *self, const uint8_t *tx, size_t tx_length, u
         channel_config_set_bswap(&out_config, true);
         channel_config_set_dreq(&out_config, pio_get_dreq(bus_data->pio, bus_data->pio_sm, true));
 
-        dma_channel_configure(bus_data->dma_out, &out_config, &bus_data->pio->txf[0], tx, tx_length / 4, true);
+        dma_channel_configure(bus_data->dma_out, &out_config, &bus_data->pio->txf[bus_data->pio_sm], tx, tx_length / 4, true);
 
         dma_channel_config in_config = dma_channel_get_default_config(bus_data->dma_in);
         channel_config_set_bswap(&in_config, true);
         channel_config_set_dreq(&in_config, pio_get_dreq(bus_data->pio, bus_data->pio_sm, false));
         channel_config_set_write_increment(&in_config, true);
         channel_config_set_read_increment(&in_config, false);
-        dma_channel_configure(bus_data->dma_in, &in_config, rx + tx_length, &bus_data->pio->rxf[0], rx_length / 4 - tx_length / 4, true);
+        dma_channel_configure(bus_data->dma_in, &in_config, rx + tx_length, &bus_data->pio->rxf[bus_data->pio_sm], rx_length / 4 - tx_length / 4, true);
 
         pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, true);
         __compiler_memory_barrier();
@@ -301,11 +301,12 @@ int cyw43_spi_transfer(cyw43_int_t *self, const uint8_t *tx, size_t tx_length, u
         channel_config_set_bswap(&out_config, true);
         channel_config_set_dreq(&out_config, pio_get_dreq(bus_data->pio, bus_data->pio_sm, true));
 
-        dma_channel_configure(bus_data->dma_out, &out_config, &bus_data->pio->txf[0], tx, tx_length / 4, true);
+        dma_channel_configure(bus_data->dma_out, &out_config, &bus_data->pio->txf[bus_data->pio_sm], tx, tx_length / 4, true);
 
-        bus_data->pio->fdebug = 1u << PIO_FDEBUG_TXSTALL_LSB;
+        const uint32_t fDebugTxStall = 1u << (PIO_FDEBUG_TXSTALL_LSB + bus_data->pio_sm);
+        bus_data->pio->fdebug = fDebugTxStall;
         pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, true);
-        while (!(bus_data->pio->fdebug & (1u << PIO_FDEBUG_TXSTALL_LSB))) {
+        while (!(bus_data->pio->fdebug & fDebugTxStall)) {
             tight_loop_contents(); // todo timeout
         }
         __compiler_memory_barrier();

--- a/src/rp2_common/cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/cyw43_driver/cyw43_bus_pio_spi.c
@@ -303,10 +303,10 @@ int cyw43_spi_transfer(cyw43_int_t *self, const uint8_t *tx, size_t tx_length, u
 
         dma_channel_configure(bus_data->dma_out, &out_config, &bus_data->pio->txf[bus_data->pio_sm], tx, tx_length / 4, true);
 
-        const uint32_t fDebugTxStall = 1u << (PIO_FDEBUG_TXSTALL_LSB + bus_data->pio_sm);
-        bus_data->pio->fdebug = fDebugTxStall;
+        uint32_t fdebug_tx_stall = 1u << (PIO_FDEBUG_TXSTALL_LSB + bus_data->pio_sm);
+        bus_data->pio->fdebug = fdebug_tx_stall;
         pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, true);
-        while (!(bus_data->pio->fdebug & fDebugTxStall)) {
+        while (!(bus_data->pio->fdebug & fdebug_tx_stall)) {
             tight_loop_contents(); // todo timeout
         }
         __compiler_memory_barrier();


### PR DESCRIPTION
Fixes #1077

cyw43 driver is currently hard wired to use state machine (SM) 0. If a user program is allocated the same pio and SM 0 as cyw43 then the program will fail. Both cyw43 and user program will fall over each other trying to use SM 0.

This fix updates the cyw43 driver so that it doesn't assume that it has unique access to SM 0.

The cyw43 driver has a nod to playing fairly with the pio and sm but didn't quite make the required changes in cyw43_spi_transfer :)
