### PR TITLE
tinyusb: enable workaround for RP2040-E15

### DIFF
--- a/src/rp2_common/tinyusb/CMakeLists.txt
+++ b/src/rp2_common/tinyusb/CMakeLists.txt
@@ -29,8 +29,9 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
     add_library(tinyusb_device_unmarked INTERFACE)
     target_link_libraries(tinyusb_device_unmarked INTERFACE tinyusb_device_base)
     target_compile_definitions(tinyusb_device_unmarked INTERFACE
-            # off by default note TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX defaults from PICO_RP2040_USB_DEVICE_ENUMERATION_FIX
-#            TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX=1
+        # off by default note TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX defaults from PICO_RP2040_USB_DEVICE_ENUMERATION_FIX
+        # TUD_OPT_RP2040_USB_DEVICE_ENUMERATION_FIX=1
+        PICO_RP2040_USB_DEVICE_UFRAME_FIX=1
     )
 
     # unmarked version used by stdio USB


### PR DESCRIPTION
This sets the compile-time flag for tinyusb's dcd_rp2040 driver by default. Applications that won't ever be plugged into a Pi 4 or Pi 400 can optionally disable this.

As of now, this flag does nothing because the corresponding submodule doesn't point to a version that has the fix in.