### PR TITLE
Add "disable" functions for STA/AP modes

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/cyw43_arch.c
+++ b/src/rp2_common/pico_cyw43_arch/cyw43_arch.c
@@ -28,9 +28,20 @@ void cyw43_arch_set_async_context(async_context_t *context) {
     async_context = context;
 }
 
-void cyw43_arch_enable_sta_mode() {
+void cyw43_arch_enable_sta_mode(void) {
     assert(cyw43_is_initialized(&cyw43_state));
     cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, true, cyw43_arch_get_country_code());
+}
+
+void cyw43_arch_disable_sta_mode(void) {
+    assert(cyw43_is_initialized(&cyw43_state));
+    if (cyw43_state.itf_state & (1 << CYW43_ITF_STA)) {
+        cyw43_cb_tcpip_deinit(&cyw43_state, CYW43_ITF_STA);
+        cyw43_state.itf_state &= ~(1 << CYW43_ITF_STA);
+    }
+    if (cyw43_state.wifi_join_state) {
+        cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
+    }
 }
 
 void cyw43_arch_enable_ap_mode(const char *ssid, const char *password, uint32_t auth) {
@@ -48,6 +59,7 @@ void cyw43_arch_enable_ap_mode(const char *ssid, const char *password, uint32_t 
 void cyw43_arch_disable_ap_mode(void) {
     assert(cyw43_is_initialized(&cyw43_state));
     cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, false, cyw43_arch_get_country_code());
+    cyw43_state.itf_state &= ~(1 << CYW43_ITF_AP);
 }
 
 #if PICO_CYW43_ARCH_DEBUG_ENABLED

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -358,10 +358,19 @@ uint32_t cyw43_arch_get_country_code(void);
 void cyw43_arch_enable_sta_mode(void);
 
 /*!
+ * \brief Disables Wi-Fi STA (Station) mode.
+ * \ingroup pico_cyw43_arch
+ *
+ * This disables the Wi-Fi in \em Station mode, disconnecting any active connection.
+ * You should subsequently check the status by calling \ref cyw43_wifi_link_status.
+ */
+void cyw43_arch_disable_sta_mode(void);
+
+/*!
  * \brief Enables Wi-Fi AP (Access point) mode.
  * \ingroup pico_cyw43_arch
  *
- * This enables the Wi-Fi in \em Access \em Point mode such that connections can be made to the device by  other Wi-Fi clients
+ * This enables the Wi-Fi in \em Access \em Point mode such that connections can be made to the device by other Wi-Fi clients
  * \param ssid the name for the access point
  * \param password the password to use or NULL for no password.
  * \param auth the authorization type to use when the password is enabled. Values are \ref CYW43_AUTH_WPA_TKIP_PSK,


### PR DESCRIPTION
We have functions to "enable" STA/AP modes, so add versions that do the opposite.

Fixes #1371
