### PR TITLE
fixes #1311 adds ws2812 pin definition

### DIFF
--- a/src/boards/include/boards/sparkfun_thingplus.h
+++ b/src/boards/include/boards/sparkfun_thingplus.h
@@ -34,6 +34,10 @@
 #define PICO_DEFAULT_LED_PIN 25
 #endif
 
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 8
+#endif
+
 // Default I2C - for qwiic connector
 #ifndef PICO_DEFAULT_I2C
 #define PICO_DEFAULT_I2C       1


### PR DESCRIPTION
Fixes #1311 just a missing pin definition for the ws2812 LED that is onboard this chip, makes the examples run without modification if it is included.
I tried to follow the same pattern but I didn't include the detailed comments about it not being a simple LED like the sparkfun_promicro has.
