### PR TITLE
Make sure BT device address is set.

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -61,6 +61,7 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
     pico_add_library(pico_btstack_hci_transport_cyw43 NOFLAG)
     target_sources(pico_btstack_hci_transport_cyw43 INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/btstack_hci_transport_cyw43.c
+            ${CMAKE_CURRENT_LIST_DIR}/btstack_chipset_cyw43.c
             )
     target_include_directories(pico_btstack_hci_transport_cyw43_headers INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/include

--- a/src/rp2_common/pico_cyw43_driver/btstack_chipset_cyw43.c
+++ b/src/rp2_common/pico_cyw43_driver/btstack_chipset_cyw43.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico/btstack_chipset_cyw43.h"
+
+static void chipset_set_bd_addr_command(bd_addr_t addr, uint8_t *hci_cmd_buffer) {
+    hci_cmd_buffer[0] = 0x01;
+    hci_cmd_buffer[1] = 0xfc;
+    hci_cmd_buffer[2] = 0x06;
+    reverse_bd_addr(addr, &hci_cmd_buffer[3]);
+}
+
+static const btstack_chipset_t btstack_chipset_cyw43 = {
+    .name = "CYW43",
+    .init = NULL,
+    .next_command = NULL,
+    .set_baudrate_command = NULL,
+    .set_bd_addr_command = chipset_set_bd_addr_command,
+};
+
+const btstack_chipset_t * btstack_chipset_cyw43_instance(void) {
+    return &btstack_chipset_cyw43;
+}

--- a/src/rp2_common/pico_cyw43_driver/btstack_cyw43.c
+++ b/src/rp2_common/pico_cyw43_driver/btstack_cyw43.c
@@ -59,7 +59,7 @@ bool btstack_cyw43_init(async_context_t *context) {
 #endif
 #endif
 
-	hci_init(hci_transport_cyw43_instance(), NULL);
+    hci_init(hci_transport_cyw43_instance(), NULL);
 
     // setup TLV storage
     setup_tlv();

--- a/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
@@ -129,13 +129,16 @@ uint32_t storage_read_blocks(__unused uint8_t *dest, __unused uint32_t block_num
 }
 
 // Generate a mac address if one is not set in otp
-void __attribute__((weak)) cyw43_hal_generate_laa_mac(__unused int idx, uint8_t buf[6]) {
+void __attribute__((weak)) cyw43_hal_generate_laa_mac(int idx, uint8_t buf[6]) {
     CYW43_DEBUG("Warning. No mac in otp. Generating mac from board id\n");
-    pico_unique_board_id_t board_id;
-    pico_get_unique_board_id(&board_id);
-    memcpy(buf, &board_id.id[2], 6);
-    buf[0] &= (uint8_t)~0x1; // unicast
-    buf[0] |= 0x2; // locally administered
+    pico_unique_board_id_t pid;
+    pico_get_unique_board_id(&pid);
+    buf[0] = 0x02; // LAA range
+    buf[1] = (pid.id[7] << 4) | (pid.id[6] & 0xf);
+    buf[2] = (pid.id[5] << 4) | (pid.id[4] & 0xf);
+    buf[3] = (pid.id[3] << 4) | (pid.id[2] & 0xf);
+    buf[4] = pid.id[1];
+    buf[5] = (pid.id[0] << 2) | idx;
 }
 
 // Return mac address

--- a/src/rp2_common/pico_cyw43_driver/include/pico/btstack_chipset_cyw43.h
+++ b/src/rp2_common/pico_cyw43_driver/include/pico/btstack_chipset_cyw43.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PICO_BTSTACK_CHIPSET_CYW43_H
+#define _PICO_BTSTACK_CHIPSET_CYW43_H
+
+#include "btstack_chipset.h"
+
+/**
+ * \brief Return the singleton BTstack chipset CY43 API instance
+ * \ingroup pico_btstack
+ */
+const btstack_chipset_t * btstack_chipset_cyw43_instance(void);
+
+#endif


### PR DESCRIPTION
Some devices seem to not have their OTP set. This is handled for the wifi mac but the BT device address gets set to an always the same default. Always set the bt address to wifi mac + 1

Fixes #1269
