### PR TITLE
Tweaks to section-attribute stuff in platform.h

### DIFF
--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -153,9 +153,9 @@ extern "C" {
  *
  * For example a `uint32_t` foo that will retain its value if the program is restarted by reset.
  *
- *     uint32_t __uninitialized_ram("foo");
+ *     uint32_t __uninitialized_ram(foo);
  *
- * The section attribute is `.uninitialized_ram.<group>`
+ * The section attribute is `.uninitialized_data.<group>`
  *
  * \param group a string suffix to use in the section name to distinguish groups that can be linker
  *              garbage-collected independently
@@ -174,7 +174,7 @@ extern "C" {
  * \param group a string suffix to use in the section name to distinguish groups that can be linker
  *              garbage-collected independently
  */
-#define __in_flash(group) __attribute__((section(".flashdata" group)))
+#define __in_flash(group) __attribute__((section(".flashdata." group)))
 
 /*! \brief Indicates a function should not be stored in flash
  *  \ingroup pico_platform


### PR DESCRIPTION
I _think_ this is right, based on a careful reading of the comments and the code, but I can't be 100% sure.
I also think that the `\param group ...` stuff in the `__uninitialized_ram` section is now wrong, but I'm not sure what it should be changed to.