### PR TITLE
Fixed assert when calling cancel_alarm(0)

### DIFF
--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -261,6 +261,8 @@ alarm_id_t alarm_pool_add_alarm_at(alarm_pool_t *pool, absolute_time_t time, ala
 }
 
 bool alarm_pool_cancel_alarm(alarm_pool_t *pool, alarm_id_t alarm_id) {
+    if (alarm_id == 0)
+        return false;
     bool rc = false;
     uint32_t save = spin_lock_blocking(pool->lock);
     pheap_node_id_t id = (pheap_node_id_t) alarm_id;

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -261,8 +261,7 @@ alarm_id_t alarm_pool_add_alarm_at(alarm_pool_t *pool, absolute_time_t time, ala
 }
 
 bool alarm_pool_cancel_alarm(alarm_pool_t *pool, alarm_id_t alarm_id) {
-    if (alarm_id == 0)
-        return false;
+    if (!alarm_id) return false;
     bool rc = false;
     uint32_t save = spin_lock_blocking(pool->lock);
     pheap_node_id_t id = (pheap_node_id_t) alarm_id;


### PR DESCRIPTION
Cancelling an alarm with ID `0` will currently trigger this assert: `assert(alarm_id != pool->alarm_in_progress)`. This is due to the fact that `alarm_pool_t::alarm_in_progress` is set to `0` to denote that no alarm is in progress. The assert does not consider this and falsely assumes that there is an alarm of ID `0` in progress.

One might think that `ph_contains_node(pool->heap, id)` would return `false` because a node of `0` was never inserted. But this is not the case. The `root_id` of an empty heap is `0` and therefore `0` will be considered to be contained in it, even though it was never explicitly inserted using `ph_insert_node()`. This behavior could be considered a bug in itself, and is what probably lead to this issue,  it is not at all obvious to a user of the heap. However, I did not consider this with my fix.

This PR fixes the issue by returning early if an ID of `0` is provided.