### PR TITLE
Update pio_disassembler.h

### DIFF
--- a/tools/pioasm/pio_disassembler.h
+++ b/tools/pioasm/pio_disassembler.h
@@ -10,6 +10,7 @@
 #ifdef __cplusplus
 
 #include <string>
+#include <cstdint>
 
 typedef unsigned int uint;
 


### PR DESCRIPTION
without this line i couldnt build any projects using pico_cyw43_arch_none i get an error saying i need to add this line. so i added it and the error is gone. (this error happened on arch linux)