### PR TITLE
Fix typos in the PICO_CONFIG settings

### DIFF
--- a/src/rp2_common/pico_btstack/include/pico/btstack_flash_bank.h
+++ b/src/rp2_common/pico_btstack/include/pico/btstack_flash_bank.h
@@ -14,12 +14,12 @@
 extern "C" {
 #endif
 
-// PICO_CONFIG: PICO_FLASH_BANK_TOTAL_SIZE, Total size of the Bluetooth flash storage. Must be an even multiple of FLASH_SECTOR_SIZE, type=int default=FLASH_SECTOR_SIZE*2, group=pico_btstack
+// PICO_CONFIG: PICO_FLASH_BANK_TOTAL_SIZE, Total size of the Bluetooth flash storage. Must be an even multiple of FLASH_SECTOR_SIZE, type=int, default=FLASH_SECTOR_SIZE * 2, group=pico_btstack
 #ifndef PICO_FLASH_BANK_TOTAL_SIZE
 #define PICO_FLASH_BANK_TOTAL_SIZE (FLASH_SECTOR_SIZE * 2u)
 #endif
 
-// PICO_CONFIG: PICO_FLASH_BANK_STORAGE_OFFSET, Offset in flash of the Bluetooth flash storage, type=int default=PICO_FLASH_SIZE_BYTES-PICO_FLASH_BANK_TOTAL_SIZE, group=pico_btstack
+// PICO_CONFIG: PICO_FLASH_BANK_STORAGE_OFFSET, Offset in flash of the Bluetooth flash storage, type=int, default=PICO_FLASH_SIZE_BYTES - PICO_FLASH_BANK_TOTAL_SIZE, group=pico_btstack
 #ifndef PICO_FLASH_BANK_STORAGE_OFFSET
 #define PICO_FLASH_BANK_STORAGE_OFFSET (PICO_FLASH_SIZE_BYTES - PICO_FLASH_BANK_TOTAL_SIZE)
 #endif
@@ -28,7 +28,7 @@ extern "C" {
  * \brief Return the singleton BTstack HAL flash instance, used for non-volatile storage
  * \ingroup pico_btstack
  *
- * \note By default two sectors at the end of flash are used (see \c PICO_FLASH_BANK_STORAGE_OFFSET
+ * \note By default two sectors at the end of flash are used (see \c PICO_FLASH_BANK_STORAGE_OFFSET and \c PICO_FLASH_BANK_TOTAL_SIZE)
  */
 const hal_flash_bank_t *pico_flash_bank_instance(void);
 

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch/arch_freertos.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch/arch_freertos.h
@@ -12,7 +12,7 @@
 #define CYW43_TASK_STACK_SIZE 1024
 #endif
 
-// PICO_CONFIG: CYW43_TASK_PRIORITY, Priority for the CYW43 FreeRTOS task, type=int default=4, group=pico_cyw43_arch
+// PICO_CONFIG: CYW43_TASK_PRIORITY, Priority for the CYW43 FreeRTOS task, type=int, default=tskIDLE_PRIORITY + 4, group=pico_cyw43_arch
 #ifndef CYW43_TASK_PRIORITY
 #define CYW43_TASK_PRIORITY (tskIDLE_PRIORITY + 4)
 #endif

--- a/src/rp2_common/pico_cyw43_driver/include/pico/btstack_cyw43.h
+++ b/src/rp2_common/pico_cyw43_driver/include/pico/btstack_cyw43.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /** \file pico/btstack_cyw43.h
- * \defgroup pico_bstack_cyw43
+ * \defgroup pico_btstack_cyw43
  * \ingroup pico_cyw43_driver
  *
  * \brief Low-level Bluetooth HCI support.

--- a/src/rp2_common/pico_rand/include/pico/rand.h
+++ b/src/rp2_common/pico_rand/include/pico/rand.h
@@ -138,7 +138,7 @@ extern "C" {
 #ifndef PICO_RAND_RAM_HASH_END
 #define PICO_RAND_RAM_HASH_END     SRAM_END
 #endif
-// PICO_CONFIG: PICO_RAND_RAM_HASH_START, start of address in RAM (inclusive) to hash during pico_rand seed initialization, default=PICO_RAND_RAM_HASH_END-1024, group=pico_rand
+// PICO_CONFIG: PICO_RAND_RAM_HASH_START, start of address in RAM (inclusive) to hash during pico_rand seed initialization, default=PICO_RAND_RAM_HASH_END - 1024, group=pico_rand
 #ifndef PICO_RAND_RAM_HASH_START
 #define PICO_RAND_RAM_HASH_START   (PICO_RAND_RAM_HASH_END - 1024u)
 #endif

--- a/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
+++ b/src/rp2_common/pico_stdio_uart/include/pico/stdio_uart.h
@@ -23,7 +23,7 @@
 #define PICO_STDIO_UART_DEFAULT_CRLF PICO_STDIO_DEFAULT_CRLF
 #endif
 
-// PICO_CONFIG: PICO_STDIO_UART_SUPPORT_CHARS_AVAILABLE_CALLBACK, Enable UART STDIO support for stdio_set_chars_available_callback. Can be disabled to make use of the uart elsewhere, type=bool default=1, group=pico_stdio_uart
+// PICO_CONFIG: PICO_STDIO_UART_SUPPORT_CHARS_AVAILABLE_CALLBACK, Enable UART STDIO support for stdio_set_chars_available_callback. Can be disabled to make use of the uart elsewhere, type=bool, default=1, group=pico_stdio_uart
 #ifndef PICO_STDIO_UART_SUPPORT_CHARS_AVAILABLE_CALLBACK
 #define PICO_STDIO_UART_SUPPORT_CHARS_AVAILABLE_CALLBACK 1
 #endif

--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
@@ -107,7 +107,7 @@
 #define PICO_STDIO_USB_DEVICE_SELF_POWERED 0
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK, Enable USB STDIO support for stdio_set_chars_available_callback. Can be disabled to make use of USB CDC RX callback elsewhere, type=bool default=1, group=pico_stdio_usb
+// PICO_CONFIG: PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK, Enable USB STDIO support for stdio_set_chars_available_callback. Can be disabled to make use of USB CDC RX callback elsewhere, type=bool, default=1, group=pico_stdio_usb
 #ifndef PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
 #define PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK 1
 #endif


### PR DESCRIPTION
Fix errors as spotted by `tools/extract_configs.py` and `tools/check_doxygen_groups.py`.
In hindsight, I should have thought to check these _before_ the recent push to `master`, sorry! :slightly_frowning_face: 