### PR TITLE
Fix RX vs TX typo for clearing PIO FIFOs.

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -1189,7 +1189,7 @@ static inline void pio_sm_clear_fifos(PIO pio, uint sm) {
     check_pio_param(pio);
     check_sm_param(sm);
     hw_xor_bits(&pio->sm[sm].shiftctrl, PIO_SM0_SHIFTCTRL_FJOIN_RX_BITS);
-    hw_xor_bits(&pio->sm[sm].shiftctrl, PIO_SM0_SHIFTCTRL_FJOIN_RX_BITS);
+    hw_xor_bits(&pio->sm[sm].shiftctrl, PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS);
 }
 
 /*! \brief Use a state machine to set a value on all pins for the PIO instance


### PR DESCRIPTION
Fixes #1087.

Note: I can't test that function right now. But this looks like it was the intended bit flag.