### PR TITLE
Correct writes to the UART LCR register

### DIFF
--- a/src/rp2_common/hardware_uart/include/hardware/uart.h
+++ b/src/rp2_common/hardware_uart/include/hardware/uart.h
@@ -133,11 +133,11 @@ typedef enum {
  *
  * This function always enables the FIFOs, and configures the UART for the
  * following default line format:
- * 
+ *
  * - 8 data bits
  * - No parity bit
  * - One stop bit
- * 
+ *
  * \note There is no guarantee that the baudrate requested will be possible, the nearest will be chosen,
  * and this function will return the configured baud rate.
  *
@@ -161,15 +161,15 @@ void uart_deinit(uart_inst_t *uart);
  *  \ingroup hardware_uart
  *
  * Set baud rate as close as possible to requested, and return actual rate selected.
- * 
+ *
  * The UART is paused for around two character periods whilst the settings are
  * changed. Data received during this time may be dropped by the UART.
- * 
+ *
  * Any characters still in the transmit buffer will be sent using the new
  * updated baud rate. uart_tx_wait_blocking() can be called before this
  * function to ensure all characters at the old baud rate have been sent
  * before the rate is changed.
- * 
+ *
  * This function should not be called from an interrupt context, and the UART
  * interrupt should be disabled before calling this function.
  *
@@ -196,18 +196,18 @@ static inline void uart_set_hw_flow(uart_inst_t *uart, bool cts, bool rts) {
  *  \ingroup hardware_uart
  *
  * Configure the data format (bits etc) for the UART.
- * 
+ *
  * The UART is paused for around two character periods whilst the settings are
  * changed. Data received during this time may be dropped by the UART.
- * 
+ *
  * Any characters still in the transmit buffer will be sent using the new
  * updated data format. uart_tx_wait_blocking() can be called before this
  * function to ensure all characters needing the old format have been sent
  * before the format is changed.
- * 
+ *
  * This function should not be called from an interrupt context, and the UART
  * interrupt should be disabled before calling this function.
- * 
+ *
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param data_bits Number of bits of data. 5..8
  * \param stop_bits Number of stop bits 1..2
@@ -260,11 +260,11 @@ static inline bool uart_is_enabled(uart_inst_t *uart) {
  *
  * The UART is paused for around two character periods whilst the settings are
  * changed. Data received during this time may be dropped by the UART.
- * 
+ *
  * Any characters still in the transmit FIFO will be lost if the FIFO is
  * disabled. uart_tx_wait_blocking() can be called before this
  * function to avoid this.
- * 
+ *
  * This function should not be called from an interrupt context, and the UART
  * interrupt should be disabled when calling this function.
  *

--- a/src/rp2_common/hardware_uart/include/hardware/uart.h
+++ b/src/rp2_common/hardware_uart/include/hardware/uart.h
@@ -131,6 +131,13 @@ typedef enum {
  * Put the UART into a known state, and enable it. Must be called before other
  * functions.
  *
+ * This function always enables the FIFOs, and configures the UART for the
+ * following default line format:
+ * 
+ * - 8 data bits
+ * - No parity bit
+ * - One stop bit
+ * 
  * \note There is no guarantee that the baudrate requested will be possible, the nearest will be chosen,
  * and this function will return the configured baud rate.
  *
@@ -154,6 +161,17 @@ void uart_deinit(uart_inst_t *uart);
  *  \ingroup hardware_uart
  *
  * Set baud rate as close as possible to requested, and return actual rate selected.
+ * 
+ * The UART is paused for around two character periods whilst the settings are
+ * changed. Data received during this time may be dropped by the UART.
+ * 
+ * Any characters still in the transmit buffer will be sent using the new
+ * updated baud rate. uart_tx_wait_blocking() can be called before this
+ * function to ensure all characters at the old baud rate have been sent
+ * before the rate is changed.
+ * 
+ * This function should not be called from an interrupt context, and the UART
+ * interrupt should be disabled before calling this function.
  *
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param baudrate Baudrate in Hz
@@ -177,27 +195,25 @@ static inline void uart_set_hw_flow(uart_inst_t *uart, bool cts, bool rts) {
 /*! \brief Set UART data format
  *  \ingroup hardware_uart
  *
- * Configure the data format (bits etc() for the UART
- *
+ * Configure the data format (bits etc) for the UART.
+ * 
+ * The UART is paused for around two character periods whilst the settings are
+ * changed. Data received during this time may be dropped by the UART.
+ * 
+ * Any characters still in the transmit buffer will be sent using the new
+ * updated data format. uart_tx_wait_blocking() can be called before this
+ * function to ensure all characters needing the old format have been sent
+ * before the format is changed.
+ * 
+ * This function should not be called from an interrupt context, and the UART
+ * interrupt should be disabled before calling this function.
+ * 
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param data_bits Number of bits of data. 5..8
  * \param stop_bits Number of stop bits 1..2
  * \param parity Parity option.
  */
-static inline void uart_set_format(uart_inst_t *uart, uint data_bits, uint stop_bits, uart_parity_t parity) {
-    invalid_params_if(UART, data_bits < 5 || data_bits > 8);
-    invalid_params_if(UART, stop_bits != 1 && stop_bits != 2);
-    invalid_params_if(UART, parity != UART_PARITY_NONE && parity != UART_PARITY_EVEN && parity != UART_PARITY_ODD);
-    hw_write_masked(&uart_get_hw(uart)->lcr_h,
-                   ((data_bits - 5u) << UART_UARTLCR_H_WLEN_LSB) |
-                   ((stop_bits - 1u) << UART_UARTLCR_H_STP2_LSB) |
-                   (bool_to_bit(parity != UART_PARITY_NONE) << UART_UARTLCR_H_PEN_LSB) |
-                   (bool_to_bit(parity == UART_PARITY_EVEN) << UART_UARTLCR_H_EPS_LSB),
-                   UART_UARTLCR_H_WLEN_BITS |
-                   UART_UARTLCR_H_STP2_BITS |
-                   UART_UARTLCR_H_PEN_BITS |
-                   UART_UARTLCR_H_EPS_BITS);
-}
+void uart_set_format(uart_inst_t *uart, uint data_bits, uint stop_bits, uart_parity_t parity);
 
 /*! \brief Setup UART interrupts
  *  \ingroup hardware_uart
@@ -242,15 +258,20 @@ static inline bool uart_is_enabled(uart_inst_t *uart) {
 /*! \brief Enable/Disable the FIFOs on specified UART
  *  \ingroup hardware_uart
  *
+ * The UART is paused for around two character periods whilst the settings are
+ * changed. Data received during this time may be dropped by the UART.
+ * 
+ * Any characters still in the transmit FIFO will be lost if the FIFO is
+ * disabled. uart_tx_wait_blocking() can be called before this
+ * function to avoid this.
+ * 
+ * This function should not be called from an interrupt context, and the UART
+ * interrupt should be disabled when calling this function.
+ *
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param enabled true to enable FIFO (default), false to disable
  */
-static inline void uart_set_fifo_enabled(uart_inst_t *uart, bool enabled) {
-    hw_write_masked(&uart_get_hw(uart)->lcr_h,
-                   (bool_to_bit(enabled) << UART_UARTLCR_H_FEN_LSB),
-                   UART_UARTLCR_H_FEN_BITS);
-}
-
+void uart_set_fifo_enabled(uart_inst_t *uart, bool enabled);
 
 // ----------------------------------------------------------------------------
 // Generic input/output
@@ -397,12 +418,7 @@ static inline char uart_getc(uart_inst_t *uart) {
  * \param uart UART instance. \ref uart0 or \ref uart1
  * \param en Assert break condition (TX held low) if true. Clear break condition if false.
  */
-static inline void uart_set_break(uart_inst_t *uart, bool en) {
-    if (en)
-        hw_set_bits(&uart_get_hw(uart)->lcr_h, UART_UARTLCR_H_BRK_BITS);
-    else
-        hw_clear_bits(&uart_get_hw(uart)->lcr_h, UART_UARTLCR_H_BRK_BITS);
-}
+void uart_set_break(uart_inst_t *uart, bool en);
 
 /*! \brief Set CR/LF conversion on UART
  *  \ingroup hardware_uart

--- a/src/rp2_common/hardware_uart/uart.c
+++ b/src/rp2_common/hardware_uart/uart.c
@@ -39,8 +39,9 @@ static inline void uart_unreset(uart_inst_t *uart) {
 uint uart_init(uart_inst_t *uart, uint baudrate) {
     invalid_params_if(UART, uart != uart0 && uart != uart1);
 
-    if (clock_get_hz(clk_peri) == 0)
+    if (clock_get_hz(clk_peri) == 0) {
         return 0;
+    }
 
     uart_reset(uart);
     uart_unreset(uart);
@@ -97,7 +98,7 @@ uint32_t uart_disable_before_lcr_write(uart_inst_t *uart) {
 
     uint32_t current_ibrd = uart_get_hw(uart)->ibrd;
     uint32_t current_fbrd = uart_get_hw(uart)->fbrd;
-    uint64_t baud_period_usec = 1u + 
+    uint64_t baud_period_usec = 1u +
         ((uint64_t)64 * current_ibrd + current_fbrd) /
         (4u * clock_get_hz(clk_peri));
 
@@ -125,8 +126,9 @@ uint uart_set_baudrate(uart_inst_t *uart, uint baudrate) {
     // Need to cleanly disable UART before touching LCR
     bool was_enabled = uart_is_enabled(uart);
     uint32_t cr_save;
-    if (was_enabled)
+    if (was_enabled) {
         cr_save = uart_disable_before_lcr_write(uart);
+    }
 
     uart_get_hw(uart)->ibrd = baud_ibrd;
     uart_get_hw(uart)->fbrd = baud_fbrd;
@@ -135,8 +137,9 @@ uint uart_set_baudrate(uart_inst_t *uart, uint baudrate) {
     hw_set_bits(&uart_get_hw(uart)->lcr_h, 0);
 
     // Re-enable using saved control register value
-    if (was_enabled)
+    if (was_enabled) {
         uart_get_hw(uart)->cr = cr_save;
+    }
 
     // See datasheet
     return (4 * clock_get_hz(clk_peri)) / (64 * baud_ibrd + baud_fbrd);
@@ -150,8 +153,9 @@ void uart_set_format(uart_inst_t *uart, uint data_bits, uint stop_bits, uart_par
 
     bool was_enabled = uart_is_enabled(uart);
     uint32_t cr_save;
-    if (was_enabled)
+    if (was_enabled) {
         cr_save = uart_disable_before_lcr_write(uart);
+    }
 
     hw_write_masked(&uart_get_hw(uart)->lcr_h,
                    ((data_bits - 5u) << UART_UARTLCR_H_WLEN_LSB) |
@@ -163,37 +167,42 @@ void uart_set_format(uart_inst_t *uart, uint data_bits, uint stop_bits, uart_par
                    UART_UARTLCR_H_PEN_BITS |
                    UART_UARTLCR_H_EPS_BITS);
 
-    if (was_enabled)
+    if (was_enabled) {
         uart_get_hw(uart)->cr = cr_save;
+    }
 }
 
 void uart_set_fifo_enabled(uart_inst_t *uart, bool enabled) {
     bool was_enabled = uart_is_enabled(uart);
     uint32_t cr_save;
-    if (was_enabled)
+    if (was_enabled) {
         cr_save = uart_disable_before_lcr_write(uart);
-
+    }
     hw_write_masked(&uart_get_hw(uart)->lcr_h,
                    (bool_to_bit(enabled) << UART_UARTLCR_H_FEN_LSB),
                    UART_UARTLCR_H_FEN_BITS);
 
-    if (was_enabled)
+    if (was_enabled) {
         uart_get_hw(uart)->cr = cr_save;
+    }
 }
 
 void uart_set_break(uart_inst_t *uart, bool en) {
     bool was_enabled = uart_is_enabled(uart);
-    uint32_t cr_save;
-    if (was_enabled)
+    uint32_t cr_save = 0;  // stifle warning
+    if (was_enabled) {
         cr_save = uart_disable_before_lcr_write(uart);
+    }
 
-    if (en)
+    if (en) {
         hw_set_bits(&uart_get_hw(uart)->lcr_h, UART_UARTLCR_H_BRK_BITS);
-    else
+    } else {
         hw_clear_bits(&uart_get_hw(uart)->lcr_h, UART_UARTLCR_H_BRK_BITS);
+    }
 
-    if (was_enabled)
+    if (was_enabled) {
         uart_get_hw(uart)->cr = cr_save;
+    }
 }
 
 void uart_set_translate_crlf(uart_inst_t *uart, bool crlf) {
@@ -207,7 +216,9 @@ void uart_set_translate_crlf(uart_inst_t *uart, bool crlf) {
 bool uart_is_readable_within_us(uart_inst_t *uart, uint32_t us) {
     uint32_t t = time_us_32();
     do {
-        if (uart_is_readable(uart)) return true;
+        if (uart_is_readable(uart)) {
+             return true;
+        }
     } while ((time_us_32() - t) <= us);
     return false;
 }


### PR DESCRIPTION
The current SDK code allows application code to change UART settings when the UART is busy.  This is not correct and causes some API functionality to silently fail, see issue https://github.com/raspberrypi/pico-sdk/issues/548 and also (a part of) https://github.com/raspberrypi/pico-sdk/issues/1274
A fix was authoured in https://github.com/raspberrypi/pico-sdk/pull/556 and has been slightly tidied and then tested for this change & PR.
