### PR TITLE
Remove (legacy) direct inclusion of 'pico/platform.h' and 'pico/config.h'

### DIFF
--- a/src/common/pico_base/include/pico.h
+++ b/src/common/pico_base/include/pico.h
@@ -16,8 +16,10 @@
  * This header may be included by assembly code
 */
 
+// We may be included by assembly which cant include <cdefs.h>
 #define	__PICO_STRING(x)	#x
 #define	__PICO_XSTRING(x)	__PICO_STRING(x)
+#define __PICO_CONCAT1(x, y) x ## y
 
 #include "pico/types.h"
 #include "pico/version.h"

--- a/src/rp2_common/boot_stage2/include/boot_stage2/config.h
+++ b/src/rp2_common/boot_stage2/include/boot_stage2/config.h
@@ -9,7 +9,7 @@
 
 // NOTE THIS HEADER IS INCLUDED FROM ASSEMBLY
 
-#include "pico/config.h"
+#include "pico.h"
 
 // PICO_CONFIG: PICO_BUILD_BOOT_STAGE2_NAME, The name of the boot stage 2 if selected by the build, group=boot_stage2
 #ifdef PICO_BUILD_BOOT_STAGE2_NAME
@@ -85,10 +85,7 @@
         #error no boot stage 2 is defined by PICO_BOOT_STAGE2_CHOOSE_ macro
     #endif
     // we can't include cdefs in assembly, so define our own, but avoid conflict with real ones for c inclusion
-    #define _PICO__STRING(x) #x
-    #define _PICO__XSTRING(x) _PICO__STRING(x)
-    #define _PICO__CONCAT1(x, y) x ## y
-    #define PICO_BOOT_STAGE2_NAME _PICO__XSTRING(_BOOT_STAGE2)
-    #define PICO_BOOT_STAGE2_ASM _PICO__XSTRING(_PICO__CONCAT1(_BOOT_STAGE2,.S))
+    #define PICO_BOOT_STAGE2_NAME __PICO_XSTRING(_BOOT_STAGE2)
+    #define PICO_BOOT_STAGE2_ASM __PICO_XSTRING(__PICO_CONCAT1(_BOOT_STAGE2,.S))
 #endif
 #endif

--- a/src/rp2_common/pico_double/double_math.c
+++ b/src/rp2_common/pico_double/double_math.c
@@ -5,9 +5,7 @@
  */
 
 #include <math.h>
-#include "pico/types.h"
 #include "pico/double.h"
-#include "pico/platform.h"
 
 // opened a separate issue https://github.com/raspberrypi/pico-sdk/issues/166 to deal with these warnings if at all
 _Pragma("GCC diagnostic push")

--- a/src/rp2_common/pico_double/include/pico/double.h
+++ b/src/rp2_common/pico_double/include/pico/double.h
@@ -8,7 +8,7 @@
 #define _PICO_DOUBLE_H
 
 #include <math.h>
-#include "pico/types.h"
+#include "pico.h"
 #include "pico/bootrom/sf_table.h"
 
 #ifdef __cplusplus

--- a/src/rp2_common/pico_float/float_math.c
+++ b/src/rp2_common/pico_float/float_math.c
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include "pico/types.h"
 #include "pico/float.h"
-#include "pico/platform.h"
 
 // opened a separate issue https://github.com/raspberrypi/pico-sdk/issues/166 to deal with these warnings if at all
 _Pragma("GCC diagnostic push")

--- a/src/rp2_common/pico_float/include/pico/float.h
+++ b/src/rp2_common/pico_float/include/pico/float.h
@@ -9,7 +9,7 @@
 
 #include <math.h>
 #include <float.h>
-#include "pico/types.h"
+#include "pico.h"
 #include "pico/bootrom/sf_table.h"
 
 #ifdef __cplusplus

--- a/src/rp2_common/pico_printf/printf.c
+++ b/src/rp2_common/pico_printf/printf.c
@@ -34,7 +34,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "pico/platform.h"
+#include "pico.h"
 #include "pico/printf.h"
 
 // PICO_CONFIG: PICO_PRINTF_NTOA_BUFFER_SIZE, Define printf ntoa buffer size, min=0, max=128, default=32, group=pico_printf

--- a/src/rp2_common/pico_stdio/include/pico/stdio/driver.h
+++ b/src/rp2_common/pico_stdio/include/pico/stdio/driver.h
@@ -8,7 +8,6 @@
 #define _PICO_STDIO_DRIVER_H
 
 #include "pico/stdio.h"
-#include "pico/platform.h"
 
 struct stdio_driver {
     void (*out_chars)(const char *buf, int len);


### PR DESCRIPTION
Now `pico.h` is safe to include from everywhere (including assembly files), and ensures that defines and configs are created in the right order

fixes #1170
fixes #950