### PR TITLE
pico_stdio: mark _write and _read as weak functions

### DIFF
--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -146,13 +146,13 @@ static int stdio_get_until(char *buf, int len, absolute_time_t until) {
 
 int WRAPPER_FUNC(putchar)(int c) {
     char cc = (char)c;
-    stdio_put_string(&cc, 1, false, false);
+    _write(STDIO_HANDLE_STDOUT, &cc, 1);
     return c;
 }
 
 int WRAPPER_FUNC(puts)(const char *s) {
     int len = (int)strlen(s);
-    stdio_put_string(s, len, true, false);
+    _write(STDIO_HANDLE_STDOUT, s, len);
     stdio_flush();
     return len;
 }

--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -170,6 +170,7 @@ int puts_raw(const char *s) {
     return len;
 }
 
+__attribute__((weak))
 int _read(int handle, char *buffer, int length) {
     if (handle == STDIO_HANDLE_STDIN) {
         return stdio_get_until(buffer, length, at_the_end_of_time);
@@ -177,6 +178,7 @@ int _read(int handle, char *buffer, int length) {
     return -1;
 }
 
+__attribute__((weak))
 int _write(int handle, char *buffer, int length) {
     if (handle == STDIO_HANDLE_STDOUT || handle == STDIO_HANDLE_STDERR) {
         stdio_put_string(buffer, length, false, false);


### PR DESCRIPTION
By doing so you can override the functions in your application.

Fixes: #1126 