### PR TITLE
#713 Hack to add SPI slave support

### DIFF
--- a/src/rp2_common/hardware_spi/include/hardware/spi.h
+++ b/src/rp2_common/hardware_spi/include/hardware/spi.h
@@ -183,7 +183,7 @@ static inline void spi_set_format(spi_inst_t *spi, uint data_bits, spi_cpol_t cp
     invalid_params_if(SPI, cpha != SPI_CPHA_0 && cpha != SPI_CPHA_1);
 
     // Disable the SPI
-    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS);
+    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS;
     hw_clear_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
 
     hw_write_masked(&spi_get_hw(spi)->cr0,
@@ -209,7 +209,7 @@ static inline void spi_set_format(spi_inst_t *spi, uint data_bits, spi_cpol_t cp
  */
 static inline void spi_set_slave(spi_inst_t *spi, bool slave) {
     // Disable the SPI
-    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS);
+    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS;
     hw_clear_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
 
     if (slave)

--- a/src/rp2_common/hardware_spi/include/hardware/spi.h
+++ b/src/rp2_common/hardware_spi/include/hardware/spi.h
@@ -181,6 +181,11 @@ static inline void spi_set_format(spi_inst_t *spi, uint data_bits, spi_cpol_t cp
     invalid_params_if(SPI, order != SPI_MSB_FIRST);
     invalid_params_if(SPI, cpol != SPI_CPOL_0 && cpol != SPI_CPOL_1);
     invalid_params_if(SPI, cpha != SPI_CPHA_0 && cpha != SPI_CPHA_1);
+
+    // Disable the SPI
+    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS);
+    hw_clear_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
+
     hw_write_masked(&spi_get_hw(spi)->cr0,
                     ((uint)(data_bits - 1)) << SPI_SSPCR0_DSS_LSB |
                     ((uint)cpol) << SPI_SSPCR0_SPO_LSB |
@@ -188,6 +193,9 @@ static inline void spi_set_format(spi_inst_t *spi, uint data_bits, spi_cpol_t cp
         SPI_SSPCR0_DSS_BITS |
         SPI_SSPCR0_SPO_BITS |
         SPI_SSPCR0_SPH_BITS);
+
+    // Re-enable the SPI
+    hw_set_bits(&spi_get_hw(spi)->cr1, enable_mask);
 }
 
 /*! \brief Set SPI master/slave
@@ -200,10 +208,17 @@ static inline void spi_set_format(spi_inst_t *spi, uint data_bits, spi_cpol_t cp
  * \param slave true to set SPI device as a slave device, false for master.
  */
 static inline void spi_set_slave(spi_inst_t *spi, bool slave) {
+    // Disable the SPI
+    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS);
+    hw_clear_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
+
     if (slave)
         hw_set_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_MS_BITS);
     else
         hw_clear_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_MS_BITS);
+
+    // Re-enable the SPI
+    hw_set_bits(&spi_get_hw(spi)->cr1, enable_mask);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/rp2_common/hardware_spi/spi.c
+++ b/src/rp2_common/hardware_spi/spi.c
@@ -29,6 +29,7 @@ uint spi_init(spi_inst_t *spi, uint baudrate) {
 
     // Finally enable the SPI
     hw_set_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
+    
     return baud;
 }
 
@@ -42,6 +43,10 @@ uint spi_set_baudrate(spi_inst_t *spi, uint baudrate) {
     uint freq_in = clock_get_hz(clk_peri);
     uint prescale, postdiv;
     invalid_params_if(SPI, baudrate > freq_in);
+
+    // Disable the SPI
+    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS);
+    hw_clear_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
 
     // Find smallest prescale value which puts output frequency in range of
     // post-divide. Prescale is an even number from 2 to 254 inclusive.
@@ -60,6 +65,9 @@ uint spi_set_baudrate(spi_inst_t *spi, uint baudrate) {
 
     spi_get_hw(spi)->cpsr = prescale;
     hw_write_masked(&spi_get_hw(spi)->cr0, (postdiv - 1) << SPI_SSPCR0_SCR_LSB, SPI_SSPCR0_SCR_BITS);
+
+    // Re-enable the SPI
+    hw_set_bits(&spi_get_hw(spi)->cr1, enable_mask);
 
     // Return the frequency we were able to achieve
     return freq_in / (prescale * postdiv);

--- a/src/rp2_common/hardware_spi/spi.c
+++ b/src/rp2_common/hardware_spi/spi.c
@@ -29,7 +29,7 @@ uint spi_init(spi_inst_t *spi, uint baudrate) {
 
     // Finally enable the SPI
     hw_set_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
-    
+
     return baud;
 }
 
@@ -45,7 +45,7 @@ uint spi_set_baudrate(spi_inst_t *spi, uint baudrate) {
     invalid_params_if(SPI, baudrate > freq_in);
 
     // Disable the SPI
-    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS);
+    uint32_t enable_mask = spi_get_hw(spi)->cr1 & SPI_SSPCR1_SSE_BITS;
     hw_clear_bits(&spi_get_hw(spi)->cr1, SPI_SSPCR1_SSE_BITS);
 
     // Find smallest prescale value which puts output frequency in range of


### PR DESCRIPTION
Three SDK functions potentially attempt to change the SPI configuration while it is enabled. I hacked it to disable the module then change the configuration. It will attempt to re-enable the SPI if enabled. I do not save and restore other settings. I am not sure if this is required or not.

Tested with the following code: (Quick and dirty)
```C++
#include <stdio.h>
#include "pico/stdio.h"
#include "hardware/gpio.h"
#include "hardware/spi.h"

int main() {
    // Setup USB Serial
    stdio_init_all();

    // Setup SPI0 Pins
    for (int i = 0; i < 4; i++) {
        gpio_init(i + 2);
        gpio_set_function(i + 2, GPIO_FUNC_SPI);
    }
    gpio_set_dir(3, true);

    // Setup and enable SPI0-slave
    spi_init(spi0, 1000000);
    spi_set_format(spi0, 8, SPI_CPOL_0, SPI_CPHA_1, SPI_MSB_FIRST);
    spi_set_slave(spi0, true);

    while(1) {
        // Test SPI0-slave function
        if (spi_is_readable(spi0)) {
            uint8_t c;
            spi_read_blocking(spi0, 0, &c, 1);
            printf("%c ", c);
        }
    }
}
```
