### PR TITLE
Update source code to use the correct bit - fixes #993

### DIFF
--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -54,7 +54,7 @@ void runtime_install_stack_guard(void *stack_bottom) {
     // mask is 1 bit per 32 bytes of the 256 byte range... clear the bit for the segment we want
     uint32_t subregion_select = 0xffu ^ (1u << ((addr >> 5u) & 7u));
     mpu_hw->ctrl = 5; // enable mpu with background default map
-    mpu_hw->rbar = (addr & (uint)~0xff) | 0x8 | 0;
+    mpu_hw->rbar = (addr & (uint)~0xff) | M0PLUS_MPU_RBAR_VALID_BITS | 0;
     mpu_hw->rasr = 1 // enable region
                    | (0x7 << 1) // size 2^(7 + 1) = 256
                    | (subregion_select << 8)


### PR DESCRIPTION
Small change to correct the VALID bit set in the MPU's RBAR register.  This error had lain undetected due to the reset state of the RNR register.