### PR TITLE
Fix conflicting C++ linkage for pico_lwip panic()

### DIFF
--- a/src/rp2_common/pico_lwip/include/arch/cc.h
+++ b/src/rp2_common/pico_lwip/include/arch/cc.h
@@ -70,7 +70,13 @@ typedef int sys_prot_t;
 #endif
 
 #ifndef LWIP_PLATFORM_ASSERT
+#ifdef __cplusplus
+extern "C" {
+#endif
 void panic(const char *fmt, ...);
+#ifdef __cplusplus
+}
+#endif
 #define LWIP_PLATFORM_ASSERT(x) panic(x)
 #endif
 


### PR DESCRIPTION
Fixes #1166 by adding `extern "C"` guard around offending declaration of panic.