### PR TITLE
Add BSSID connection options to PicoW

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch.c
@@ -64,14 +64,22 @@ static const char* status_name(int status)
 #endif
 
 int cyw43_arch_wifi_connect_async(const char *ssid, const char *pw, uint32_t auth) {
+    return cyw43_arch_wifi_connect_bssid_async(ssid, NULL, pw, auth);
+}
+
+int cyw43_arch_wifi_connect_bssid_async(const char *ssid, const char *bssid, const char *pw, uint32_t auth) {
     if (!pw) auth = CYW43_AUTH_OPEN;
     // Connect to wireless
-    return cyw43_wifi_join(&cyw43_state, strlen(ssid), (const uint8_t *)ssid, pw ? strlen(pw) : 0, (const uint8_t *)pw, auth, NULL, CYW43_ITF_STA);
+    return cyw43_wifi_join(&cyw43_state, strlen(ssid), (const uint8_t *)ssid, pw ? strlen(pw) : 0, (const uint8_t *)pw, auth, bssid, CYW43_ITF_STA);
 }
 
 // Connect to wireless, return with success when an IP address has been assigned
 int cyw43_arch_wifi_connect_until(const char *ssid, const char *pw, uint32_t auth, absolute_time_t until) {
-    int err = cyw43_arch_wifi_connect_async(ssid, pw, auth);
+    return cyw43_arch_wifi_connect_bssid_until(ssid, NULL, pw, auth, until);
+}
+
+int cyw43_arch_wifi_connect_bssid_until(const char *ssid, const char *bssid, const char *pw, uint32_t auth, absolute_time_t until) {
+    int err = cyw43_arch_wifi_connect_bssid_async(ssid, bssid, pw, auth);
     if (err) return err;
 
     int status = CYW43_LINK_UP + 1;
@@ -95,8 +103,16 @@ int cyw43_arch_wifi_connect_blocking(const char *ssid, const char *pw, uint32_t 
     return cyw43_arch_wifi_connect_until(ssid, pw, auth, at_the_end_of_time);
 }
 
+int cyw43_arch_wifi_connect_bssid_blocking(const char *ssid, const char *bssid, const char *pw, uint32_t auth) {
+    return cyw43_arch_wifi_connect_bssid_until(ssid, bssid, pw, auth, at_the_end_of_time);
+}
+
 int cyw43_arch_wifi_connect_timeout_ms(const char *ssid, const char *pw, uint32_t auth, uint32_t timeout_ms) {
     return cyw43_arch_wifi_connect_until(ssid, pw, auth, make_timeout_time_ms(timeout_ms));
+}
+
+int cyw43_arch_wifi_connect_bssid_timeout_ms(const char *ssid, const char *bssid, const char *pw, uint32_t auth, uint32_t timeout_ms) {
+    return cyw43_arch_wifi_connect_until(ssid, bssid, pw, auth, make_timeout_time_ms(timeout_ms));
 }
 
 // todo maybe add an #ifdef in cyw43_driver

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -190,6 +190,20 @@ void cyw43_arch_deinit(void);
 int cyw43_arch_wifi_connect_blocking(const char *ssid, const char *pw, uint32_t auth);
 
 /*!
+ * \brief Attempt to connect to a wireless access point specified by SSID and BSSID, blocking until the network is joined or a failure is detected.
+ * \ingroup pico_cyw43_arch
+ *
+ * \param ssid the network name to connect to
+ * \param bssid the network BSSID to connect to or NULL if ignored
+ * \param password the network password or NULL if there is no password required
+ * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
+ *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
+ *
+ * \return 0 if the initialization is successful, an error code otherwise \see pico_error_codes
+ */
+int cyw43_arch_wifi_connect_bssid_blocking(const char *ssid, const char *bssid, const char *pw, uint32_t auth);
+
+/*!
  * \brief Attempt to connect to a wireless access point, blocking until the network is joined, a failure is detected or a timeout occurs
  * \ingroup pico_cyw43_arch
  *
@@ -201,6 +215,20 @@ int cyw43_arch_wifi_connect_blocking(const char *ssid, const char *pw, uint32_t 
  * \return 0 if the initialization is successful, an error code otherwise \see pico_error_codes
  */
 int cyw43_arch_wifi_connect_timeout_ms(const char *ssid, const char *pw, uint32_t auth, uint32_t timeout_ms);
+
+/*!
+ * \brief Attempt to connect to a wireless access point specified by SSID and BSSID, blocking until the network is joined, a failure is detected or a timeout occurs
+ * \ingroup pico_cyw43_arch
+ *
+ * \param ssid the network name to connect to
+ * \param bssid the network BSSID to connect to or NULL if ignored
+ * \param password the network password or NULL if there is no password required
+ * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
+ *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
+ *
+ * \return 0 if the initialization is successful, an error code otherwise \see pico_error_codes
+ */
+int cyw43_arch_wifi_connect_bssid_timeout_ms(const char *ssid, const char *bssid, const char *pw, uint32_t auth, uint32_t timeout);
 
 /*!
  * \brief Start attempting to connect to a wireless access point
@@ -217,6 +245,23 @@ int cyw43_arch_wifi_connect_timeout_ms(const char *ssid, const char *pw, uint32_
  * \return 0 if the scan was started successfully, an error code otherwise \see pico_error_codes
  */
 int cyw43_arch_wifi_connect_async(const char *ssid, const char *pw, uint32_t auth);
+
+/*!
+ * \brief Start attempting to connect to a wireless access point specified by SSID and BSSID
+ * \ingroup pico_cyw43_arch
+ *
+ * This method tells the CYW43 driver to start connecting to an access point. You should subsequently check the
+ * status by calling \ref cyw43_wifi_link_status.
+ *
+ * \param ssid the network name to connect to
+ * \param bssid the network BSSID to connect to or NULL if ignored
+ * \param password the network password or NULL if there is no password required
+ * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
+ *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
+ *
+ * \return 0 if the scan was started successfully, an error code otherwise \see pico_error_codes
+ */
+int cyw43_arch_wifi_connect_bssid_async(const char *ssid, const char *bssid, const char *pw, uint32_t auth);
 
 /*!
  * \brief Return the country code used to initialize cyw43_arch


### PR DESCRIPTION
When working with a mesh or multiple APs with the same SSID, it is often necessary to specify which of the APs to connect to in order to maximize the WiFi strength.

Add BSSID options to the SDK's PicoW cyw43_arch_wifi_connect_XXX APIs.

Fixes #1090