### PR TITLE
pioasm: Add JSON output format for machine consumption

### DIFF
--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(pioasm
 target_sources(pioasm PRIVATE c_sdk_output.cpp)
 target_sources(pioasm PRIVATE python_output.cpp)
 target_sources(pioasm PRIVATE hex_output.cpp)
+target_sources(pioasm PRIVATE json_output.cpp)
 target_sources(pioasm PRIVATE ada_output.cpp)
 target_sources(pioasm PRIVATE ${PIOASM_EXTRA_SOURCE_FILES})
 

--- a/tools/pioasm/json_output.cpp
+++ b/tools/pioasm/json_output.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <algorithm>
+#include <iostream>
+#include "output_format.h"
+#include "pio_disassembler.h"
+
+struct json_output : public output_format {
+    struct factory {
+        factory() {
+            output_format::add(new json_output());
+        }
+    };
+
+    json_output() : output_format("json") {}
+
+    std::string get_description() override {
+        return "Machine-formatted output for integrating with external tools";
+    }
+
+    int output(std::string destination, std::vector<std::string> output_options,
+               const compiled_source &source) override {
+
+        for (const auto &program : source.programs) {
+            for(const auto &p : program.lang_opts) {
+                if (p.first.size() >= name.size() && p.first.compare(0, name.size(), name) == 0) {
+                    std::cerr << "warning: " << name << " does not support output options; " << p.first << " lang_opt ignored.\n";
+                }
+            }
+        }
+        FILE *out = open_single_output(destination);
+        if (!out) return 1;
+
+        fprintf(out, "{\n");
+        bool first = true;
+        // TODO: output symbols?
+
+        for (const auto &program : source.programs) {
+            // output trailing comma if necessary
+            if (!first) {
+                fprintf(out, ",\n");
+            } else {
+                first = false;
+            }
+
+            fprintf(out, "\t\"%s\": {\n", program.name.c_str());
+            fprintf(out, "\t\t\"wrap_target\": %d,\n", program.wrap_target);
+            fprintf(out, "\t\t\"wrap\": %d,\n", program.wrap);
+            fprintf(out, "\t\t\"origin\": %d,\n", program.origin.get());
+
+            if (program.sideset_bits_including_opt.is_specified()) {
+                fprintf(out, "\t\t\"sideset\": {\"size\": %d, \"optional\": %s, \"pindirs\": %s},\n", program.sideset_bits_including_opt.get(),
+                        program.sideset_opt ? "true" : "false",
+                        program.sideset_pindirs ? "true" : "false");
+            } else {
+                fprintf(out, "\t\t\"sideset\": {\"size\": 0, \"optional\": false, \"pindirs\": false},\n", program.origin.get());
+            }
+
+            fprintf(out, "\t\t\"instructions\": [\n");
+            bool first_inst = true;
+            for (int i = 0; i < (int)program.instructions.size(); i++) {
+                const auto &inst = program.instructions[i];
+                // output trailing comma if necessary
+                if (!first_inst) {
+                    fprintf(out, ",\n");
+                } else {
+                    first_inst = false;
+                }
+                fprintf(out, "\t\t\t{\"hex\": \"%04x\", \"index\": %d, \"disassembly\": \"%s\"}", inst, i,
+                        disassemble(inst, program.sideset_bits_including_opt.get(), program.sideset_opt).c_str());
+            }
+            fprintf(out, "\n");
+            fprintf(out, "\t\t]\n");
+            fprintf(out, "\t}");
+        }
+        fprintf(out, "\n}\n");
+        if (out != stdout) { fclose(out); }
+        return 0;
+    }
+};
+
+static json_output::factory creator;

--- a/tools/pioasm/json_output.cpp
+++ b/tools/pioasm/json_output.cpp
@@ -92,7 +92,7 @@ struct json_output : public output_format {
             }
             fprintf(out, "\t\t{\n");
 
-            fprintf(out, "%s\"name\": %s,\n", tabs, program.name.c_str());
+            fprintf(out, "%s\"name\": \"%s\",\n", tabs, program.name.c_str());
             fprintf(out, "%s\"wrapTarget\": %d,\n", tabs, program.wrap_target);
             fprintf(out, "%s\"wrap\": %d,\n", tabs, program.wrap);
             fprintf(out, "%s\"origin\": %d,\n", tabs, program.origin.get());


### PR DESCRIPTION
Fixes #1393

## Not included

 * Symbols and "code blocks". I wasn't sure if they were necessary in the JSON output
 * Instructions are one line, as I wanted to get feedback on this before pulling apart `pio_disassembler.cpp`


## Sample output

```json
{
	"publicSymbols": {
		"In_TOP": 9999
	},
	"programs": [
		{
			"name": "spi_gap0_sample1",
			"wrapTarget": 0,
			"wrap": 4,
			"origin": -1,
			"sideset": {"size": 1, "optional": false, "pindirs": false},
			"publicSymbols": {
			},
			"publicLabels": {
				"lp1_end": 2,
				"end": 5
			},
			"instructions": [
				{"hex": "6001"},
				{"hex": "1040"},
				{"hex": "E080"},
				{"hex": "5001"},
				{"hex": "0083"}
			]
		},
		{
			"name": "spi_gap01_sample0",
			"wrapTarget": 0,
			"wrap": 5,
			"origin": 5,
			"sideset": {"size": 1, "optional": false, "pindirs": false},
			"publicSymbols": {
				"This_is_a_number": 65500
			},
			"publicLabels": {
				"lp1_end": 2,
				"end": 6
			},
			"instructions": [
				{"hex": "6001"},
				{"hex": "1040"},
				{"hex": "E080"},
				{"hex": "B042"},
				{"hex": "4001"},
				{"hex": "1084"}
			]
		}
	]
}
```