### PR TITLE
sdio_uart: avoid generating garbage input due to initialization

### DIFF
--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -70,9 +70,9 @@ void stdin_uart_init() {
 
 void stdio_uart_init_full(struct uart_inst *uart, uint baud_rate, int tx_pin, int rx_pin) {
     uart_instance = uart;
-    uart_init(uart_instance, baud_rate);
     if (tx_pin >= 0) gpio_set_function((uint)tx_pin, GPIO_FUNC_UART);
     if (rx_pin >= 0) gpio_set_function((uint)rx_pin, GPIO_FUNC_UART);
+    uart_init(uart_instance, baud_rate);
     stdio_set_driver_enabled(&stdio_uart, true);
 }
 


### PR DESCRIPTION
First mapping the GPIO pins to the UART peripheral before enabling the UART peripheral avoids generation of garbage character on the UART's input.

Fixes: #1124 