### PR TITLE
include cstdint

### DIFF
--- a/tools/pioasm/pio_disassembler.cpp
+++ b/tools/pioasm/pio_disassembler.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <sstream>
 #include <iomanip>
+#include <cstdint>
 #include "pio_disassembler.h"
 
 extern "C" void disassemble(char *buf, int buf_len, uint16_t inst, uint sideset_bits, bool sideset_opt) {


### PR DESCRIPTION
This fixes build on newer versions of GCC(13.0.1). Fixes #1317
