### PR TITLE
revert use of pico_add_library in pcio_usb_reset_interface which is used by picotool and included directly as _headers library by SDK anyway

### DIFF
--- a/src/common/pico_usb_reset_interface/CMakeLists.txt
+++ b/src/common/pico_usb_reset_interface/CMakeLists.txt
@@ -1,2 +1,6 @@
+# don't use pico_add_library here as picotool includes it directly
 add_library(pico_usb_reset_interface_headers INTERFACE)
+add_library(pico_usb_reset_interface INTERFACE)
+target_link_libraries(pico_usb_reset_interface INTERFACE pico_usb_reset_interface_headers)
+
 target_include_directories(pico_usb_reset_interface_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)

--- a/src/common/pico_usb_reset_interface/CMakeLists.txt
+++ b/src/common/pico_usb_reset_interface/CMakeLists.txt
@@ -1,2 +1,2 @@
-pico_add_library(pico_usb_reset_interface NOFLAG)
+add_library(pico_usb_reset_interface_headers INTERFACE)
 target_include_directories(pico_usb_reset_interface_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)


### PR DESCRIPTION
this makes SDK backwards compatible with picotool build