### PR TITLE
change clock_gpio_init to take float and add clock_gpio_init_int_frac

### DIFF
--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -314,7 +314,7 @@ void clocks_enable_resus(resus_callback_t resus_callback) {
     clocks_hw->resus.ctrl = CLOCKS_CLK_SYS_RESUS_CTRL_ENABLE_BITS | timeout;
 }
 
-void clock_gpio_init(uint gpio, uint src, uint div) {
+void clock_gpio_init(uint gpio, uint src, float div) {
     // Bit messy but it's as much code to loop through a lookup
     // table. The sources for each gpout generators are the same
     // so just call with the sources from GP0
@@ -327,10 +327,14 @@ void clock_gpio_init(uint gpio, uint src, uint div) {
         invalid_params_if(CLOCKS, true);
     }
 
+    // set up div
+    invalid_params_if(CLOCKS, div <= 0);
+    uint udiv = div * (1u << 8u);
+
     // Set up the gpclk generator
     clocks_hw->clk[gpclk].ctrl = (src << CLOCKS_CLK_GPOUT0_CTRL_AUXSRC_LSB) |
                                  CLOCKS_CLK_GPOUT0_CTRL_ENABLE_BITS;
-    clocks_hw->clk[gpclk].div = div << CLOCKS_CLK_GPOUT0_DIV_INT_LSB;
+    clocks_hw->clk[gpclk].div = udiv;
 
     // Set gpio pin to gpclock function
     gpio_set_function(gpio, GPIO_FUNC_GPCK);

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -314,7 +314,7 @@ void clocks_enable_resus(resus_callback_t resus_callback) {
     clocks_hw->resus.ctrl = CLOCKS_CLK_SYS_RESUS_CTRL_ENABLE_BITS | timeout;
 }
 
-void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div, uint8_t frac) {
+void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div_int, uint8_t div_frac) {
     // Bit messy but it's as much code to loop through a lookup
     // table. The sources for each gpout generators are the same
     // so just call with the sources from GP0
@@ -330,7 +330,7 @@ void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div, uint8_t frac) 
     // Set up the gpclk generator
     clocks_hw->clk[gpclk].ctrl = (src << CLOCKS_CLK_GPOUT0_CTRL_AUXSRC_LSB) |
                                  CLOCKS_CLK_GPOUT0_CTRL_ENABLE_BITS;
-    clocks_hw->clk[gpclk].div = (div << CLOCKS_CLK_GPOUT0_DIV_INT_LSB) | frac;
+    clocks_hw->clk[gpclk].div = (div_int << CLOCKS_CLK_GPOUT0_DIV_INT_LSB) | div_frac;
 
     // Set gpio pin to gpclock function
     gpio_set_function(gpio, GPIO_FUNC_GPCK);

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -314,8 +314,7 @@ void clocks_enable_resus(resus_callback_t resus_callback) {
     clocks_hw->resus.ctrl = CLOCKS_CLK_SYS_RESUS_CTRL_ENABLE_BITS | timeout;
 }
 
-void clock_gpio_init(uint gpio, uint src, float div) {
-    invalid_params_if(CLOCKS, div >= 1 << (CLOCKS_CLK_GPOUT0_DIV_INT_MSB - CLOCKS_CLK_GPOUT0_DIV_INT_LSB + 1));
+void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div, uint8_t frac) {
     // Bit messy but it's as much code to loop through a lookup
     // table. The sources for each gpout generators are the same
     // so just call with the sources from GP0
@@ -331,7 +330,7 @@ void clock_gpio_init(uint gpio, uint src, float div) {
     // Set up the gpclk generator
     clocks_hw->clk[gpclk].ctrl = (src << CLOCKS_CLK_GPOUT0_CTRL_AUXSRC_LSB) |
                                  CLOCKS_CLK_GPOUT0_CTRL_ENABLE_BITS;
-    clocks_hw->clk[gpclk].div = (uint32_t)(div * (float) (1 << CLOCKS_CLK_GPOUT0_DIV_INT_LSB));
+    clocks_hw->clk[gpclk].div = (div << CLOCKS_CLK_GPOUT0_DIV_INT_LSB) | frac;
 
     // Set gpio pin to gpclock function
     gpio_set_function(gpio, GPIO_FUNC_GPCK);

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -315,6 +315,7 @@ void clocks_enable_resus(resus_callback_t resus_callback) {
 }
 
 void clock_gpio_init(uint gpio, uint src, float div) {
+    invalid_params_if(CLOCKS, div >= 1 << (CLOCKS_CLK_GPOUT0_DIV_INT_MSB - CLOCKS_CLK_GPOUT0_DIV_INT_LSB + 1));
     // Bit messy but it's as much code to loop through a lookup
     // table. The sources for each gpout generators are the same
     // so just call with the sources from GP0
@@ -327,14 +328,10 @@ void clock_gpio_init(uint gpio, uint src, float div) {
         invalid_params_if(CLOCKS, true);
     }
 
-    // set up div
-    invalid_params_if(CLOCKS, div <= 0);
-    uint udiv = div * (1u << 8u);
-
     // Set up the gpclk generator
     clocks_hw->clk[gpclk].ctrl = (src << CLOCKS_CLK_GPOUT0_CTRL_AUXSRC_LSB) |
                                  CLOCKS_CLK_GPOUT0_CTRL_ENABLE_BITS;
-    clocks_hw->clk[gpclk].div = udiv;
+    clocks_hw->clk[gpclk].div = (uint32_t)(div * (float) (1 << CLOCKS_CLK_GPOUT0_DIV_INT_LSB));
 
     // Set gpio pin to gpclock function
     gpio_set_function(gpio, GPIO_FUNC_GPCK);

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -314,7 +314,7 @@ void clocks_enable_resus(resus_callback_t resus_callback) {
     clocks_hw->resus.ctrl = CLOCKS_CLK_SYS_RESUS_CTRL_ENABLE_BITS | timeout;
 }
 
-void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div_int, uint8_t div_frac) {
+void clock_gpio_init_int_frac(uint gpio, uint src, uint32_t div_int, uint8_t div_frac) {
     // Bit messy but it's as much code to loop through a lookup
     // table. The sources for each gpout generators are the same
     // so just call with the sources from GP0

--- a/src/rp2_common/hardware_clocks/include/hardware/clocks.h
+++ b/src/rp2_common/hardware_clocks/include/hardware/clocks.h
@@ -174,7 +174,7 @@ void clocks_enable_resus(resus_callback_t resus_callback);
  * \param src  The source clock. See the register field CLOCKS_CLK_GPOUT0_CTRL_AUXSRC for a full list. The list is the same for each GPOUT clock generator.
  * \param div  The amount to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock.
  */
-void clock_gpio_init(uint gpio, uint src, uint div);
+void clock_gpio_init(uint gpio, uint src, float div);
 
 /*! \brief Configure a clock to come from a gpio input
  *  \ingroup hardware_clocks

--- a/src/rp2_common/hardware_clocks/include/hardware/clocks.h
+++ b/src/rp2_common/hardware_clocks/include/hardware/clocks.h
@@ -172,10 +172,10 @@ void clocks_enable_resus(resus_callback_t resus_callback);
  *
  * \param gpio The GPIO pin to output the clock to. Valid GPIOs are: 21, 23, 24, 25. These GPIOs are connected to the GPOUT0-3 clock generators.
  * \param src  The source clock. See the register field CLOCKS_CLK_GPOUT0_CTRL_AUXSRC for a full list. The list is the same for each GPOUT clock generator.
- * \param div_int  The integer part of dividing the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock. this is in range of 1..2^24-1.
- * \param div_frac The frac of dividing the source clock by. This is in range of 0..255.
+ * \param div_int  The integer part of the value to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock. this is in range of 1..2^24-1.
+ * \param div_frac The fractional part of the value to divide the source clock by. This is in range of 0..255 (/256).
  */
-void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div_int, uint8_t div_frac);
+void clock_gpio_init_int_frac(uint gpio, uint src, uint32_t div_int, uint8_t div_frac);
 
 /*! \brief Output an optionally divided clock to the specified gpio pin.
  *  \ingroup hardware_clocks
@@ -188,7 +188,7 @@ static inline void clock_gpio_init(uint gpio, uint src, float div)
 {
     uint div_int = (uint)div;
     uint8_t frac = (uint8_t)((div - (float)div_int) * (1u << CLOCKS_CLK_GPOUT0_DIV_INT_LSB));
-    clock_gpio_init_with_frac(gpio, src, div_int, frac);
+    clock_gpio_init_int_frac(gpio, src, div_int, frac);
 }
 
 /*! \brief Configure a clock to come from a gpio input

--- a/src/rp2_common/hardware_clocks/include/hardware/clocks.h
+++ b/src/rp2_common/hardware_clocks/include/hardware/clocks.h
@@ -172,22 +172,22 @@ void clocks_enable_resus(resus_callback_t resus_callback);
  *
  * \param gpio The GPIO pin to output the clock to. Valid GPIOs are: 21, 23, 24, 25. These GPIOs are connected to the GPOUT0-3 clock generators.
  * \param src  The source clock. See the register field CLOCKS_CLK_GPOUT0_CTRL_AUXSRC for a full list. The list is the same for each GPOUT clock generator.
- * \param div  The amount to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock.
- * \param frac The frac to divide the source clock by.
+ * \param div_int  The integer part of dividing the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock. this is in range of 1..2^24-1.
+ * \param div_frac The frac of dividing the source clock by. This is in range of 0..255.
  */
-void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div, uint8_t frac);
+void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div_int, uint8_t div_frac);
 
 /*! \brief Output an optionally divided clock to the specified gpio pin.
  *  \ingroup hardware_clocks
  *
  * \param gpio The GPIO pin to output the clock to. Valid GPIOs are: 21, 23, 24, 25. These GPIOs are connected to the GPOUT0-3 clock generators.
  * \param src  The source clock. See the register field CLOCKS_CLK_GPOUT0_CTRL_AUXSRC for a full list. The list is the same for each GPOUT clock generator.
- * \param div  The amount to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock.
+ * \param div  The float amount to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock.
  */
 static inline void clock_gpio_init(uint gpio, uint src, float div)
 {
     uint div_int = (uint)div;
-    uint frac = (uint8_t)((div - (float)div_int) * (1u << CLOCKS_CLK_GPOUT0_DIV_INT_LSB));
+    uint8_t frac = (uint8_t)((div - (float)div_int) * (1u << CLOCKS_CLK_GPOUT0_DIV_INT_LSB));
     clock_gpio_init_with_frac(gpio, src, div_int, frac);
 }
 

--- a/src/rp2_common/hardware_clocks/include/hardware/clocks.h
+++ b/src/rp2_common/hardware_clocks/include/hardware/clocks.h
@@ -173,8 +173,23 @@ void clocks_enable_resus(resus_callback_t resus_callback);
  * \param gpio The GPIO pin to output the clock to. Valid GPIOs are: 21, 23, 24, 25. These GPIOs are connected to the GPOUT0-3 clock generators.
  * \param src  The source clock. See the register field CLOCKS_CLK_GPOUT0_CTRL_AUXSRC for a full list. The list is the same for each GPOUT clock generator.
  * \param div  The amount to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock.
+ * \param frac The frac to divide the source clock by.
  */
-void clock_gpio_init(uint gpio, uint src, float div);
+void clock_gpio_init_with_frac(uint gpio, uint src, uint32_t div, uint8_t frac);
+
+/*! \brief Output an optionally divided clock to the specified gpio pin.
+ *  \ingroup hardware_clocks
+ *
+ * \param gpio The GPIO pin to output the clock to. Valid GPIOs are: 21, 23, 24, 25. These GPIOs are connected to the GPOUT0-3 clock generators.
+ * \param src  The source clock. See the register field CLOCKS_CLK_GPOUT0_CTRL_AUXSRC for a full list. The list is the same for each GPOUT clock generator.
+ * \param div  The amount to divide the source clock by. This is useful to not overwhelm the GPIO pin with a fast clock.
+ */
+static inline void clock_gpio_init(uint gpio, uint src, float div)
+{
+    uint div_int = (uint)div;
+    uint frac = (uint8_t)((div - (float)div_int) * (1u << CLOCKS_CLK_GPOUT0_DIV_INT_LSB));
+    clock_gpio_init_with_frac(gpio, src, div_int, frac);
+}
 
 /*! \brief Configure a clock to come from a gpio input
  *  \ingroup hardware_clocks


### PR DESCRIPTION
The current API only accept a div while the hardware supports frac as well. Make div as float so that we can support FRAC without breaking the existing applications. (C will silent cast int to float to make old code still compile)