### PR TITLE
Use cyw43_malloc/free macro instead of malloc/free to allow alternative implementations

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus.c
+++ b/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus.c
@@ -62,14 +62,14 @@ static cybt_result_t cybt_fw_download_prepare(uint8_t **p_write_buf, uint8_t **p
     *p_write_buf = NULL;
     *p_hex_buf = NULL;
 
-    *p_write_buf = malloc(BTFW_DOWNLOAD_BLK_SIZE + BTFW_SD_ALIGN);
+    *p_write_buf = cyw43_malloc(BTFW_DOWNLOAD_BLK_SIZE + BTFW_SD_ALIGN);
     if (NULL == *p_write_buf) {
         return CYBT_ERR_OUT_OF_MEMORY;
     }
 
-    *p_hex_buf = malloc(BTFW_MAX_STR_LEN);
+    *p_hex_buf = cyw43_malloc(BTFW_MAX_STR_LEN);
     if (NULL == *p_hex_buf) {
-        free(*p_write_buf);
+        cyw43_free(*p_write_buf);
         return CYBT_ERR_OUT_OF_MEMORY;
     }
 
@@ -78,11 +78,11 @@ static cybt_result_t cybt_fw_download_prepare(uint8_t **p_write_buf, uint8_t **p
 
 static cybt_result_t cybt_fw_download_finish(uint8_t *p_write_buf, uint8_t *p_hex_buf) {
     if (p_write_buf) {
-        free(p_write_buf);
+        cyw43_free(p_write_buf);
     }
 
     if (p_hex_buf) {
-        free(p_hex_buf);
+        cyw43_free(p_hex_buf);
     }
 
     return CYBT_SUCCESS;

--- a/src/rp2_common/pico_cyw43_driver/include/cyw43_configport.h
+++ b/src/rp2_common/pico_cyw43_driver/include/cyw43_configport.h
@@ -157,6 +157,14 @@ void cyw43_post_poll_hook(void);
 
 #define CYW43_POST_POLL_HOOK cyw43_post_poll_hook();
 
+// Allow malloc and free to be changed
+#ifndef cyw43_malloc
+#define cyw43_malloc malloc
+#endif
+#ifndef cyw43_free
+#define cyw43_free free
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Bluetooth needs a tempoarary buffer to load firmware. Micropython won't work safely with malloc and free so allow these calls to be changed by using cyw43_alloc / free macros.
