### PR TITLE
Allow external pico-sdk-tools package

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,12 @@
 function(_pico_init_pioasm)
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PICO_SDK_PATH}/tools)
-    # todo CMAKE_CURRENT_FUNCTION_LIST_DIR ... what version?
-    find_package(Pioasm REQUIRED)
+    # Assemble the version string from components instead of using PICO_SDK_VERSION_STRING, because the version string
+    # potentially has a PRE_RELEASE_ID suffix, which will trip up the find_package call.
+    find_package(pico-sdk-tools "${PICO_SDK_VERSION_MAJOR}.${PICO_SDK_VERSION_MINOR}.${PICO_SDK_VERSION_REVISION}" QUIET CONFIG CMAKE_FIND_ROOT_PATH_BOTH)
+    if (NOT Pioasm_FOUND)
+        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PICO_SDK_PATH}/tools)
+        # todo CMAKE_CURRENT_FUNCTION_LIST_DIR ... what version?
+        find_package(Pioasm REQUIRED)
+    endif()
 endfunction()
 
 # PICO_CMAKE_CONFIG: PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, default output format used by pioasm when using pico_generate_pio_header, default=c-sdk, group=build
@@ -53,6 +58,7 @@ function(pico_add_uf2_output TARGET)
     else()
         set(output_path "")
     endif()
+    find_package(pico-sdk-tools "${PICO_SDK_VERSION_MAJOR}.${PICO_SDK_VERSION_MINOR}.${PICO_SDK_VERSION_REVISION}" QUIET CONFIG CMAKE_FIND_ROOT_PATH_BOTH)
     if (NOT ELF2UF2_FOUND)
         set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PICO_SDK_PATH}/tools)
         find_package(ELF2UF2)


### PR DESCRIPTION
This allows us to create a package named `pico-sdk-tools` somewhere in the CMake search path, and have that package provide pre-compiled binaries for pioasm and elf2uf2. This is useful, especially on Windows, where a native compiler might not be available.