### PR TITLE
user_irqs should be claimed globally not per core, since vector tabes are shared

### DIFF
--- a/src/rp2_common/hardware_irq/include/hardware/irq.h
+++ b/src/rp2_common/hardware_irq/include/hardware/irq.h
@@ -18,6 +18,11 @@
 #define PICO_DISABLE_SHARED_IRQ_HANDLERS 0
 #endif
 
+// PICO_CONFIG: PICO_VTABLE_PER_CORE, user is using separate vector tables per core, type=bool, default=0, group=hardware_irq
+#ifndef PICO_VTABLE_PER_CORE
+#define PICO_VTABLE_PER_CORE 0
+#endif
+
 #ifndef __ASSEMBLER__
 
 #include "pico.h"

--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -114,6 +114,10 @@ void multicore_launch_core1_with_stack(void (*entry)(void), uint32_t *stack_bott
     stack_ptr[0] = (uintptr_t) entry;
     stack_ptr[1] = (uintptr_t) stack_bottom;
     stack_ptr[2] = (uintptr_t) core1_wrapper;
+#if PICO_VTABLE_PER_CORE
+#warning PICO_VTABLE_PER_CORE==1 is not currently supported in pico_multicore
+    panic_unsupported();
+#endif
     multicore_launch_core1_raw(core1_trampoline, stack_ptr, scb_hw->vtor);
 }
 


### PR DESCRIPTION
fixes #1051 