### PR TITLE
Add a cmake function for setting IP addresses

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -89,5 +89,32 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
                 )
     endif()
 
+    # Set an ip address in a compile definition
+    # target name, target type, compile definition name to set then address in a string
+    # This can be used to set the following compile definitions
+    # CYW43_DEFAULT_IP_ADDRESS
+    # CYW43_DEFAULT_IP_MASK
+    # CYW43_DEFAULT_IP_GATEWAY
+    # CYW43_DEFAULT_IP_DNS
+    # CYW43_DEFAULT_AP_IP_ADDRESS
+    # e.g. pico_configure_ip4_address(picow_tcpip_server_background PRIVATE CYW43_DEFAULT_IP_ADDRESS "10.3.15.204")
+    function(pico_configure_ip4_address TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
+            string(REGEX MATCHALL "[0-9]+" IP_ADDRESS_LIST ${IP_ADDRESS_STR})
+            list(LENGTH IP_ADDRESS_LIST IP_ADDRESS_COMPONENT_COUNT)
+            if (NOT ${IP_ADDRESS_COMPONENT_COUNT} EQUAL 4)
+                    message(FATAL_ERROR "wrong number of components in ip address 4 != ${IP_ADDRESS_COMPONENT_COUNT}")
+            endif()
+            set(IP_ADDRESS_HEX "0x0")
+            foreach(IP_COMPONENT ${IP_ADDRESS_LIST})
+                    if (${IP_COMPONENT} GREATER 255)
+                            message(FATAL_ERROR "ip address component too big ${IP_COMPONENT} > 255")
+                    endif()
+                    math(EXPR IP_ADDRESS_HEX "(${IP_ADDRESS_HEX} << 8 ) | ${IP_COMPONENT}" OUTPUT_FORMAT HEXADECIMAL)
+            endforeach()
+            target_compile_definitions(${TARGET_LIB} ${TARGET_TYPE}
+                    ${DEF_NAME}=${IP_ADDRESS_HEX}
+                    )
+    endfunction()
+
     pico_promote_common_scope_vars()
 endif()


### PR DESCRIPTION
The fix for the following issue adds some macros to set default ip addresses. These are expressed in hex which is a bit non-obvious to set. So add a macro to convert from a string to the hex representation.

https://github.com/georgerobotics/cyw43-driver/issues/41
