### PR TITLE
fix adafruit_itsybitsy_rp2040 default I2C

### DIFF
--- a/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
+++ b/src/boards/include/boards/adafruit_itsybitsy_rp2040.h
@@ -48,7 +48,7 @@
 
 //------------- I2C -------------//
 #ifndef PICO_DEFAULT_I2C
-#define PICO_DEFAULT_I2C 0
+#define PICO_DEFAULT_I2C 1
 #endif
 
 #ifndef PICO_DEFAULT_I2C_SDA_PIN


### PR DESCRIPTION
resolves #1161

This corrects the mismatched `PICO_DEFAULT_I2C` bus number (favors the breadboard pins not the stemma connector).