### PR TITLE
Add some configuration for VBUS / VSYS

### DIFF
--- a/src/boards/include/boards/pico.h
+++ b/src/boards/include/boards/pico.h
@@ -81,4 +81,14 @@
 #define PICO_RP2040_B0_SUPPORTED 1
 #endif
 
+// Pin get VBUS
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// Pin used to monitor VSYS using ADC
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
 #endif

--- a/src/boards/include/boards/pico_w.h
+++ b/src/boards/include/boards/pico_w.h
@@ -99,4 +99,19 @@
 #define CYW43_WL_GPIO_LED_PIN 0
 #endif
 
+// CYW43 GPIO to get VBUS
+#ifndef CYW43_WL_GPIO_VBUS_PIN
+#define CYW43_WL_GPIO_VBUS_PIN 2
+#endif
+
+// VSYS pin is shared with CYW43
+#ifndef CYW43_USES_VSYS_PIN
+#define CYW43_USES_VSYS_PIN 1
+#endif
+
+// Pin used to monitor VSYS using ADC
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
 #endif


### PR DESCRIPTION
The process for reading VBUS and VSYS on Pico and Pico W is different. It's hard to write code that compiles for both devices. Add some configuration to the board files.

Fixes #1222
