### PR TITLE
SYS funcs and GCC12 fixes

### DIFF
--- a/src/common/pico_time/include/pico/time.h
+++ b/src/common/pico_time/include/pico/time.h
@@ -159,7 +159,7 @@ static inline int64_t absolute_time_diff_us(absolute_time_t from, absolute_time_
 
 /*! \brief The timestamp representing the end of time; this is actually not the maximum possible
  * timestamp, but is set to 0x7fffffff_ffffffff microseconds to avoid sign overflows with time
- * arithmetic. This is still over 7 million years, so should be sufficient.
+ * arithmetic. This is almost 300,000 years, so should be sufficient.
  * \ingroup timestamp
  */
 extern const absolute_time_t at_the_end_of_time;

--- a/src/rp2_common/pico_lwip/include/arch/cc.h
+++ b/src/rp2_common/pico_lwip/include/arch/cc.h
@@ -32,6 +32,8 @@
 #ifndef __CC_H__
 #define __CC_H__
 
+#include <sys/time.h>
+
 #if NO_SYS
 // todo really we should just not allow SYS_LIGHTWEIGHT_PROT for nosys mode (it doesn't do anything anyway)
 typedef int sys_prot_t;

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <sys/time.h>
+#include <sys/times.h>
 #include <unistd.h>
 #include "pico.h"
 
@@ -230,6 +231,18 @@ __attribute((weak)) int settimeofday(__unused const struct timeval *tv, __unused
         int64_t us_since_epoch = tv->tv_sec * 1000000 + tv->tv_usec;
         epoch_time_us_since_boot = (int64_t)to_us_since_boot(get_absolute_time()) - us_since_epoch;
     }
+    return 0;
+}
+
+__attribute((weak)) int _times(struct tms *tms) {
+#if CLOCKS_PER_SEC >= 1000000
+    tms->tms_utime = to_us_since_boot(get_absolute_time()) * (CLOCKS_PER_SEC / 1000000);
+#else
+    tms->tms_utime = to_us_since_boot(get_absolute_time()) / (1000000 / CLOCKS_PER_SEC);
+#endif
+    tms->tms_stime = 0;
+    tms->tms_cutime = 0;
+    tms->tms_cstime = 0;
     return 0;
 }
 

--- a/src/rp2_common/pico_standard_link/crt0.S
+++ b/src/rp2_common/pico_standard_link/crt0.S
@@ -263,10 +263,6 @@ platform_entry: // symbol for stack traces
     blx r1
     // exit should not return.  If it does, hang the core.
     // (fall thru into our hang _exit impl
-.weak _exit
-.type _exit,%function
-.thumb_func
-_exit:
 1: // separate label because _exit can be moved out of branch range
     bkpt #0
     b 1b

--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <sys/stat.h>
 
 #include "pico.h"
 #if LIB_PICO_PRINTF_PICO
@@ -172,19 +173,39 @@ int puts_raw(const char *s) {
     return len;
 }
 
-int _read(int handle, char *buffer, int length) {
+int __attribute__((weak)) _read(int handle, char *buffer, int length) {
     if (handle == STDIO_HANDLE_STDIN) {
         return stdio_get_until(buffer, length, at_the_end_of_time);
     }
     return -1;
 }
 
-int _write(int handle, char *buffer, int length) {
+int __attribute__((weak)) _write(int handle, char *buffer, int length) {
     if (handle == STDIO_HANDLE_STDOUT || handle == STDIO_HANDLE_STDERR) {
         stdio_put_string(buffer, length, false, false);
         return length;
     }
     return -1;
+}
+
+int __attribute__((weak)) _open(__unused const char *fn, __unused int oflag, ...) {
+    return -1;
+}
+
+int __attribute__((weak)) _close(__unused int fd) {
+    return -1;
+}
+
+off_t __attribute__((weak)) _lseek(__unused int fd, __unused off_t pos, __unused int whence) {
+    return -1;
+}
+
+int __attribute__((weak)) _fstat(__unused int fd, __unused struct stat *buf) {
+    return -1;
+}
+
+int __attribute__((weak)) _isatty(int fd) {
+    return fd == STDIO_HANDLE_STDIN || fd == STDIO_HANDLE_STDOUT || fd == STDIO_HANDLE_STDERR;
 }
 
 void stdio_set_driver_enabled(stdio_driver_t *driver, bool enable) {


### PR DESCRIPTION
* Add implementation of _gettimeofday and settimeofday
* Remove seme GCC warnings about unimplemented SYS functions (e.g. _open) by making them weak
* Removed _exit from crt0.S since we have a weak version in runtime.c and we don't want two weak impls since the linker can't pick If the user omits runtime.c then they'll need to provide _exit or get the error
* Add sys/time.h to arch/cc.h for lwIP as it seems under GCC12 this is not getting included

