### PR TITLE
Fix waveshare_rp2040_zero USB unrecognize after unplug and replug

### DIFF
--- a/src/boards/include/boards/waveshare_rp2040_zero.h
+++ b/src/boards/include/boards/waveshare_rp2040_zero.h
@@ -64,7 +64,7 @@
 #define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
 
 #ifndef PICO_FLASH_SPI_CLKDIV
-#define PICO_FLASH_SPI_CLKDIV 2
+#define PICO_FLASH_SPI_CLKDIV 4
 #endif
 
 #ifndef PICO_FLASH_SIZE_BYTES
@@ -72,7 +72,7 @@
 #endif
 
 // All boards have B1 RP2040
-#ifndef PICO_RP2040_B0_SUPPORTED 
+#ifndef PICO_RP2040_B0_SUPPORTED
 #define PICO_RP2040_B0_SUPPORTED  0
 #endif
 


### PR DESCRIPTION
Some RP2040-Zero boards from WaveShare can only be recognized via USB after flashing UF2 into it, and if you unplug and replug it, nothing happens on both USB host and device, RP2040-Zero seems just not booting.

According to @ArkBrj, it seems that setting `PICO_FLASH_SPI_CLKDIV` to `2` makes the clock chip exceed the spec, setting it to `4` fixes this bug.

I tested it with the blink program in pico-examples, this does fix the bug for me.

Fixes <https://github.com/raspberrypi/pico-sdk/issues/1304>.

This also has a minor change to remove a trailing space by my editor.