### PR TITLE
Fix various Doxygen errors

### DIFF
--- a/src/common/pico_time/include/pico/time.h
+++ b/src/common/pico_time/include/pico/time.h
@@ -447,7 +447,6 @@ uint alarm_pool_core_num(alarm_pool_t *pool);
  * \brief Destroy the alarm pool, cancelling all alarms and freeing up the underlying hardware alarm
  * \ingroup alarm
  * \param pool the pool
- * \return the hardware alarm used by the pool
  */
 void alarm_pool_destroy(alarm_pool_t *pool);
 

--- a/src/rp2_common/hardware_interp/include/hardware/interp.h
+++ b/src/rp2_common/hardware_interp/include/hardware/interp.h
@@ -432,7 +432,6 @@ static inline uint32_t interp_peek_full_result(interp_hw_t *interp) {
  * \param interp Interpolator instance, interp0 or interp1.
  * \param lane The lane number, 0 or 1
  * \param val Value to add
- * \return The content of the FULL register
  */
 static inline void interp_add_accumulater(interp_hw_t *interp, uint lane, uint32_t val) {
     interp->add_raw[lane] = val;

--- a/src/rp2_common/hardware_sync/include/hardware/sync.h
+++ b/src/rp2_common/hardware_sync/include/hardware/sync.h
@@ -300,7 +300,6 @@ inline static bool is_spin_locked(spin_lock_t *lock) {
  *
  * \param lock Spinlock instance
  * \param saved_irq Return value from the \ref spin_lock_blocking() function.
- * \return interrupt status to be used when unlocking, to restore to original state
  *
  * \sa spin_lock_blocking()
  */

--- a/src/rp2_common/pico_async_context/include/pico/async_context.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context.h
@@ -31,7 +31,7 @@
  * Note: "when pending" workers with work pending are executed before "at time" workers.
  *
  * The async_context provides locking mechanisms, see \ref async_context_acquire_lock_blocking,
- * \ref async_context_release_lock and \ref async_context_check_lock which can be used by
+ * \ref async_context_release_lock and \ref async_context_lock_check which can be used by
  * external code to ensure execution of external code does not happen concurrently with worker code.
  * Locked code runs on the calling core, however \ref async_context_execute_sync is provided to
  * synchronously run a function from the core of the async_context.
@@ -245,7 +245,7 @@ static inline void async_context_lock_check(async_context_t *context) {
  *
  * \param context the async_context
  * \param func the function to call
- * \param parm the paramter to pass to the function
+ * \param param the paramter to pass to the function
  * \return the return value from func
  */
 static inline uint32_t async_context_execute_sync(async_context_t *context, uint32_t (*func)(void *param), void *param) {
@@ -455,7 +455,6 @@ static inline uint async_context_core_num(const async_context_t *context) {
  * callback is being called once this method returns.
  *
  * \param context the async_context
- * \return the physical core number
  */
 static inline void async_context_deinit(async_context_t *context) {
     context->type->deinit(context);

--- a/src/rp2_common/pico_async_context/include/pico/async_context_freertos.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context_freertos.h
@@ -83,7 +83,7 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
  * \brief Return a copy of the default configuration object used by \ref async_context_freertos_init_with_defaults() 
  * \ingroup async_context_freertos
  *
- * The caller can then modify just the settings it cares about, and call \ref async_context_threasafe_background_init()
+ * The caller can then modify just the settings it cares about, and call \ref async_context_freertos_init()
  * \return the default configuration object
  */
  static inline async_context_freertos_config_t async_context_freertos_default_config(void) {

--- a/src/rp2_common/pico_async_context/include/pico/async_context_threadsafe_background.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context_threadsafe_background.h
@@ -85,7 +85,7 @@ bool async_context_threadsafe_background_init(async_context_threadsafe_backgroun
  * \brief Return a copy of the default configuration object used by \ref async_context_threadsafe_background_init_with_defaults() 
  * \ingroup async_context_threadsafe_background
  *
- * The caller can then modify just the settings it cares about, and call \ref async_context_threasafe_background_init()
+ * The caller can then modify just the settings it cares about, and call \ref async_context_threadsafe_background_init()
  * \return the default configuration object
  */
 async_context_threadsafe_background_config_t async_context_threadsafe_background_default_config(void);

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -404,7 +404,7 @@ int cyw43_arch_wifi_connect_bssid_blocking(const char *ssid, const uint8_t *bssi
  * \param pw the network password or NULL if there is no password required
  * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
  *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
- * \param timeout
+ * \param timeout how long to wait in milliseconds for a connection to succeed before giving up
  *
  * \return 0 if the initialization is successful, an error code otherwise \see pico_error_codes
  */
@@ -419,7 +419,7 @@ int cyw43_arch_wifi_connect_timeout_ms(const char *ssid, const char *pw, uint32_
  * \param pw the network password or NULL if there is no password required
  * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
  *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
- * \param timeout
+ * \param timeout how long to wait in milliseconds for a connection to succeed before giving up
  *
  * \return 0 if the initialization is successful, an error code otherwise \see pico_error_codes
  */

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -81,7 +81,7 @@ extern "C" {
  *
  * * \b pico_cyw43_arch_lwip_poll - For using the RAW lwIP API (in `NO_SYS=1` mode) without any background processing or multi-core/thread safety.
  *
- *    The user must call \ref pico_cyw43_poll periodically from their main loop.
+ *    The user must call \ref cyw43_arch_poll periodically from their main loop.
  *
  *    This wrapper library:
  *    - Sets \c CYW43_LWIP=1 to enable lwIP support in \c pico_cyw43_arch and \c cyw43_driver.
@@ -262,7 +262,7 @@ void cyw43_arch_wait_for_work_until(absolute_time_t until);
  * If you are using single-core polling only (pico_cyw43_arch_poll) then these calls are no-ops
  * anyway it is good practice to call them anyway where they are necessary.
  *
- * \note as of SDK release 1.5.0, this is now equivalent to calling \ref pico_async_context_acquire_lock_blocking
+ * \note as of SDK release 1.5.0, this is now equivalent to calling \ref async_context_acquire_lock_blocking
  * on the async_context associated with cyw43_arch and lwIP.
  *
  * \sa cyw43_arch_lwip_end
@@ -353,7 +353,7 @@ uint32_t cyw43_arch_get_country_code(void);
  * \brief Enables Wi-Fi STA (Station) mode.
  * \ingroup pico_cyw43_arch
  *
- * This enables the Wi-Fi in \emStation mode such that connections can be made to other Wi-Fi Access Points
+ * This enables the Wi-Fi in \em Station mode such that connections can be made to other Wi-Fi Access Points
  */
 void cyw43_arch_enable_sta_mode(void);
 
@@ -388,7 +388,7 @@ int cyw43_arch_wifi_connect_blocking(const char *ssid, const char *pw, uint32_t 
  *
  * \param ssid the network name to connect to
  * \param bssid the network BSSID to connect to or NULL if ignored
- * \param password the network password or NULL if there is no password required
+ * \param pw the network password or NULL if there is no password required
  * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
  *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
  *
@@ -404,6 +404,7 @@ int cyw43_arch_wifi_connect_bssid_blocking(const char *ssid, const uint8_t *bssi
  * \param pw the network password or NULL if there is no password required
  * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
  *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
+ * \param timeout
  *
  * \return 0 if the initialization is successful, an error code otherwise \see pico_error_codes
  */
@@ -415,9 +416,10 @@ int cyw43_arch_wifi_connect_timeout_ms(const char *ssid, const char *pw, uint32_
  *
  * \param ssid the network name to connect to
  * \param bssid the network BSSID to connect to or NULL if ignored
- * \param password the network password or NULL if there is no password required
+ * \param pw the network password or NULL if there is no password required
  * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
  *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
+ * \param timeout
  *
  * \return 0 if the initialization is successful, an error code otherwise \see pico_error_codes
  */
@@ -448,7 +450,7 @@ int cyw43_arch_wifi_connect_async(const char *ssid, const char *pw, uint32_t aut
  *
  * \param ssid the network name to connect to
  * \param bssid the network BSSID to connect to or NULL if ignored
- * \param password the network password or NULL if there is no password required
+ * \param pw the network password or NULL if there is no password required
  * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,
  *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
  *

--- a/src/rp2_common/pico_cyw43_driver/include/pico/btstack_cyw43.h
+++ b/src/rp2_common/pico_cyw43_driver/include/pico/btstack_cyw43.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 /** \file pico/btstack_cyw43.h
- * \defgroup pico_btstack_cyw43
+ * \defgroup pico_btstack_cyw43 pico_btstack_cyw43
  * \ingroup pico_cyw43_driver
  *
  * \brief Low-level Bluetooth HCI support.

--- a/src/rp2_common/pico_i2c_slave/include/pico/i2c_slave.h
+++ b/src/rp2_common/pico_i2c_slave/include/pico/i2c_slave.h
@@ -44,7 +44,7 @@ typedef enum i2c_slave_event_t
  * The event handler will run from the I2C ISR, so it should return quickly (under 25 us at 400 kb/s).
  * Avoid blocking inside the handler and split large data transfers across multiple calls for best results.
  * When sending data to master, up to \ref i2c_get_write_available()  bytes can be written without blocking.
- * When receiving data from master, up to \ref 2c_get_read_available() bytes can be read without blocking.
+ * When receiving data from master, up to \ref i2c_get_read_available() bytes can be read without blocking.
  *
  * \param i2c Either \ref i2c0 or \ref i2c1
  * \param event Event type.

--- a/src/rp2_common/pico_rand/include/pico/rand.h
+++ b/src/rp2_common/pico_rand/include/pico/rand.h
@@ -39,7 +39,7 @@ extern "C" {
  *
  * \note All entropy sources are hashed before application to the PRNG state machine.
  *
- * \note The \em first time a random number is requested, the 128-bit PRNG state
+ * The \em first time a random number is requested, the 128-bit PRNG state
  * must be seeded. Multiple entropy sources are also available for the seeding operation:
  *
  *  - The Ring Oscillator (ROSC) (\ref PICO_RAND_SEED_ENTROPY_SRC_ROSC == 1):


### PR DESCRIPTION
@kilograham and @peterharperuk Please check these changes carefully, as some of them were only "educated guesses" :slightly_smiling_face: 

And if you want to add/suggest some suitable text for the `timeout` params, that'd be great.

I made the change I did to `rand.h` because Doxygen was collapsing the two `\note` blocks into a single Note, which looked very weird in the final output.