### PR TITLE
Changing the sys clock also sets peripheral clock to 48MHz

### DIFF
--- a/src/rp2_common/pico_stdlib/stdlib.c
+++ b/src/rp2_common/pico_stdlib/stdlib.c
@@ -36,6 +36,16 @@ void set_sys_clock_48mhz() {
     }
 }
 
+// When the System clock PLL set-up is changed from the initial setting made
+// during system initialisation, the code automatically switches the peripheral
+// clock to the 48MHz USB clock for safety reasons.
+// The Pico config option below allows a user to change this default behaviour if
+// required by defining the pico config option below as 0 in their board file.
+// PICO_CONFIG: SET_SYS_CLK_PLL_SETS_PERI_CLK_TO_USB_CLK, When the SYS clock PLL is changed, *also* switch the peripheral clock to the USB clock, type=bool, default=1, advanced=true, group=hardware_clocks
+#ifndef SET_SYS_CLK_PLL_SETS_PERI_CLK_TO_USB_CLK
+#define SET_SYS_CLK_PLL_SETS_PERI_CLK_TO_USB_CLK 1
+#endif
+
 void set_sys_clock_pll(uint32_t vco_freq, uint post_div1, uint post_div2) {
     if (!running_on_fpga()) {
         clock_configure(clk_sys,
@@ -61,11 +71,18 @@ void set_sys_clock_pll(uint32_t vco_freq, uint post_div1, uint post_div2) {
                         CLOCKS_CLK_SYS_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS,
                         freq, freq);
 
+#if SET_SYS_CLK_PLL_SETS_PERI_CLK_TO_USB_CLK
         clock_configure(clk_peri,
                         0, // Only AUX mux on ADC
                         CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB,
                         USB_CLK_KHZ * KHZ,
                         USB_CLK_KHZ * KHZ);
+#else
+        clock_configure(clk_peri,
+                        0,
+                        CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS,
+                        freq, freq);
+#endif
     }
 }
 

--- a/src/rp2_common/pico_stdlib/stdlib.c
+++ b/src/rp2_common/pico_stdlib/stdlib.c
@@ -43,7 +43,7 @@ void set_sys_clock_48mhz() {
 // if required, by defining the Pico config option below as 1 in their board file.
 // If this option is selected, the peripheral clock will remain connected to the
 // system PLL clock and so will change frequency with that.
-// PICO_CONFIG: PICO_CLOCK_AJDUST_PERI_CLOCK_WITH_SYS_CLOCK, When the SYS clock PLL is changed also switch the peripheral clock to the USB clock, type=bool, default=0, advanced=true, group=hardware_clocks
+// PICO_CONFIG: PICO_CLOCK_AJDUST_PERI_CLOCK_WITH_SYS_CLOCK, When the SYS clock PLL is changed keep the peripheral clock attached to it, type=bool, default=0, advanced=true, group=hardware_clocks
 #ifndef PICO_CLOCK_AJDUST_PERI_CLOCK_WITH_SYS_CLOCK
 #define PICO_CLOCK_AJDUST_PERI_CLOCK_WITH_SYS_CLOCK 0
 #endif

--- a/src/rp2_common/pico_stdlib/stdlib.c
+++ b/src/rp2_common/pico_stdlib/stdlib.c
@@ -36,15 +36,12 @@ void set_sys_clock_48mhz() {
     }
 }
 
-// When the System clock PLL setup is changed from the initial setting made
-// during system initialisation, the code automatically switches the peripheral
-// clock to the 48MHz USB clock to ensure continuity of peripheral operation.
-// The Pico config option below allows a user to change this default behaviour,
-// if required, by defining the Pico config option below as 1 in their board file.
-// If this option is selected, the peripheral clock will remain connected to the
-// system PLL clock and so will change frequency with that.
 // PICO_CONFIG: PICO_CLOCK_AJDUST_PERI_CLOCK_WITH_SYS_CLOCK, When the SYS clock PLL is changed keep the peripheral clock attached to it, type=bool, default=0, advanced=true, group=hardware_clocks
 #ifndef PICO_CLOCK_AJDUST_PERI_CLOCK_WITH_SYS_CLOCK
+// By default, when reconfiguring the system clock PLL settings after runtime initialization,
+// the peripheral clock is switched to the 48MHz USB clock to ensure continuity of peripheral operation. 
+// Setting this value to 1 changes the behavior to have the peripheral clock re-configured
+// to the system clock at it's new frequency.
 #define PICO_CLOCK_AJDUST_PERI_CLOCK_WITH_SYS_CLOCK 0
 #endif
 


### PR DESCRIPTION
Currently, changing the system clock frequency also _always_ sets the peripheral clock frequency to 48MHz.
Fix:  Add a PICO_ config control that can be defined to override this behaviour. The current behaviour is unchanged by default.
Fixes issue #841 

