### PR TITLE
Make linker fill alignment gaps with bkpt instruction

### DIFF
--- a/src/rp2_common/pico_standard_link/memmap_default.ld
+++ b/src/rp2_common/pico_standard_link/memmap_default.ld
@@ -86,6 +86,8 @@ SECTIONS
         *(.eh_frame*)
         . = ALIGN(4);
     } > FLASH
+        /* bkpt has opcode 0xBE and one (ignored) immediate parameter, which we set to 0xBE, giving us 0xBEBE */
+        = 0xBEBE
 
     .rodata : {
         *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a:) .rodata*)
@@ -125,11 +127,13 @@ SECTIONS
         __data_start__ = .;
         *(vtable)
 
+        FILL(0xBEBE)
         *(.time_critical*)
 
         /* remaining .text and .rodata; i.e. stuff we exclude above because we want it in RAM */
         *(.text*)
         . = ALIGN(4);
+        FILL(0)
         *(.rodata*)
         . = ALIGN(4);
 


### PR DESCRIPTION
Request for comment: what do you think of this?
This came out from https://forums.raspberrypi.com/viewtopic.php?p=2089017#p2088888.

The linker fills in some gaps that result from alignment. But it filled in just zeros. Would it be better if those filler bytes would trigger a breakpoint or fault in case they are ever executed?