### PR TITLE
added include cstdint, fixed #1363

### DIFF
--- a/tools/pioasm/pio_disassembler.h
+++ b/tools/pioasm/pio_disassembler.h
@@ -10,6 +10,7 @@
 #ifdef __cplusplus
 
 #include <string>
+#include <cstdint>
 
 typedef unsigned int uint;
 


### PR DESCRIPTION
Part of [porting to GCC 13](https://gcc.gnu.org/gcc-13/porting_to.html):

>  The following headers are used less widely in libstdc++ and may need to be included explicitly when compiling with GCC 13:
>    \<string\> (for std::string, std::to_string, std::stoi etc.)
>    \<system_error\> (for std::error_code, std::error_category, std::system_error).
>    \<cstdint\> (for std::int8_t, std::int32_t etc.)
>    \<cstdio\> (for std::printf, std::fopen etc.)
>    \<cstdlib\> (for std::strtol, std::malloc etc.)
