### PR TITLE
pico_lwip_arch fix

### DIFF
--- a/src/rp2_common/pico_lwip/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/CMakeLists.txt
@@ -264,7 +264,7 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
     pico_add_library(pico_lwip_arch NOFLAG)
     target_include_directories(pico_lwip_arch_headers INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/include)
-    target_link_libraries(pico_lwip_arch INTERFACE pico_rand)
+    pico_mirrored_target_link_libraries(pico_lwip_arch INTERFACE pico_rand)
 
     # our nosys impl
     pico_add_library(pico_lwip_nosys NOFLAG)


### PR DESCRIPTION
It should use pico_mirrored_target_link_libraries.

Fixes #1387
