### PR TITLE
Rework build targets to mirror libraries as _headers versions, and fix dependency issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,29 @@ function(pico_add_subdirectory subdir)
     pico_promote_common_scope_vars()
 endfunction()
 
+# takes dependencies after the target
+function(pico_mirrored_target_link_libraries TARGET SCOPE)
+    if (${ARGC} LESS 3)
+        message(FATAL_ERROR "expected a target, scope and at least one dependency")
+    endif()
+    if (NOT TARGET ${TARGET}_headers)
+        message(FATAL_ERROR "${TARGET} does not have headers")
+    endif()
+    # library should depend on its own header
+    target_link_libraries(${TARGET} ${SCOPE} ${TARGET}_headers)
+    foreach(DEPENDENCY IN LISTS ARGN)
+        if (DEPENDENCY MATCHES ".*_headers")
+            message(FATAL_ERROR "should not use headers with pico_mirrored_target_link_libraries")
+        endif()
+        # note, it would be nice to only add the dependency if it exists, but we do
+        # not necessarily add libraries in reverse dependency order, so we do this
+        # unconditionally, so this function should only be passed dependencies that
+        # have headers, or link will fail with a missing library -lfoo_headers
+        target_link_libraries(${TARGET}_headers ${SCOPE} ${DEPENDENCY}_headers)
+        target_link_libraries(${TARGET} ${SCOPE} ${DEPENDENCY})
+    endforeach()
+endfunction()
+
 # add a link option to wrap the given function name; i.e. -Wl:wrap=FUNCNAME for gcc
 function(pico_wrap_function TARGET FUNCNAME)
     target_link_options(${TARGET} INTERFACE "LINKER:--wrap=${FUNCNAME}")
@@ -42,18 +65,34 @@ function(pico_add_map_output TARGET)
     endif ()
 endfunction()
 
-# create a hardware_NAME_headers target (see pico_pico_simple_hardware_headers_target)
-# create a hardware_NAME target (see pico_pico_simple_hardware_target)
+# create a hardware_NAME_headers target (see pico_simple_hardware_headers_target)
+# create a hardware_NAME target (see pico_simple_hardware_target)
 macro(pico_simple_hardware_target NAME)
     pico_simple_hardware_headers_target(${NAME})
     pico_simple_hardware_impl_target(${NAME})
 endmacro()
 
 # create an INTERFACE library named target, and define LIB_TARGET=1 (upper case) as a compile option
+# and make it dependent on a pre-existing corresponding _headers library
+# optional arg NOFLAG will skip the LIB_TARGET definition
 function(pico_add_impl_library target)
     add_library(${target} INTERFACE)
     string(TOUPPER ${target} TARGET_UPPER)
-    target_compile_definitions(${target} INTERFACE LIB_${TARGET_UPPER}=1)
+    if (${ARGC} GREATER 1)
+        if (NOT "${ARGV1}" STREQUAL "NOFLAG")
+            message(FATAL_ERROR "Unknown parameter ${ARGV1}")
+        endif()
+    else()
+        target_compile_definitions(${target} INTERFACE LIB_${TARGET_UPPER}=1)
+    endif()
+    target_link_libraries(${target} INTERFACE ${target}_headers)
+endfunction()
+
+# create an INTERFACE library named target along with associated header, and define LIB_TARGET=1 (upper case) as a compile option
+# optional arg NOFLAG will skip the LIB_TARGET definition
+function(pico_add_library target)
+    add_library(${target}_headers INTERFACE)
+    pico_add_impl_library(${target} ${ARGN})
 endfunction()
 
 # create an INTERFACE library named hardware_NAME_headers INTERFACE library if it doesn't already exist,
