### PR TITLE
add cyw43_arch_disable_ap_mode() to cyw43_arch 

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch.c
@@ -45,6 +45,11 @@ void cyw43_arch_enable_ap_mode(const char *ssid, const char *password, uint32_t 
     cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, true, cyw43_arch_get_country_code());
 }
 
+void cyw43_arch_disable_ap_mode() {
+    assert(cyw43_is_initialized(&cyw43_state));
+    cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, false, cyw43_arch_get_country_code());
+}
+
 #if PICO_CYW43_ARCH_DEBUG_ENABLED
 // Return a string for the wireless state
 static const char* cyw43_tcpip_link_status_name(int status)

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -368,6 +368,14 @@ void cyw43_arch_enable_sta_mode(void);
  *             \ref CYW43_AUTH_WPA2_AES_PSK, or \ref CYW43_AUTH_WPA2_MIXED_PSK (see \ref CYW43_AUTH_)
  */
 void cyw43_arch_enable_ap_mode(const char *ssid, const char *password, uint32_t auth);
+    
+/*!
+ * \brief Disables Wi-Fi AP (Access point) mode.
+ * \ingroup pico_cyw43_arch
+ *
+ * This Disbles the Wi-Fi in \em Access \em Point mode.
+ */
+void cyw43_arch_disable_ap_mode();
 
 /*!
  * \brief Attempt to connect to a wireless access point, blocking until the network is joined or a failure is detected.


### PR DESCRIPTION
the pico/cyw43_arch.h doesn't have functionality to turn off the access point mode of wireless controller. To be able to build a captive portal functionality on the pico w controller, the access point will need to be turned off some time after it is turned on.