### PR TITLE
Add dma_channel_cleanup method and use it to cleanup after pico_cyw43_driver is closed

### DIFF
--- a/src/rp2_common/hardware_dma/dma.c
+++ b/src/rp2_common/hardware_dma/dma.c
@@ -72,10 +72,8 @@ bool dma_timer_is_claimed(uint timer) {
 
 void dma_channel_cleanup(uint channel) {
     check_dma_channel_param(channel);
-    // we definitely want to disable chaining, because that could cause a restart
-    // during abort. Sicne we're doing that, it's just as easy to reset to default config!
-    const dma_channel_config config = dma_channel_get_default_config(channel);
-    dma_channel_set_config(channel, &config, false);
+    // Disable CHAIN_TO, and disable channel, so that it ignores any further triggers 
+    hw_write_masked( &dma_hw->ch[channel].al1_ctrl, (channel << DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB) | (0u << DMA_CH0_CTRL_TRIG_EN_LSB), DMA_CH0_CTRL_TRIG_CHAIN_TO_BITS | DMA_CH0_CTRL_TRIG_EN_BITS );
     // disable IRQs first as abort can cause spurious IRQs
     dma_channel_set_irq0_enabled(channel, false);
     dma_channel_set_irq1_enabled(channel, false);

--- a/src/rp2_common/hardware_dma/include/hardware/dma.h
+++ b/src/rp2_common/hardware_dma/include/hardware/dma.h
@@ -912,8 +912,8 @@ static inline void dma_channel_cleanup(uint channel) {
     check_dma_channel_param(channel);
     // we definitely want to disable chaining, because that could cause a restart
     // during abort. Sicne we're doing that, it's just as easy to reset to default config!
-    uint32_t cfg = dma_channel_default_config(channel);
-    dma_channel_set_config(channel, &cfg, false);
+    uint32_t config = dma_channel_get_default_config(channel);
+    dma_channel_set_config(channel, &config, false);
     // disable IRQs first as abort can cause spurious IRQs
     dma_channel_set_irq0_enabled(channel, false);
     dma_channel_set_irq1_enabled(channel, false);

--- a/src/rp2_common/hardware_dma/include/hardware/dma.h
+++ b/src/rp2_common/hardware_dma/include/hardware/dma.h
@@ -891,6 +891,30 @@ static inline uint dma_get_timer_dreq(uint timer_num) {
     return DREQ_DMA_TIMER0 + timer_num;
 }
 
+/*! \brief Performs DMA channel cleanup after use
+ *  \ingroup hardware_dma
+ *
+ * This can be used to cleanup dma channels when they're no longer needed.
+ * IRQ's for this channel are disabled, DMA transfers are stopped and any outstanding interrupts are cleared.
+ * The channel is then clear to be reused for other purposes.
+ *
+ * \code
+ * if (dma_channel >= 0) {
+ *     dma_channel_cleanup(dma_channel);
+ *     dma_channel_unclaim(dma_channel);
+ *     dma_channel = -1;
+ * }
+ * \endcode
+ *
+ * \param channel DMA channel
+ */
+static inline void dma_channel_cleanup(uint channel) {
+    dma_channel_set_irq0_enabled(channel, false);
+    dma_channel_set_irq1_enabled(channel, false);
+    dma_channel_abort(channel);
+    dma_hw->intr = 1u << channel;
+}
+
 #ifndef NDEBUG
 void print_dma_ctrl(dma_channel_hw_t *channel);
 #endif

--- a/src/rp2_common/hardware_dma/include/hardware/dma.h
+++ b/src/rp2_common/hardware_dma/include/hardware/dma.h
@@ -908,19 +908,7 @@ static inline uint dma_get_timer_dreq(uint timer_num) {
  *
  * \param channel DMA channel
  */
-static inline void dma_channel_cleanup(uint channel) {
-    check_dma_channel_param(channel);
-    // we definitely want to disable chaining, because that could cause a restart
-    // during abort. Sicne we're doing that, it's just as easy to reset to default config!
-    uint32_t config = dma_channel_get_default_config(channel);
-    dma_channel_set_config(channel, &config, false);
-    // disable IRQs first as abort can cause spurious IRQs
-    dma_channel_set_irq0_enabled(channel, false);
-    dma_channel_set_irq1_enabled(channel, false);
-    dma_channel_abort(channel);
-    // finally clear the IRQ status, which may have been set during abort
-    dma_hw->intr = 1u << channel;
-}
+void dma_channel_cleanup(uint channel);
 
 #ifndef NDEBUG
 void print_dma_ctrl(dma_channel_hw_t *channel);

--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -163,10 +163,12 @@ void cyw43_spi_deinit(cyw43_int_t *self) {
             pio_sm_unclaim(bus_data->pio, bus_data->pio_sm);
         }
         if (bus_data->dma_out >= 0) {
+            dma_channel_cleanup(bus_data->dma_out);
             dma_channel_unclaim(bus_data->dma_out);
             bus_data->dma_out = -1;
         }
         if (bus_data->dma_in >= 0) {
+            dma_channel_cleanup(bus_data->dma_in);
             dma_channel_unclaim(bus_data->dma_in);
             bus_data->dma_in = -1;
         }


### PR DESCRIPTION
cyw43 seems to be causing a dma channel interrupt to go off if the same channels are reused after cyw43 is deinitialised. Achnowledging them seems to fix it.

Fixes #1156

