### PR TITLE
[HUST CSE][rp2_common][pico_malloc.c]Modify to check if rc is a null pointer

### DIFF
--- a/src/rp2_common/pico_malloc/pico_malloc.c
+++ b/src/rp2_common/pico_malloc/pico_malloc.c
@@ -37,8 +37,13 @@ void *WRAPPER_FUNC(malloc)(size_t size) {
     mutex_exit(&malloc_mutex);
 #endif
 #if PICO_DEBUG_MALLOC
-    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
-        printf("malloc %d %p->%p\n", (uint) size, rc, ((uint8_t *) rc) + size);
+    if (!rc) 
+    {
+        printf("malloc %d failed to allocate memory\n", (uint) (count * size));
+    } 
+    else if (((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) 
+    {
+        printf("malloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
     }
 #endif
     check_alloc(rc, size);
@@ -54,7 +59,12 @@ void *WRAPPER_FUNC(calloc)(size_t count, size_t size) {
     mutex_exit(&malloc_mutex);
 #endif
 #if PICO_DEBUG_MALLOC
-    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
+   if (!rc) 
+    {
+        printf("calloc %d failed to allocate memory\n", (uint) (count * size));
+    } 
+    else if (((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) 
+    {
         printf("calloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
     }
 #endif
@@ -71,8 +81,13 @@ void *WRAPPER_FUNC(realloc)(void *mem, size_t size) {
     mutex_exit(&malloc_mutex);
 #endif
 #if PICO_DEBUG_MALLOC
-    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
-        printf("realloc %p %d->%p\n", mem, (uint) size, rc);
+   if (!rc) 
+    {
+        printf("realloc %d failed to allocate memory\n", (uint) (count * size));
+    } 
+    else if (((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) 
+    {
+        printf("realloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
     }
 #endif
     check_alloc(rc, size);


### PR DESCRIPTION
    The code on lines 41, 58, and 75 of this code may attempt to convert a null pointer to a uint8_t* type and attempt to perform an addition operation on top of that pointer. This behavior is undefined, and the undefined result depends on the specific compiler and runtime environment. In some cases, this may cause the program to crash.
    In this modified version, we first check if rc is NULL. if rc is NULL, we print a message stating that calloc failed to allocate the required memory. Only if rc is not NULL do we attempt pointer arithmetic and proceed to the next conditional step. This avoids undefined pointer operations when rc is NULL.
    The issue of this pr is Fixes #1397 