@@ -66,7 +105,7 @@ macro(pico_simple_hardware_headers_target NAME)
         target_include_directories(hardware_${NAME}_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
         target_link_libraries(hardware_${NAME}_headers INTERFACE pico_base_headers)
         if (NOT PICO_NO_HARDWARE)
-            target_link_libraries(hardware_${NAME}_headers INTERFACE hardware_structs hardware_claim)
+            target_link_libraries(hardware_${NAME}_headers INTERFACE hardware_structs hardware_claim_headers)
         endif()
     endif()
 endmacro()
@@ -80,13 +119,17 @@ macro(pico_simple_hardware_headers_only_target NAME)
         #   super interesting except to determine functionality as they are mostly passive accessors, however
         #   they could be useful to determine if the header is available.
         # pico_add_sdk_impl_library(hardware_${NAME})
-        add_library(hardware_${NAME} INTERFACE)
+        add_library(hardware_${NAME}_headers INTERFACE)
 
-        target_include_directories(hardware_${NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-        target_link_libraries(hardware_${NAME} INTERFACE pico_base_headers)
+        # a headers only target should still have an explicit _headers library for consistency
+        target_include_directories(hardware_${NAME}_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+        target_link_libraries(hardware_${NAME}_headers INTERFACE pico_base_headers)
         if (NOT PICO_NO_HARDWARE)
-            target_link_libraries(hardware_${NAME} INTERFACE hardware_structs)
+            target_link_libraries(hardware_${NAME}_headers INTERFACE hardware_structs)
         endif()
+
+        add_library(hardware_${NAME} INTERFACE)
+        target_link_libraries(hardware_${NAME} INTERFACE hardware_${NAME}_headers)
     endif()
 endmacro()
 
@@ -104,7 +147,10 @@ macro(pico_simple_hardware_impl_target NAME)
                 ${CMAKE_CURRENT_LIST_DIR}/${NAME}.c
                 )
 
-        target_link_libraries(hardware_${NAME} INTERFACE hardware_${NAME}_headers pico_platform)
+        pico_mirrored_target_link_libraries(hardware_${NAME} INTERFACE pico_platform)
+        if (NOT PICO_NO_HARDWARE)
+            target_link_libraries(hardware_${NAME} INTERFACE hardware_claim)
+        endif()
     endif()
 endmacro()
 

--- a/src/common/pico_base/CMakeLists.txt
+++ b/src/common/pico_base/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_base_headers)
-    add_library(pico_base_headers INTERFACE)
+    pico_add_library(pico_base NOFLAG)
     target_include_directories(pico_base_headers INTERFACE include ${CMAKE_BINARY_DIR}/generated/pico_base)
 
     # PICO_BUILD_DEFINE: PICO_BOARD, Name of board, type=string, default=CMake PICO_BOARD variable, group=pico_base
@@ -11,3 +11,4 @@ if (NOT TARGET pico_base_headers)
     list(APPEND PICO_SDK_POST_LIST_FILES ${CMAKE_CURRENT_LIST_DIR}/generate_config_header.cmake)
     pico_promote_common_scope_vars()
 endif()
+

--- a/src/common/pico_stdlib/CMakeLists.txt
+++ b/src/common/pico_stdlib/CMakeLists.txt
@@ -1,11 +1,5 @@
 if (NOT TARGET pico_stdlib_headers)
     add_library(pico_stdlib_headers INTERFACE)
     target_include_directories(pico_stdlib_headers INTERFACE include)
-    target_link_libraries(pico_stdlib_headers INTERFACE
-            hardware_gpio
-            hardware_uart
-            hardware_divider
-            pico_time
-            pico_util
-    )
+    # dependencies handled in implementation CMakeLists.txt
 endif()

--- a/src/common/pico_sync/CMakeLists.txt
+++ b/src/common/pico_sync/CMakeLists.txt
@@ -1,44 +1,46 @@
 if (NOT TARGET pico_sync_headers)
     add_library(pico_sync_headers INTERFACE)
-    target_include_directories(pico_sync_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-    target_link_libraries(pico_sync_headers INTERFACE hardware_sync pico_time)
-endif()
-
-if (NOT TARGET pico_sync_core)
-    pico_add_impl_library(pico_sync_core)
-    target_sources(pico_sync_core INTERFACE
-            ${CMAKE_CURRENT_LIST_DIR}/lock_core.c
-    )
-    target_link_libraries(pico_sync_core INTERFACE pico_sync_headers)
-endif()
-
-if (NOT TARGET pico_sync_sem)
-    pico_add_impl_library(pico_sync_sem)
-    target_sources(pico_sync_sem INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/sem.c
-    )
-    target_link_libraries(pico_sync_sem INTERFACE pico_sync_core pico_time)
-endif()
-
-if (NOT TARGET pico_sync_mutex)
-    pico_add_impl_library(pico_sync_mutex)
-    target_sources(pico_sync_mutex INTERFACE
-            ${CMAKE_CURRENT_LIST_DIR}/mutex.c
-            )
-    target_link_libraries(pico_sync_mutex INTERFACE pico_sync_core pico_time)
-endif()
-
-if (NOT TARGET pico_sync_critical_section)
-    pico_add_impl_library(pico_sync_critical_section)
-    target_sources(pico_sync_critical_section INTERFACE
-            ${CMAKE_CURRENT_LIST_DIR}/critical_section.c
-            )
-    target_link_libraries(pico_sync_critical_section INTERFACE pico_sync_core pico_time)
+    target_link_libraries(pico_sync_headers INTERFACE
+            hardware_sync_headers
+            pico_time_headers)
 endif()
 
 if (NOT TARGET pico_sync)
     pico_add_impl_library(pico_sync)
-    target_link_libraries(pico_sync INTERFACE pico_sync_sem pico_sync_mutex pico_sync_critical_section pico_sync_core)
+    target_include_directories(pico_sync_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    pico_mirrored_target_link_libraries(pico_sync INTERFACE pico_sync_sem pico_sync_mutex pico_sync_critical_section pico_time hardware_sync)
+endif()
+
+
+if (NOT TARGET pico_sync_core)
+    pico_add_library(pico_sync_core NOFLAG)
+    target_sources(pico_sync_core INTERFACE
+            ${CMAKE_CURRENT_LIST_DIR}/lock_core.c
+    )
+endif()
+
+if (NOT TARGET pico_sync_sem)
+    pico_add_library(pico_sync_sem)
+    target_sources(pico_sync_sem INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/sem.c
+    )
+    pico_mirrored_target_link_libraries(pico_sync_sem INTERFACE pico_sync_core)
+endif()
+
+if (NOT TARGET pico_sync_mutex)
+    pico_add_library(pico_sync_mutex)
+    target_sources(pico_sync_mutex INTERFACE
+            ${CMAKE_CURRENT_LIST_DIR}/mutex.c
+            )
+    pico_mirrored_target_link_libraries(pico_sync_mutex INTERFACE pico_sync_core)
+endif()
+
+if (NOT TARGET pico_sync_critical_section)
+    pico_add_library(pico_sync_critical_section)
+    target_sources(pico_sync_critical_section INTERFACE
+            ${CMAKE_CURRENT_LIST_DIR}/critical_section.c
+            )
+    pico_mirrored_target_link_libraries(pico_sync_critical_section INTERFACE pico_sync_core)
 endif()
 
 

--- a/src/common/pico_time/CMakeLists.txt
+++ b/src/common/pico_time/CMakeLists.txt
@@ -1,9 +1,7 @@
 if (NOT TARGET pico_time_headers)
     add_library(pico_time_headers INTERFACE)
-
     target_include_directories(pico_time_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-
-    target_link_libraries(pico_time_headers INTERFACE hardware_timer)
+    target_link_libraries(pico_time_headers INTERFACE hardware_timer_headers pico_sync_headers pico_util_headers)
 endif()
 
 if (NOT TARGET pico_time)
@@ -12,5 +10,5 @@ if (NOT TARGET pico_time)
     target_sources(pico_time INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/time.c
             ${CMAKE_CURRENT_LIST_DIR}/timeout_helper.c)
-    target_link_libraries(pico_time INTERFACE pico_time_headers pico_sync pico_util)
+    target_link_libraries(pico_time INTERFACE hardware_timer pico_sync pico_util)
 endif()

--- a/src/common/pico_usb_reset_interface/CMakeLists.txt
+++ b/src/common/pico_usb_reset_interface/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(pico_usb_reset_interface_headers INTERFACE)
+pico_add_library(pico_usb_reset_interface NOFLAG)
 target_include_directories(pico_usb_reset_interface_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/src/common/pico_util/CMakeLists.txt
+++ b/src/common/pico_util/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (NOT TARGET pico_util_headers)
     add_library(pico_util_headers INTERFACE)
     target_include_directories(pico_util_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-    target_link_libraries(pico_util_headers INTERFACE pico_base_headers hardware_sync)
+    target_link_libraries(pico_util_headers INTERFACE pico_base_headers hardware_sync_headers)
 endif()
 
 if (NOT TARGET pico_util)
@@ -11,5 +11,5 @@ if (NOT TARGET pico_util)
             ${CMAKE_CURRENT_LIST_DIR}/pheap.c
             ${CMAKE_CURRENT_LIST_DIR}/queue.c
     )
-    target_link_libraries(pico_util INTERFACE pico_util_headers)
+    pico_mirrored_target_link_libraries(pico_util INTERFACE pico_sync)
 endif()

--- a/src/host/hardware_sync/CMakeLists.txt
+++ b/src/host/hardware_sync/CMakeLists.txt
@@ -7,6 +7,6 @@ if (NOT TARGET hardware_sync)
         ${CMAKE_CURRENT_LIST_DIR}/sync_core0_only.c
     )
 
-    target_link_libraries(hardware_sync INTERFACE hardware_sync_headers pico_platform)
+    pico_mirrored_target_link_libraries(hardware_sync INTERFACE pico_platform)
 endif()
 

--- a/src/host/hardware_timer/CMakeLists.txt
+++ b/src/host/hardware_timer/CMakeLists.txt
@@ -1,6 +1,6 @@
 pico_simple_hardware_target(timer)
 
-target_compile_definitions(hardware_timer INTERFACE
+target_compile_definitions(hardware_timer_headers INTERFACE
     PICO_HARDWARE_TIMER_RESOLUTION_US=1000 # to loosen tests a little
 )
 

--- a/src/host/pico_divider/CMakeLists.txt
+++ b/src/host/pico_divider/CMakeLists.txt
@@ -3,7 +3,7 @@ pico_add_impl_library(pico_divider)
 target_sources(pico_divider INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/divider.c)
 
-target_link_libraries(pico_divider INTERFACE pico_divider_headers)
+pico_mirrored_target_link_libraries(pico_divider INTERFACE hardware_divider)
 
 macro(pico_set_divider_implementation TARGET IMPL)
 endmacro()

--- a/src/host/pico_multicore/CMakeLists.txt
+++ b/src/host/pico_multicore/CMakeLists.txt
@@ -1,7 +1,9 @@
 if (NOT TARGET pico_multicore)
-    pico_add_impl_library(pico_multicore)
+    pico_add_library(pico_multicore)
 
-    target_include_directories(pico_multicore INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    target_include_directories(pico_multicore_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+
+    pico_mirrored_target_link_libraries(pico_multicore INTERFACE pico_base)
 endif()
 
 

--- a/src/host/pico_platform/include/pico/platform.h
+++ b/src/host/pico_platform/include/pico/platform.h
@@ -8,6 +8,7 @@
 #define _PICO_PLATFORM_H
 
 #include "hardware/platform_defs.h"
+#include <stdint.h>
 #include <stddef.h>
 
 #ifdef __unix__

--- a/src/host/pico_printf/CMakeLists.txt
+++ b/src/host/pico_printf/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_printf)
-    pico_add_impl_library(pico_printf)
+    pico_add_library(pico_printf)
     function(pico_set_printf_implementation)
     endfunction()
 endif()

--- a/src/host/pico_stdio/CMakeLists.txt
+++ b/src/host/pico_stdio/CMakeLists.txt
@@ -1,14 +1,14 @@
 if (NOT TARGET pico_stdio)
-    pico_add_impl_library(pico_stdio)
+    pico_add_library(pico_stdio NOFLAG)
 
-    target_include_directories(pico_stdio INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    target_include_directories(pico_stdio_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     target_sources(pico_stdio INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/stdio.c
             )
-    pico_add_impl_library(pico_stdio_usb)
-    pico_add_impl_library(pico_stdio_uart)
-    pico_add_impl_library(pico_stdio_semihosting)
+    pico_add_library(pico_stdio_usb)
+    pico_add_library(pico_stdio_uart)
+    pico_add_library(pico_stdio_semihosting)
     
     function(pico_enable_stdio_uart)
     endfunction()

--- a/src/host/pico_stdlib/CMakeLists.txt
+++ b/src/host/pico_stdlib/CMakeLists.txt
@@ -14,6 +14,7 @@ if (NOT TARGET pico_stdlib)
             pico_printf
             pico_stdio
             hardware_gpio
+            hardware_uart
     )
 endif()
 

--- a/src/rp2040/hardware_regs/CMakeLists.txt
+++ b/src/rp2040/hardware_regs/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(hardware_regs INTERFACE)
-target_include_directories(hardware_regs INTERFACE include)
-target_link_libraries(hardware_regs INTERFACE hardware_base)
+add_library(hardware_regs_headers INTERFACE)
+target_include_directories(hardware_regs_headers INTERFACE include)
+pico_mirrored_target_link_libraries(hardware_regs INTERFACE hardware_base)

--- a/src/rp2040/hardware_structs/CMakeLists.txt
+++ b/src/rp2040/hardware_structs/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(hardware_structs INTERFACE)
-target_include_directories(hardware_structs INTERFACE include)
-target_link_libraries(hardware_structs INTERFACE hardware_regs)
+add_library(hardware_structs_headers INTERFACE)
+target_include_directories(hardware_structs_headers INTERFACE include)
+pico_mirrored_target_link_libraries(hardware_structs INTERFACE hardware_regs)

--- a/src/rp2_common/cmsis/CMakeLists.txt
+++ b/src/rp2_common/cmsis/CMakeLists.txt
@@ -50,15 +50,15 @@ set(PICO_CMSIS_VENDOR RaspberryPi)
 set(PICO_CMSIS_DEVICE RP2040)
 
 if (PICO_CMSIS_CORE_PATH)
-    pico_add_impl_library(cmsis_core)
+    pico_add_library(cmsis_core)
     target_sources(cmsis_core INTERFACE
             ${PICO_CMSIS_CORE_PATH}/CMSIS/Device/${PICO_CMSIS_VENDOR}/${PICO_CMSIS_DEVICE}/Source/system_${PICO_CMSIS_DEVICE}.c
     )
-    target_include_directories(cmsis_core INTERFACE
+    target_include_directories(cmsis_core_headers INTERFACE
             ${PICO_CMSIS_CORE_PATH}/CMSIS/Core/Include
             ${PICO_CMSIS_CORE_PATH}/CMSIS/Device/${PICO_CMSIS_VENDOR}/${PICO_CMSIS_DEVICE}/Include
     )
-    target_link_libraries(cmsis_core INTERFACE hardware_clocks pico_platform)
+    pico_mirrored_target_link_libraries(cmsis_core INTERFACE hardware_clocks pico_platform)
 
     list(APPEND PICO_RP2040_CONFIG_HEADER_FILES ${CMAKE_CURRENT_LIST_DIR}/include/cmsis/rename_exceptions.h)
     pico_promote_common_scope_vars()

--- a/src/rp2_common/hardware_adc/CMakeLists.txt
+++ b/src/rp2_common/hardware_adc/CMakeLists.txt
@@ -1,4 +1,4 @@
 pico_simple_hardware_target(adc)
 
 # additional library
-target_link_libraries(hardware_adc INTERFACE hardware_resets)
+pico_mirrored_target_link_libraries(hardware_adc INTERFACE hardware_gpio hardware_resets)

--- a/src/rp2_common/hardware_base/CMakeLists.txt
+++ b/src/rp2_common/hardware_base/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_library(hardware_base INTERFACE)
-target_include_directories(hardware_base INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-target_link_libraries(hardware_base INTERFACE pico_base_headers)
+add_library(hardware_base_headers INTERFACE)
+target_include_directories(hardware_base_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_link_libraries(hardware_base_headers INTERFACE pico_base_headers)
+target_link_libraries(hardware_base INTERFACE hardware_base_headers)

--- a/src/rp2_common/hardware_claim/CMakeLists.txt
+++ b/src/rp2_common/hardware_claim/CMakeLists.txt
@@ -1,2 +1,3 @@
 pico_simple_hardware_target(claim)
-target_link_libraries(hardware_claim INTERFACE hardware_sync)
+
+pico_mirrored_target_link_libraries(hardware_claim INTERFACE hardware_sync)

--- a/src/rp2_common/hardware_clocks/CMakeLists.txt
+++ b/src/rp2_common/hardware_clocks/CMakeLists.txt
@@ -1,6 +1,6 @@
 pico_simple_hardware_target(clocks)
 
-target_link_libraries(hardware_clocks INTERFACE
+pico_mirrored_target_link_libraries(hardware_clocks INTERFACE
         hardware_gpio
         hardware_irq
         hardware_resets

--- a/src/rp2_common/hardware_divider/CMakeLists.txt
+++ b/src/rp2_common/hardware_divider/CMakeLists.txt
@@ -1,3 +1,3 @@
 pico_simple_hardware_headers_only_target(divider)
 target_sources(hardware_divider INTERFACE ${CMAKE_CURRENT_LIST_DIR}/divider.S)
-target_link_libraries(hardware_divider INTERFACE hardware_structs)
+target_link_libraries(hardware_divider_headers INTERFACE hardware_structs)

--- a/src/rp2_common/hardware_dma/CMakeLists.txt
+++ b/src/rp2_common/hardware_dma/CMakeLists.txt
@@ -1,2 +1,2 @@
 pico_simple_hardware_target(dma)
-target_link_libraries(hardware_dma INTERFACE hardware_claim)
+pico_mirrored_target_link_libraries(hardware_dma INTERFACE hardware_claim)

--- a/src/rp2_common/hardware_exception/CMakeLists.txt
+++ b/src/rp2_common/hardware_exception/CMakeLists.txt
@@ -1,1 +1,2 @@
 pico_simple_hardware_target(exception)
+pico_mirrored_target_link_libraries(hardware_exception INTERFACE hardware_sync)

--- a/src/rp2_common/hardware_exception/exception.c
+++ b/src/rp2_common/hardware_exception/exception.c
@@ -6,10 +6,8 @@
 
 #include "hardware/exception.h"
 #include "hardware/regs/m0plus.h"
-#include "hardware/platform_defs.h"
 #include "hardware/structs/scb.h"
-
-#include "pico/mutex.h"
+#include "hardware/sync.h"
 #include "pico/assert.h"
 
 #ifndef exception_is_compile_time_default

--- a/src/rp2_common/hardware_flash/CMakeLists.txt
+++ b/src/rp2_common/hardware_flash/CMakeLists.txt
@@ -1,2 +1,2 @@
 pico_simple_hardware_target(flash)
-target_link_libraries(hardware_flash INTERFACE pico_bootrom)
+pico_mirrored_target_link_libraries(hardware_flash INTERFACE pico_bootrom)

--- a/src/rp2_common/hardware_gpio/CMakeLists.txt
+++ b/src/rp2_common/hardware_gpio/CMakeLists.txt
@@ -1,2 +1,2 @@
 pico_simple_hardware_target(gpio)
-target_link_libraries(hardware_gpio INTERFACE hardware_irq)
+pico_mirrored_target_link_libraries(hardware_gpio INTERFACE hardware_irq)

--- a/src/rp2_common/hardware_i2c/CMakeLists.txt
+++ b/src/rp2_common/hardware_i2c/CMakeLists.txt
@@ -1,1 +1,2 @@
 pico_simple_hardware_target(i2c)
+pico_mirrored_target_link_libraries(hardware_i2c INTERFACE pico_time hardware_resets hardware_clocks)

--- a/src/rp2_common/hardware_irq/CMakeLists.txt
+++ b/src/rp2_common/hardware_irq/CMakeLists.txt
@@ -3,4 +3,5 @@ pico_simple_hardware_target(irq)
 # additional sources/libraries
 
 target_sources(hardware_irq INTERFACE ${CMAKE_CURRENT_LIST_DIR}/irq_handler_chain.S)
-target_link_libraries(hardware_irq INTERFACE pico_sync)
+
+pico_mirrored_target_link_libraries(hardware_irq INTERFACE pico_sync)

--- a/src/rp2_common/hardware_pio/CMakeLists.txt
+++ b/src/rp2_common/hardware_pio/CMakeLists.txt
@@ -1,4 +1,7 @@
 pico_simple_hardware_target(pio)
 
 # additional libraries
-target_link_libraries(hardware_pio INTERFACE hardware_gpio hardware_claim)
+pico_mirrored_target_link_libraries(hardware_pio INTERFACE
+        hardware_gpio
+        hardware_claim
+        )

--- a/src/rp2_common/hardware_pll/CMakeLists.txt
+++ b/src/rp2_common/hardware_pll/CMakeLists.txt
@@ -1,1 +1,3 @@
 pico_simple_hardware_target(pll)
+
+pico_mirrored_target_link_libraries(hardware_pll INTERFACE hardware_clocks)

--- a/src/rp2_common/hardware_rtc/CMakeLists.txt
+++ b/src/rp2_common/hardware_rtc/CMakeLists.txt
@@ -1,1 +1,2 @@
 pico_simple_hardware_target(rtc)
+pico_mirrored_target_link_libraries(hardware_rtc INTERFACE hardware_irq hardware_resets hardware_clocks)

--- a/src/rp2_common/hardware_spi/CMakeLists.txt
+++ b/src/rp2_common/hardware_spi/CMakeLists.txt
@@ -1,1 +1,3 @@
 pico_simple_hardware_target(spi)
+
+pico_mirrored_target_link_libraries(hardware_spi INTERFACE hardware_resets hardware_clocks)

--- a/src/rp2_common/hardware_spi/include/hardware/spi.h
+++ b/src/rp2_common/hardware_spi/include/hardware/spi.h
@@ -8,7 +8,6 @@
 #define _HARDWARE_SPI_H
 
 #include "pico.h"
-#include "pico/time.h"
 #include "hardware/structs/spi.h"
 #include "hardware/regs/dreq.h"
 

--- a/src/rp2_common/hardware_timer/CMakeLists.txt
+++ b/src/rp2_common/hardware_timer/CMakeLists.txt
@@ -1,2 +1,2 @@
 pico_simple_hardware_target(timer)
-target_link_libraries(hardware_timer INTERFACE hardware_claim)
+pico_mirrored_target_link_libraries(hardware_timer INTERFACE hardware_claim hardware_irq)

--- a/src/rp2_common/hardware_uart/CMakeLists.txt
+++ b/src/rp2_common/hardware_uart/CMakeLists.txt
@@ -1,1 +1,3 @@
 pico_simple_hardware_target(uart)
+
+pico_mirrored_target_link_libraries(hardware_uart INTERFACE hardware_resets hardware_clocks)

--- a/src/rp2_common/hardware_xosc/CMakeLists.txt
+++ b/src/rp2_common/hardware_xosc/CMakeLists.txt
@@ -1,1 +1,2 @@
 pico_simple_hardware_target(xosc)
+pico_mirrored_target_link_libraries(hardware_xosc INTERFACE hardware_clocks)

--- a/src/rp2_common/pico_async_context/CMakeLists.txt
+++ b/src/rp2_common/pico_async_context/CMakeLists.txt
@@ -1,24 +1,24 @@
-add_library(pico_async_context_base INTERFACE)
-target_include_directories(pico_async_context_base INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+pico_add_library(pico_async_context_base NOFLAG)
+target_include_directories(pico_async_context_base_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 target_sources(pico_async_context_base INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/async_context_base.c
         )
-target_link_libraries(pico_async_context_base INTERFACE pico_platform)
+pico_mirrored_target_link_libraries(pico_async_context_base INTERFACE pico_platform)
 
-pico_add_impl_library(pico_async_context_poll INTERFACE)
+pico_add_library(pico_async_context_poll)
 target_sources(pico_async_context_poll INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/async_context_poll.c
 )
-target_link_libraries(pico_async_context_poll INTERFACE pico_async_context_base)
+pico_mirrored_target_link_libraries(pico_async_context_poll INTERFACE pico_async_context_base)
 
-pico_add_impl_library(pico_async_context_threadsafe_background INTERFACE)
+pico_add_library(pico_async_context_threadsafe_background)
 target_sources(pico_async_context_threadsafe_background INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/async_context_threadsafe_background.c
         )
-target_link_libraries(pico_async_context_threadsafe_background INTERFACE pico_async_context_base)
+pico_mirrored_target_link_libraries(pico_async_context_threadsafe_background INTERFACE pico_async_context_base)
 
-pico_add_impl_library(pico_async_context_freertos INTERFACE)
+pico_add_library(pico_async_context_freertos)
 target_sources(pico_async_context_freertos INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/async_context_freertos.c
         )
-target_link_libraries(pico_async_context_freertos INTERFACE pico_async_context_base)
+pico_mirrored_target_link_libraries(pico_async_context_freertos INTERFACE pico_async_context_base)

--- a/src/rp2_common/pico_bit_ops/CMakeLists.txt
+++ b/src/rp2_common/pico_bit_ops/CMakeLists.txt
@@ -3,7 +3,7 @@ if (NOT TARGET pico_bit_ops)
     pico_add_impl_library(pico_bit_ops)
 
     # no custom implementation; falls thru to compiler
-    pico_add_impl_library(pico_bit_ops_compiler)
+    pico_add_library(pico_bit_ops_compiler)
 
     # add alias "default" which is just pico.
     add_library(pico_bit_ops_default INTERFACE)
@@ -11,7 +11,7 @@ if (NOT TARGET pico_bit_ops)
 
     set(PICO_DEFAULT_BIT_OPS_IMPL pico_bit_ops_default)
 
-    pico_add_impl_library(pico_bit_ops_pico)
+    pico_add_library(pico_bit_ops_pico)
     target_link_libraries(pico_bit_ops INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_BIT_OPS_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_BIT_OPS_IMPL>,${PICO_DEFAULT_BIT_OPS_IMPL}>)
 

--- a/src/rp2_common/pico_bootrom/CMakeLists.txt
+++ b/src/rp2_common/pico_bootrom/CMakeLists.txt
@@ -1,8 +1,10 @@
-add_library(pico_bootrom INTERFACE)
+pico_add_library(pico_bootrom_headers NOFLAG)
 
+target_include_directories(pico_bootrom_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+
+add_library(pico_bootrom INTERFACE)
 target_sources(pico_bootrom INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/bootrom.c
         )
 
-target_include_directories(pico_bootrom INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-target_link_libraries(pico_bootrom INTERFACE pico_base_headers)
+pico_mirrored_target_link_libraries(pico_bootrom INTERFACE pico_base)

--- a/src/rp2_common/pico_bootsel_via_double_reset/CMakeLists.txt
+++ b/src/rp2_common/pico_bootsel_via_double_reset/CMakeLists.txt
@@ -1,10 +1,11 @@
-pico_add_impl_library(pico_bootsel_via_double_reset)
+pico_add_library(pico_bootsel_via_double_reset)
 
 target_sources(pico_bootsel_via_double_reset INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/pico_bootsel_via_double_reset.c
         )
 
-target_link_libraries(pico_bootsel_via_double_reset INTERFACE
+pico_mirrored_target_link_libraries(pico_bootsel_via_double_reset INTERFACE
         pico_bootrom
         pico_time
+        pico_binary_info
         )

--- a/src/rp2_common/pico_cyw43_arch/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_arch/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (PICO_CYW43_SUPPORTED) # set by BOARD=pico-w
     if (TARGET cyw43_driver_picow)
-        pico_add_impl_library(pico_cyw43_arch)
+        pico_add_library(pico_cyw43_arch NOFLAG)
         target_sources(pico_cyw43_arch INTERFACE
                 ${CMAKE_CURRENT_LIST_DIR}/cyw43_arch.c
                 ${CMAKE_CURRENT_LIST_DIR}/cyw43_arch_poll.c
@@ -8,10 +8,10 @@ if (PICO_CYW43_SUPPORTED) # set by BOARD=pico-w
                 ${CMAKE_CURRENT_LIST_DIR}/cyw43_arch_freertos.c
                 )
 
-        target_include_directories(pico_cyw43_arch INTERFACE
+        target_include_directories(pico_cyw43_arch_headers INTERFACE
                 ${CMAKE_CURRENT_LIST_DIR}/include)
 
-        target_link_libraries(pico_cyw43_arch INTERFACE
+        pico_mirrored_target_link_libraries(pico_cyw43_arch INTERFACE
                 pico_unique_id
                 cyw43_driver_picow # driver for pico w
                 pico_cyw43_driver # integration with async_context
@@ -21,51 +21,51 @@ if (PICO_CYW43_SUPPORTED) # set by BOARD=pico-w
             message(WARNING "lwIP is not available; Full Pico W wireless support will be unavailable")
         else()
             message("Pico W wireless build support available.")
-            add_library(pico_cyw43_arch_poll INTERFACE)
-            target_link_libraries(pico_cyw43_arch_poll INTERFACE
-                    pico_cyw43_arch
-                    pico_async_context_poll)
-            target_compile_definitions(pico_cyw43_arch_poll INTERFACE
+            pico_add_library(pico_cyw43_arch_poll NOFLAG)
+            target_compile_definitions(pico_cyw43_arch_poll_headers INTERFACE
                     PICO_CYW43_ARCH_POLL=1
                     )
+            pico_mirrored_target_link_libraries(pico_cyw43_arch_poll INTERFACE
+                    pico_cyw43_arch
+                    pico_async_context_poll)
 
-            add_library(pico_cyw43_arch_lwip_poll INTERFACE)
-            target_link_libraries(pico_cyw43_arch_lwip_poll INTERFACE
+            pico_add_library(pico_cyw43_arch_lwip_poll NOFLAG)
+            pico_mirrored_target_link_libraries(pico_cyw43_arch_lwip_poll INTERFACE
                     pico_lwip_nosys
                     pico_cyw43_arch_poll)
-            target_compile_definitions(pico_cyw43_arch_lwip_poll INTERFACE
+            target_compile_definitions(pico_cyw43_arch_lwip_poll_headers INTERFACE
                     CYW43_LWIP=1
                     )
 
-            add_library(pico_cyw43_arch_threadsafe_background INTERFACE)
-            target_link_libraries(pico_cyw43_arch_threadsafe_background INTERFACE
+            pico_add_library(pico_cyw43_arch_threadsafe_background NOFLAG)
+            pico_mirrored_target_link_libraries(pico_cyw43_arch_threadsafe_background INTERFACE
                     pico_cyw43_arch
                     pico_async_context_threadsafe_background)
-            target_compile_definitions(pico_cyw43_arch_threadsafe_background INTERFACE
+            target_compile_definitions(pico_cyw43_arch_threadsafe_background_headers INTERFACE
                     PICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1
                     )
-            add_library(pico_cyw43_arch_lwip_threadsafe_background INTERFACE)
 
-            target_link_libraries(pico_cyw43_arch_lwip_threadsafe_background INTERFACE
+            pico_add_library(pico_cyw43_arch_lwip_threadsafe_background NOFLAG)
+            pico_mirrored_target_link_libraries(pico_cyw43_arch_lwip_threadsafe_background INTERFACE
                     pico_lwip_nosys
                     pico_cyw43_arch_threadsafe_background)
-            target_compile_definitions(pico_cyw43_arch_lwip_threadsafe_background INTERFACE
+            target_compile_definitions(pico_cyw43_arch_lwip_threadsafe_background_headers INTERFACE
                     CYW43_LWIP=1
                     )
 
-            add_library(pico_cyw43_arch_sys_freertos INTERFACE)
-            target_link_libraries(pico_cyw43_arch_sys_freertos INTERFACE
+            pico_add_library(pico_cyw43_arch_sys_freertos NOFLAG)
+            pico_mirrored_target_link_libraries(pico_cyw43_arch_sys_freertos INTERFACE
                     pico_cyw43_arch
                     pico_async_context_freertos)
-            target_compile_definitions(pico_cyw43_arch_sys_freertos INTERFACE
+            target_compile_definitions(pico_cyw43_arch_sys_freertos_headers INTERFACE
                     PICO_CYW43_ARCH_FREERTOS=1
                     )
 
-            add_library(pico_cyw43_arch_lwip_sys_freertos INTERFACE)
-            target_link_libraries(pico_cyw43_arch_lwip_sys_freertos INTERFACE
+            pico_add_library(pico_cyw43_arch_lwip_sys_freertos NOFLAG)
+            pico_mirrored_target_link_libraries(pico_cyw43_arch_lwip_sys_freertos INTERFACE
                     pico_lwip_freertos
                     pico_cyw43_arch_sys_freertos)
-            target_compile_definitions(pico_cyw43_arch_lwip_sys_freertos INTERFACE
+            target_compile_definitions(pico_cyw43_arch_lwip_sys_freertos_headers INTERFACE
                     CYW43_LWIP=1
                     LWIP_PROVIDE_ERRNO=1
                     # now the default
@@ -73,11 +73,11 @@ if (PICO_CYW43_SUPPORTED) # set by BOARD=pico-w
                     )
         endif()
 
-        add_library(pico_cyw43_arch_none INTERFACE)
-        target_link_libraries(pico_cyw43_arch_none INTERFACE
+        pico_add_library(pico_cyw43_arch_none NOFLAG)
+        pico_mirrored_target_link_libraries(pico_cyw43_arch_none INTERFACE
                 pico_cyw43_arch
                 pico_async_context_threadsafe_background)
-        target_compile_definitions(pico_cyw43_arch_none INTERFACE
+        target_compile_definitions(pico_cyw43_arch_none_headers INTERFACE
                 CYW43_LWIP=0
                 PICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 # none still uses threadsafe_background to make gpio use easy
                 )

--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -21,24 +21,24 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
     pico_register_common_scope_var(PICO_CYW43_DRIVER_PATH)
 
     # base driver without our bus
-    add_library(cyw43_driver INTERFACE)
+    pico_add_library(cyw43_driver NOFLAG)
     target_sources(cyw43_driver INTERFACE
             ${PICO_CYW43_DRIVER_PATH}/src/cyw43_ll.c
             ${PICO_CYW43_DRIVER_PATH}/src/cyw43_stats.c
             ${PICO_CYW43_DRIVER_PATH}/src/cyw43_lwip.c
             ${PICO_CYW43_DRIVER_PATH}/src/cyw43_ctrl.c
             )
-    target_include_directories(cyw43_driver INTERFACE
+    target_include_directories(cyw43_driver_headers INTERFACE
             ${PICO_CYW43_DRIVER_PATH}/src
             ${PICO_CYW43_DRIVER_PATH}/firmware
             )
 
     # pico_cyw43_driver adds async_context integration to cyw43_driver
-    add_library(pico_cyw43_driver INTERFACE)
+    pico_add_library(pico_cyw43_driver NOFLAG)
     target_sources(pico_cyw43_driver INTERFACE
             cyw43_driver.c)
-    target_include_directories(pico_cyw43_driver INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-    target_link_libraries(pico_cyw43_driver INTERFACE cyw43_driver)
+    target_include_directories(pico_cyw43_driver_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    pico_mirrored_target_link_libraries(pico_cyw43_driver INTERFACE cyw43_driver)
 
     # Firmware stuff
     set(CYW43_FIRMWARE_BIN 43439A0-7.95.49.00.combined)
@@ -66,16 +66,16 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
             VERBATIM)
 
     # cyw43_driver_picow is cyw43_driver plus Pico W specific bus implementation, and Pico W firmware
-    add_library(cyw43_driver_picow INTERFACE)
+    pico_add_library(cyw43_driver_picow NOFLAG)
     target_sources(cyw43_driver_picow INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/cyw43_bus_pio_spi.c
             )
-    pico_generate_pio_header(cyw43_driver_picow ${CMAKE_CURRENT_LIST_DIR}/cyw43_bus_pio_spi.pio)
+    pico_generate_pio_header(cyw43_driver_picow_headers ${CMAKE_CURRENT_LIST_DIR}/cyw43_bus_pio_spi.pio)
     add_dependencies(cyw43_driver_picow INTERFACE cyw43_firmware_package)
     target_link_libraries(cyw43_driver_picow INTERFACE
             ${CYW43_FIRMWARE_OBJ}
             )
-    target_link_libraries(cyw43_driver_picow INTERFACE
+    pico_mirrored_target_link_libraries(cyw43_driver_picow INTERFACE
             cyw43_driver
             hardware_pio
             hardware_dma

--- a/src/rp2_common/pico_divider/CMakeLists.txt
+++ b/src/rp2_common/pico_divider/CMakeLists.txt
@@ -3,7 +3,7 @@ if (NOT TARGET pico_divider)
     pico_add_impl_library(pico_divider)
 
     # no custom implementation; falls thru to compiler
-    pico_add_impl_library(pico_divider_compiler)
+    add_library(pico_divider_compiler INTERFACE)
 
     # add alias "default" which is just hardware.
     add_library(pico_divider_default INTERFACE)
@@ -25,7 +25,7 @@ if (NOT TARGET pico_divider)
             hardware_regs
             )
 
-    pico_add_impl_library(pico_divider_hardware)
+    add_library(pico_divider_hardware INTERFACE)
 
     target_link_libraries(pico_divider_hardware INTERFACE pico_divider_hardware_explicit)
 

--- a/src/rp2_common/pico_double/CMakeLists.txt
+++ b/src/rp2_common/pico_double/CMakeLists.txt
@@ -1,11 +1,10 @@
 if (NOT TARGET pico_double)
     # library to be depended on - we make this depend on particular implementations using per target generator expressions
-    pico_add_impl_library(pico_double)
+    pico_add_library(pico_double)
 
     # no custom implementation; falls thru to compiler
-    pico_add_impl_library(pico_double_compiler)
+    pico_add_library(pico_double_compiler)
 
-    add_library(pico_double_headers INTERFACE)
     target_include_directories(pico_double_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     # add alias "default" which is just pico.
@@ -17,7 +16,7 @@ if (NOT TARGET pico_double)
     target_link_libraries(pico_double INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_DOUBLE_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_DOUBLE_IMPL>,${PICO_DEFAULT_DOUBLE_IMPL}>)
 
-    pico_add_impl_library(pico_double_pico)
+    pico_add_library(pico_double_pico)
     target_sources(pico_double_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/double_aeabi.S
             ${CMAKE_CURRENT_LIST_DIR}/double_init_rom.c
@@ -25,16 +24,16 @@ if (NOT TARGET pico_double)
             ${CMAKE_CURRENT_LIST_DIR}/double_v1_rom_shim.S
     )
 
-    target_link_libraries(pico_double_pico INTERFACE pico_bootrom pico_double_headers)
+    target_link_libraries(pico_double_pico INTERFACE pico_bootrom pico_double_headers hardware_divider)
 
-    pico_add_impl_library(pico_double_none)
+    pico_add_library(pico_double_none)
     target_sources(pico_double_none INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/double_none.S
             )
 
     target_link_libraries(pico_double_none INTERFACE pico_double_headers)
 
-    target_compile_definitions(pico_double_none INTERFACE
+    target_compile_definitions(pico_double_none_headers INTERFACE
             PICO_PRINTF_SUPPORT_FLOAT=0 # printing floats/doubles won't work, so we can save space by removing it
     )
 

--- a/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/CMakeLists.txt
+++ b/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/CMakeLists.txt
@@ -1,9 +1,9 @@
-pico_add_impl_library(pico_fix_rp2040_usb_device_enumeration)
+pico_add_library(pico_fix_rp2040_usb_device_enumeration NOFLAG)
 
 target_sources(pico_fix_rp2040_usb_device_enumeration INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/rp2040_usb_device_enumeration.c
         )
 
-target_include_directories(pico_fix_rp2040_usb_device_enumeration INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(pico_fix_rp2040_usb_device_enumeration_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(pico_fix_rp2040_usb_device_enumeration INTERFACE hardware_structs pico_time)
+pico_mirrored_target_link_libraries(pico_fix_rp2040_usb_device_enumeration INTERFACE hardware_structs hardware_gpio pico_time)

--- a/src/rp2_common/pico_float/CMakeLists.txt
+++ b/src/rp2_common/pico_float/CMakeLists.txt
@@ -1,11 +1,10 @@
 if (NOT TARGET pico_float)
     # library to be depended on - we make this depend on particular implementations using per target generator expressions
-    pico_add_impl_library(pico_float)
+    pico_add_library(pico_float NOFLAG)
 
     # no custom implementation; falls thru to compiler
-    pico_add_impl_library(pico_float_compiler)
+    pico_add_library(pico_float_compiler)
 
-    add_library(pico_float_headers INTERFACE)
     target_include_directories(pico_float_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     # add alias "default" which is just rom.
@@ -17,7 +16,7 @@ if (NOT TARGET pico_float)
     target_link_libraries(pico_float INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_FLOAT_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_FLOAT_IMPL>,${PICO_DEFAULT_FLOAT_IMPL}>)
 
-    pico_add_impl_library(pico_float_pico)
+    pico_add_library(pico_float_pico)
     target_sources(pico_float_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/float_aeabi.S
             ${CMAKE_CURRENT_LIST_DIR}/float_init_rom.c
@@ -25,9 +24,9 @@ if (NOT TARGET pico_float)
             ${CMAKE_CURRENT_LIST_DIR}/float_v1_rom_shim.S
     )
 
-    target_link_libraries(pico_float_pico INTERFACE pico_bootrom pico_float_headers)
+    target_link_libraries(pico_float_pico INTERFACE pico_bootrom pico_float_headers hardware_divider)
 
-    pico_add_impl_library(pico_float_none)
+    pico_add_library(pico_float_none)
     target_sources(pico_float_none INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/float_none.S
             )

--- a/src/rp2_common/pico_int64_ops/CMakeLists.txt
+++ b/src/rp2_common/pico_int64_ops/CMakeLists.txt
@@ -1,10 +1,10 @@
 if (NOT TARGET pico_int64_ops)
 
     #shims for ROM functions for -lgcc functions  (listed below)
-    pico_add_impl_library(pico_int64_ops)
+    pico_add_library(pico_int64_ops NOFLAG)
 
     # no custom implementation; falls thru to compiler
-    pico_add_impl_library(pico_int64_ops_compiler)
+    pico_add_library(pico_int64_ops_compiler)
 
     # add alias "default" which is just pico.
     add_library(pico_int64_ops_default INTERFACE)
@@ -15,8 +15,9 @@ if (NOT TARGET pico_int64_ops)
     target_link_libraries(pico_int64_ops INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_INT64_OPS_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_INT64_OPS_IMPL>,${PICO_DEFAULT_INT64_OPS_IMPL}>)
 
-    pico_add_impl_library(pico_int64_ops_pico)
+    pico_add_library(pico_int64_ops_pico)
     target_include_directories(pico_int64_ops_pico INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    pico_mirrored_target_link_libraries(pico_int64_ops_pico INTERFACE pico_base)
 
     target_sources(pico_int64_ops_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/pico_int64_ops_aeabi.S

--- a/src/rp2_common/pico_lwip/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/CMakeLists.txt
@@ -24,7 +24,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
     pico_register_common_scope_var(PICO_LWIP_PATH)
 
     # The minimum set of files needed for lwIP.
-    add_library(pico_lwip_core INTERFACE)
+    pico_add_library(pico_lwip_core NOFLAG)
     target_sources(pico_lwip_core INTERFACE
             ${PICO_LWIP_PATH}/src/core/init.c
             ${PICO_LWIP_PATH}/src/core/def.c
@@ -47,10 +47,10 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             ${PICO_LWIP_PATH}/src/core/timeouts.c
             ${PICO_LWIP_PATH}/src/core/udp.c
             )
-    target_include_directories(pico_lwip_core INTERFACE
+    target_include_directories(pico_lwip_core_headers INTERFACE
             ${PICO_LWIP_PATH}/src/include)
 
-    add_library(pico_lwip_core4 INTERFACE)
+    pico_add_library(pico_lwip_core4 NOFLAG)
     target_sources(pico_lwip_core4 INTERFACE
             ${PICO_LWIP_PATH}/src/core/ipv4/autoip.c
             ${PICO_LWIP_PATH}/src/core/ipv4/dhcp.c
@@ -69,7 +69,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
     endif()
 
-    add_library(pico_lwip_core6 INTERFACE)
+    pico_add_library(pico_lwip_core6 NOFLAG)
     target_sources(pico_lwip_core6 INTERFACE
             ${PICO_LWIP_PATH}/src/core/ipv6/dhcp6.c
             ${PICO_LWIP_PATH}/src/core/ipv6/ethip6.c
@@ -83,7 +83,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # APIFILES: The files which implement the sequential and socket APIs.
-    add_library(pico_lwip_api INTERFACE)
+    pico_add_library(pico_lwip_api NOFLAG)
     target_sources(pico_lwip_api INTERFACE
             ${PICO_LWIP_PATH}/src/api/api_lib.c
             ${PICO_LWIP_PATH}/src/api/api_msg.c
@@ -97,7 +97,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # Files implementing various generic network interface functions
-    add_library(pico_lwip_netif INTERFACE)
+    pico_add_library(pico_lwip_netif NOFLAG)
     target_sources(pico_lwip_netif INTERFACE
             ${PICO_LWIP_PATH}/src/netif/ethernet.c
             ${PICO_LWIP_PATH}/src/netif/bridgeif.c
@@ -106,7 +106,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # 6LoWPAN
-    add_library(pico_lwip_sixlowpan INTERFACE)
+    pico_add_library(pico_lwip_sixlowpan NOFLAG)
     target_sources(pico_lwip_sixlowpan INTERFACE
             ${PICO_LWIP_PATH}/src/netif/lowpan6_common.c
             ${PICO_LWIP_PATH}/src/netif/lowpan6.c
@@ -115,7 +115,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # PPP
-    add_library(pico_lwip_ppp INTERFACE)
+    pico_add_library(pico_lwip_ppp NOFLAG)
     target_sources(pico_lwip_ppp INTERFACE
             ${PICO_LWIP_PATH}/src/netif/ppp/auth.c
             ${PICO_LWIP_PATH}/src/netif/ppp/ccp.c
@@ -150,7 +150,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # SNMPv3 agent
-    add_library(pico_lwip_snmp INTERFACE)
+    pico_add_library(pico_lwip_snmp NOFLAG)
     target_sources(pico_lwip_snmp INTERFACE
             ${PICO_LWIP_PATH}/src/apps/snmp/snmp_asn1.c
             ${PICO_LWIP_PATH}/src/apps/snmp/snmp_core.c
@@ -176,7 +176,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # HTTP server + client
-    add_library(pico_lwip_http INTERFACE)
+    pico_add_library(pico_lwip_http NOFLAG)
     target_sources(pico_lwip_http INTERFACE
             ${PICO_LWIP_PATH}/src/apps/http/altcp_proxyconnect.c
             ${PICO_LWIP_PATH}/src/apps/http/fs.c
@@ -185,31 +185,31 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # MAKEFSDATA HTTP server host utility
-    add_library(pico_lwip_makefsdata INTERFACE)
+    pico_add_library(pico_lwip_makefsdata NOFLAG)
     target_sources(pico_lwip_makefsdata INTERFACE
             ${PICO_LWIP_PATH}/src/apps/http/makefsdata/makefsdata.c
             )
 
     # iperf
-    add_library(pico_lwip_iperf INTERFACE)
+    pico_add_library(pico_lwip_iperf NOFLAG)
     target_sources(pico_lwip_iperf INTERFACE
             ${PICO_LWIP_PATH}/src/apps/lwiperf/lwiperf.c
             )
 
     # SMTP client
-    add_library(pico_lwip_smtp INTERFACE)
+    pico_add_library(pico_lwip_smtp NOFLAG)
     target_sources(pico_lwip_smtp INTERFACE
             ${PICO_LWIP_PATH}/src/apps/smtp/smtp.c
             )
 
     # SNTP client
-    add_library(pico_lwip_sntp INTERFACE)
+    pico_add_library(pico_lwip_sntp NOFLAG)
     target_sources(pico_lwip_sntp INTERFACE
             ${PICO_LWIP_PATH}/src/apps/sntp/sntp.c
             )
 
     # MDNS responder
-    add_library(pico_lwip_mdns INTERFACE)
+    pico_add_library(pico_lwip_mdns NOFLAG)
     target_sources(pico_lwip_mdns INTERFACE
             ${PICO_LWIP_PATH}/src/apps/mdns/mdns.c
             )
@@ -223,19 +223,19 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
     endif()
 
     # NetBIOS name server
-    add_library(pico_lwip_netbios INTERFACE)
+    pico_add_library(pico_lwip_netbios NOFLAG)
     target_sources(pico_lwip_netbios INTERFACE
             ${PICO_LWIP_PATH}/src/apps/netbiosns/netbiosns.c
             )
 
     # TFTP server files
-    add_library(pico_lwip_tftp INTERFACE)
+    pico_add_library(pico_lwip_tftp NOFLAG)
     target_sources(pico_lwip_tftp INTERFACE
             ${PICO_LWIP_PATH}/src/apps/tftp/tftp.c
             )
 
     # Mbed TLS files
-    add_library(pico_lwip_mbedtls INTERFACE)
+    pico_add_library(pico_lwip_mbedtls NOFLAG)
     target_sources(pico_lwip_mbedtls INTERFACE
             ${PICO_LWIP_PATH}/src/apps/altcp_tls/altcp_tls_mbedtls.c
             ${PICO_LWIP_PATH}/src/apps/altcp_tls/altcp_tls_mbedtls_mem.c
@@ -243,14 +243,14 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             )
 
     # MQTT client files
-    add_library(pico_lwip_mqtt INTERFACE)
+    pico_add_library(pico_lwip_mqtt NOFLAG)
     target_sources(pico_lwip_mqtt INTERFACE
             ${PICO_LWIP_PATH}/src/apps/mqtt/mqtt.c
             )
 
     # All LWIP files without apps
-    add_library(pico_lwip INTERFACE)
-    target_link_libraries(pico_lwip INTERFACE
+    pico_add_library(pico_lwip NOFLAG)
+    pico_mirrored_target_link_libraries(pico_lwip INTERFACE
         pico_lwip_core
         pico_lwip_core4
         pico_lwip_core6
@@ -261,16 +261,16 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
     )
 
     # our arch/cc.h
-    add_library(pico_lwip_arch INTERFACE)
-    target_include_directories(pico_lwip_arch INTERFACE
+    pico_add_library(pico_lwip_arch NOFLAG)
+    target_include_directories(pico_lwip_arch_headers INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/include)
 
     # our nosys impl
-    add_library(pico_lwip_nosys INTERFACE)
+    pico_add_library(pico_lwip_nosys NOFLAG)
     target_sources(pico_lwip_nosys INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/lwip_nosys.c
             )
-    target_link_libraries(pico_lwip_nosys INTERFACE
+    pico_mirrored_target_link_libraries(pico_lwip_nosys INTERFACE
             pico_async_context_base
             pico_lwip_arch
             pico_lwip
@@ -282,21 +282,21 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
     pico_register_common_scope_var(PICO_LWIP_CONTRIB_PATH)
 
     # Make lwip_contrib_freertos library, with the FreeRTOS/lwIP code from lwip-contrib
-    add_library(pico_lwip_contrib_freertos INTERFACE)
+    pico_add_library(pico_lwip_contrib_freertos NOFLAG)
     target_sources(pico_lwip_contrib_freertos INTERFACE
             ${PICO_LWIP_CONTRIB_PATH}/ports/freertos/sys_arch.c
             )
-    target_include_directories(pico_lwip_contrib_freertos INTERFACE
+    target_include_directories(pico_lwip_contrib_freertos_headers INTERFACE
             ${PICO_LWIP_CONTRIB_PATH}/ports/freertos/include
             )
-    target_link_libraries(pico_lwip_contrib_freertos INTERFACE
+    pico_mirrored_target_link_libraries(pico_lwip_contrib_freertos INTERFACE
             pico_lwip_arch)
 
-    add_library(pico_lwip_freertos INTERFACE)
+    pico_add_library(pico_lwip_freertos NOFLAG)
     target_sources(pico_lwip_freertos INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/lwip_freertos.c
             )
-    target_link_libraries(pico_lwip_freertos INTERFACE
+    pico_mirrored_target_link_libraries(pico_lwip_freertos INTERFACE
             pico_async_context_base
             pico_lwip
             pico_lwip_contrib_freertos

--- a/src/rp2_common/pico_malloc/CMakeLists.txt
+++ b/src/rp2_common/pico_malloc/CMakeLists.txt
@@ -1,12 +1,12 @@
 if (NOT TARGET pico_malloc)
     #shims for ROM functions for -lgcc functions  (listed below)
-    pico_add_impl_library(pico_malloc)
+    pico_add_library(pico_malloc NOFLAG)
 
     target_sources(pico_malloc INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/pico_malloc.c
             )
 
-    target_include_directories(pico_malloc INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    target_include_directories(pico_malloc_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     pico_wrap_function(pico_malloc malloc)
     pico_wrap_function(pico_malloc calloc)

--- a/src/rp2_common/pico_mbedtls/CMakeLists.txt
+++ b/src/rp2_common/pico_mbedtls/CMakeLists.txt
@@ -94,7 +94,7 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
         xtea.c
     )
     list(TRANSFORM src_crypto PREPEND ${PICO_MBEDTLS_PATH}/library/)
-    add_library(pico_mbedtls_crypto INTERFACE)
+    pico_add_library(pico_mbedtls_crypto NOFLAG)
     target_sources(pico_mbedtls_crypto INTERFACE ${src_crypto})
 
     set(src_x509
@@ -109,7 +109,7 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
         x509write_csr.c
     )
     list(TRANSFORM src_x509 PREPEND ${PICO_MBEDTLS_PATH}/library/)
-    add_library(pico_mbedtls_x509 INTERFACE)
+    pico_add_library(pico_mbedtls_x509 NOFLAG)
     target_sources(pico_mbedtls_x509 INTERFACE ${src_x509})
 
     set(src_tls
@@ -126,18 +126,18 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
         ssl_tls13_keys.c
     )
     list(TRANSFORM src_tls PREPEND ${PICO_MBEDTLS_PATH}/library/)
-    add_library(pico_mbedtls_tls INTERFACE)
+    pico_add_library(pico_mbedtls_tls NOFLAG)
     target_sources(pico_mbedtls_tls INTERFACE ${src_tls})
 
-    pico_add_impl_library(pico_mbedtls)
-    target_link_libraries(pico_mbedtls INTERFACE pico_mbedtls_crypto pico_mbedtls_x509 pico_mbedtls_tls pico_rand)
+    pico_add_library(pico_mbedtls NOFLAG)
+    pico_mirrored_target_link_libraries(pico_mbedtls INTERFACE pico_mbedtls_crypto pico_mbedtls_x509 pico_mbedtls_tls pico_rand)
     if (DEFINED PICO_MBEDTLS_CONFIG_FILE)
-        target_compile_definitions(pico_mbedtls INTERFACE MBEDTLS_CONFIG_FILE="${PICO_MBEDTLS_CONFIG_FILE}")
+        target_compile_definitions(pico_mbedtls_headers INTERFACE MBEDTLS_CONFIG_FILE="${PICO_MBEDTLS_CONFIG_FILE}")
     else()
-        target_compile_definitions(pico_mbedtls INTERFACE MBEDTLS_CONFIG_FILE="mbedtls_config.h")
+        target_compile_definitions(pico_mbedtls_headers INTERFACE MBEDTLS_CONFIG_FILE="mbedtls_config.h")
     endif()
     target_sources(pico_mbedtls INTERFACE ${CMAKE_CURRENT_LIST_DIR}/pico_mbedtls.c)
-    target_include_directories(pico_mbedtls INTERFACE ${PICO_MBEDTLS_PATH}/include/ ${PICO_MBEDTLS_PATH}/library/)
+    target_include_directories(pico_mbedtls_headers INTERFACE ${PICO_MBEDTLS_PATH}/include/ ${PICO_MBEDTLS_PATH}/library/)
 
     function(suppress_mbedtls_warnings)
         set_source_files_properties(

--- a/src/rp2_common/pico_mem_ops/CMakeLists.txt
+++ b/src/rp2_common/pico_mem_ops/CMakeLists.txt
@@ -1,9 +1,9 @@
 if (NOT TARGET pico_mem_ops)
     #shims for ROM functions for -lgcc functions  (listed below)
-    pico_add_impl_library(pico_mem_ops)
+    pico_add_library(pico_mem_ops)
 
     # no custom implementation; falls thru to compiler
-    pico_add_impl_library(pico_mem_ops_compiler)
+    add_library(pico_mem_ops_compiler INTERFACE)
 
     # add alias "default" which is just pico.
     add_library(pico_mem_ops_default INTERFACE)
@@ -11,14 +11,15 @@ if (NOT TARGET pico_mem_ops)
 
     set(PICO_DEFAULT_MEM_OPS_IMPL pico_mem_ops_default)
 
-    pico_add_impl_library(pico_mem_ops_pico)
+    pico_add_library(pico_mem_ops_pico)
     target_link_libraries(pico_mem_ops INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_MEM_OPS_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_MEM_OPS_IMPL>,${PICO_DEFAULT_MEM_OPS_IMPL}>)
 
     target_sources(pico_mem_ops_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/mem_ops_aeabi.S
             )
-
+    target_include_directories(pico_mem_ops_pico_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    pico_mirrored_target_link_libraries(pico_mem_ops_pico INTERFACE pico_base)
 
     target_link_libraries(pico_mem_ops INTERFACE pico_bootrom)
 

--- a/src/rp2_common/pico_multicore/CMakeLists.txt
+++ b/src/rp2_common/pico_multicore/CMakeLists.txt
@@ -1,12 +1,13 @@
 if (NOT TARGET pico_multicore)
-    pico_add_impl_library(pico_multicore)
+    pico_add_library(pico_multicore)
+    target_include_directories(pico_multicore_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     target_sources(pico_multicore INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/multicore.c)
 
-    target_include_directories(pico_multicore INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-
-    target_link_libraries(pico_multicore INTERFACE pico_sync hardware_irq)
+    pico_mirrored_target_link_libraries(pico_multicore INTERFACE
+            pico_sync
+            hardware_irq)
 endif()
 
 

--- a/src/rp2_common/pico_printf/CMakeLists.txt
+++ b/src/rp2_common/pico_printf/CMakeLists.txt
@@ -1,11 +1,10 @@
 if (NOT TARGET pico_printf)
     # library to be depended on - we make this depend on particular implementations using per target generator expressions
-    pico_add_impl_library(pico_printf)
+    pico_add_library(pico_printf NOFLAG)
 
     # no custom implementation; falls thru to compiler
-    pico_add_impl_library(pico_printf_compiler)
+    pico_add_library(pico_printf_compiler)
 
-    add_library(pico_printf_headers INTERFACE)
     target_include_directories(pico_printf_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     # add alias "default" which is just pico.
@@ -17,18 +16,16 @@ if (NOT TARGET pico_printf)
     target_link_libraries(pico_printf INTERFACE
             $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_PRINTF_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_PRINTF_IMPL>,${PICO_DEFAULT_PRINTF_IMPL}>)
 
-    pico_add_impl_library(pico_printf_pico)
+    pico_add_library(pico_printf_pico)
     target_sources(pico_printf_pico INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/printf.c
     )
-
     target_link_libraries(pico_printf_pico INTERFACE pico_printf_headers)
 
-    pico_add_impl_library(pico_printf_none)
+    pico_add_library(pico_printf_none)
     target_sources(pico_printf_none INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/printf_none.S
     )
-
     target_link_libraries(pico_printf_none INTERFACE pico_printf_headers)
 
     function(wrap_printf_functions TARGET)

--- a/src/rp2_common/pico_rand/CMakeLists.txt
+++ b/src/rp2_common/pico_rand/CMakeLists.txt
@@ -1,12 +1,12 @@
-pico_add_impl_library(pico_rand)
+pico_add_library(pico_rand)
 
 target_sources(pico_rand INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/rand.c
 )
 
-target_include_directories(pico_rand INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(pico_rand_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(pico_rand INTERFACE
+pico_mirrored_target_link_libraries(pico_rand INTERFACE
         pico_unique_id
         hardware_clocks
         hardware_timer

--- a/src/rp2_common/pico_runtime/CMakeLists.txt
+++ b/src/rp2_common/pico_runtime/CMakeLists.txt
@@ -1,12 +1,12 @@
-pico_add_impl_library(pico_runtime)
+pico_add_library(pico_runtime NOFLAG)
 
 target_sources(pico_runtime INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/runtime.c
 )
 
-target_include_directories(pico_runtime INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(pico_runtime_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(pico_runtime INTERFACE
+pico_mirrored_target_link_libraries(pico_runtime INTERFACE
         hardware_uart
         hardware_clocks
         hardware_irq
@@ -15,28 +15,28 @@ target_link_libraries(pico_runtime INTERFACE
         )
 
 if (TARGET pico_bit_ops)
-    target_link_libraries(pico_runtime INTERFACE pico_bit_ops)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_bit_ops)
 endif()
 if (TARGET pico_divider)
-    target_link_libraries(pico_runtime INTERFACE pico_divider)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_divider)
 endif()
 if (TARGET pico_double)
-    target_link_libraries(pico_runtime INTERFACE pico_double)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_double)
 endif()
 if (TARGET pico_int64_ops)
-    target_link_libraries(pico_runtime INTERFACE pico_int64_ops)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_int64_ops)
 endif()
 if (TARGET pico_float)
-    target_link_libraries(pico_runtime INTERFACE pico_float)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_float)
 endif()
 if (TARGET pico_malloc)
-    target_link_libraries(pico_runtime INTERFACE pico_malloc)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_malloc)
 endif()
 if (TARGET pico_mem_ops)
-    target_link_libraries(pico_runtime INTERFACE pico_mem_ops)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_mem_ops)
 endif()
 if (TARGET pico_standard_link)
-    target_link_libraries(pico_runtime INTERFACE pico_standard_link)
+    pico_mirrored_target_link_libraries(pico_runtime INTERFACE pico_standard_link)
 endif()
 
 # todo is this correct/needed?

--- a/src/rp2_common/pico_standard_link/CMakeLists.txt
+++ b/src/rp2_common/pico_standard_link/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT TARGET pico_standard_link)
-    pico_add_impl_library(pico_standard_link)
+    pico_add_library(pico_standard_link NOFLAG)
 
     target_sources(pico_standard_link INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/crt0.S
@@ -14,7 +14,8 @@ if (NOT TARGET pico_standard_link)
         target_link_options(pico_standard_link INTERFACE "LINKER:-nostdlib")
     endif ()
 
-    target_link_libraries(pico_standard_link INTERFACE hardware_regs boot_stage2_headers pico_bootrom pico_binary_info pico_cxx_options)
+    pico_mirrored_target_link_libraries(pico_standard_link INTERFACE hardware_regs pico_bootrom pico_binary_info)
+    target_link_libraries(pico_standard_link INTERFACE pico_cxx_options  boot_stage2_headers)
 
     function(pico_add_link_depend TARGET dependency)
         get_target_property(target_type ${TARGET} TYPE)

--- a/src/rp2_common/pico_stdio/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (NOT TARGET pico_stdio)
-    pico_add_impl_library(pico_stdio)
+    pico_add_library(pico_stdio NOFLAG)
 
-    target_include_directories(pico_stdio INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    target_include_directories(pico_stdio_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     target_sources(pico_stdio INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/stdio.c
@@ -14,6 +14,6 @@ if (NOT TARGET pico_stdio)
     pico_wrap_function(pico_stdio getchar)
 
     if (TARGET pico_printf)
-        target_link_libraries(pico_stdio INTERFACE pico_printf)
+        pico_mirrored_target_link_libraries(pico_stdio INTERFACE pico_printf)
     endif()
 endif()

--- a/src/rp2_common/pico_stdio_semihosting/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio_semihosting/CMakeLists.txt
@@ -1,9 +1,9 @@
-pico_add_impl_library(pico_stdio_semihosting)
+pico_add_library(pico_stdio_semihosting)
 
 target_sources(pico_stdio_semihosting INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/stdio_semihosting.c
 )
 
-target_include_directories(pico_stdio_semihosting INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(pico_stdio_semihosting_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(pico_stdio_semihosting INTERFACE pico_stdio)
+pico_mirrored_target_link_libraries(pico_stdio_semihosting INTERFACE pico_stdio)

--- a/src/rp2_common/pico_stdio_uart/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio_uart/CMakeLists.txt
@@ -1,9 +1,9 @@
-pico_add_impl_library(pico_stdio_uart)
+pico_add_library(pico_stdio_uart)
 
 target_sources(pico_stdio_uart INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/stdio_uart.c
 )
 
-target_include_directories(pico_stdio_uart INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(pico_stdio_uart_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(pico_stdio_uart INTERFACE pico_stdio)
+pico_mirrored_target_link_libraries(pico_stdio_uart INTERFACE pico_stdio)

--- a/src/rp2_common/pico_stdio_usb/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio_usb/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (TARGET tinyusb_device_unmarked)
-    pico_add_impl_library(pico_stdio_usb)
+    pico_add_library(pico_stdio_usb)
 
-    target_include_directories(pico_stdio_usb INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+    target_include_directories(pico_stdio_usb_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
     target_sources(pico_stdio_usb INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/reset_interface.c
@@ -9,11 +9,13 @@ if (TARGET tinyusb_device_unmarked)
         ${CMAKE_CURRENT_LIST_DIR}/stdio_usb_descriptors.c
     )
 
-    target_link_libraries(pico_stdio_usb INTERFACE
-        tinyusb_device_unmarked
+    pico_mirrored_target_link_libraries(pico_stdio_usb INTERFACE
         pico_stdio
         pico_time
         pico_unique_id
-        pico_usb_reset_interface_headers
+        pico_usb_reset_interface
+    )
+    target_link_libraries(pico_stdio_usb INTERFACE
+        tinyusb_device_unmarked
     )
 endif()

--- a/src/rp2_common/pico_stdlib/CMakeLists.txt
+++ b/src/rp2_common/pico_stdlib/CMakeLists.txt
@@ -6,16 +6,19 @@ option(PICO_STDIO_USB "Globablly enable stdio USB" 0)
 option(PICO_STDIO_SEMIHOSTING "Globablly enable stdio semihosting" 0)
 
 if (NOT TARGET pico_stdlib)
-    pico_add_impl_library(pico_stdlib)
+    pico_add_impl_library(pico_stdlib NOFLAG)
     target_sources(pico_stdlib INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/stdlib.c
     )
-    target_link_libraries(pico_stdlib INTERFACE
-        pico_stdlib_headers
-        pico_platform
-        pico_runtime
-        pico_stdio
-        pico_time
+    pico_mirrored_target_link_libraries(pico_stdlib INTERFACE
+            hardware_gpio
+            hardware_uart
+            hardware_divider
+            pico_time
+            pico_util
+            pico_platform
+            pico_runtime
+            pico_stdio
     )
 
     function(pico_enable_stdio_uart TARGET ENABLED)
@@ -32,14 +35,17 @@ if (NOT TARGET pico_stdlib)
 
     if (TARGET pico_stdio_uart)
         target_link_libraries(pico_stdlib INTERFACE $<IF:$<BOOL:$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_STDIO_UART>,>,${PICO_STDIO_UART},$<TARGET_PROPERTY:PICO_TARGET_STDIO_UART>>>,pico_stdio_uart,>)
+        target_link_libraries(pico_stdlib_headers INTERFACE $<IF:$<BOOL:$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_STDIO_UART>,>,${PICO_STDIO_UART},$<TARGET_PROPERTY:PICO_TARGET_STDIO_UART>>>,pico_stdio_uart_headers,>)
     endif()
 
     if (TARGET pico_stdio_usb)
         target_link_libraries(pico_stdlib INTERFACE $<IF:$<BOOL:$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_STDIO_USB>,>,${PICO_STDIO_USB},$<TARGET_PROPERTY:PICO_TARGET_STDIO_USB>>>,pico_stdio_usb,>)
+        target_link_libraries(pico_stdlib_headers INTERFACE $<IF:$<BOOL:$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_STDIO_USB>,>,${PICO_STDIO_USB},$<TARGET_PROPERTY:PICO_TARGET_STDIO_USB>>>,pico_stdio_usb_headers,>)
     endif()
 
     if (TARGET pico_stdio_semihosting)
         target_link_libraries(pico_stdlib INTERFACE $<IF:$<BOOL:$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_STDIO_SEMIHOSTING>,>,${PICO_STDIO_SEMIHOSTING},$<TARGET_PROPERTY:PICO_TARGET_STDIO_SEMIHOSTING>>>,pico_stdio_semihosting,>)
+        target_link_libraries(pico_stdlib_headers INTERFACE $<IF:$<BOOL:$<IF:$<STREQUAL:$<TARGET_PROPERTY:PICO_TARGET_STDIO_SEMIHOSTING>,>,${PICO_STDIO_SEMIHOSTING},$<TARGET_PROPERTY:PICO_TARGET_STDIO_SEMIHOSTING>>>,pico_stdio_semihosting_headers,>)
     endif()
 
 endif()

--- a/src/rp2_common/pico_unique_id/CMakeLists.txt
+++ b/src/rp2_common/pico_unique_id/CMakeLists.txt
@@ -1,9 +1,9 @@
-pico_add_impl_library(pico_unique_id)
+pico_add_library(pico_unique_id NOFLAG)
 
 target_sources(pico_unique_id INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/unique_id.c
 )
 
-target_include_directories(pico_unique_id INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(pico_unique_id_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(pico_unique_id INTERFACE hardware_flash)
+pico_mirrored_target_link_libraries(pico_unique_id INTERFACE hardware_flash)

--- a/src/rp2_common/tinyusb/CMakeLists.txt
+++ b/src/rp2_common/tinyusb/CMakeLists.txt
@@ -37,13 +37,13 @@ if (EXISTS ${PICO_TINYUSB_PATH}/${TINYUSB_TEST_PATH})
     # unmarked version used by stdio USB
     target_link_libraries(tinyusb_device_unmarked INTERFACE tinyusb_common pico_fix_rp2040_usb_device_enumeration tinyusb_device_base)
 
-    pico_add_impl_library(tinyusb_device)
+    pico_add_library(tinyusb_device)
     target_link_libraries(tinyusb_device INTERFACE tinyusb_device_unmarked)
 
-    pico_add_impl_library(tinyusb_host)
+    pico_add_library(tinyusb_host)
     target_link_libraries(tinyusb_host INTERFACE tinyusb_host_base tinyusb_common)
 
-    pico_add_impl_library(tinyusb_board)
+    pico_add_library(tinyusb_board)
     target_link_libraries(tinyusb_board INTERFACE tinyusb_bsp)
 
     # Override suppress_tinyusb_warnings to add suppression of (falsely) reported GCC 11.2 warnings


### PR DESCRIPTION
Rework build targets such that:

1. Pico SDK libraries now have the correct dependencies on other SDK libraries
2. Pico SDK libraries all have _headers variants to include the just headers. This may facilitate building user STATIC libraries without pulling in SDK code, though care will still need to be taken w.r.t. values of #defines
3. Make sure the _headers versions also have the correct dependencies

Note: There are a few exceptions to 1. for some non code libraries like pico_standard_link and pico_cxx_options