### PR TITLE
pico_time_headers must not depend on non header target

### DIFF
--- a/src/common/pico_time/CMakeLists.txt
+++ b/src/common/pico_time/CMakeLists.txt
@@ -3,7 +3,7 @@ if (NOT TARGET pico_time_headers)
 
     target_include_directories(pico_time_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-    target_link_libraries(pico_time_headers INTERFACE hardware_timer)
+    target_link_libraries(pico_time_headers INTERFACE hardware_timer_headers)
 endif()
 
 if (NOT TARGET pico_time)


### PR DESCRIPTION
The [pico_time_headers](https://github.com/raspberrypi/pico-sdk/blob/master/src/common/pico_time/CMakeLists.txt#L6) target currently depends on hardware_timer instead of hardware_timer_headers, pulling in implementation when only headers are required.

Fixes #1154