### PR TITLE
Move multicore_lockout victim initialzied tracking to pico_multicore

### DIFF
--- a/src/rp2_common/pico_multicore/include/pico/multicore.h
+++ b/src/rp2_common/pico_multicore/include/pico/multicore.h
@@ -257,6 +257,18 @@ static inline uint32_t multicore_fifo_get_status(void) {
  */
 void multicore_lockout_victim_init(void);
 
+/*! \brief Determine if \ref multicore_victim_init() has been called on the specified core.
+ *  \ingroup multicore_lockout
+ *
+ * \note this state persists even if the core is subsequently reset; therefore you are advised to
+ * always call \ref multicore_lockout_victim_init() again after resetting a core, which had previously
+ * been initialized.
+ *
+ * \param core_num the core number (0 or 1)
+ * \return true if \ref multicore_victim_init() has been called on the specified core, false otherwise.
+ */
+bool multicore_lockout_victim_is_initialized(uint core_num);
+
 /*! \brief Request the other core to pause in a known state and wait for it to do so
  *  \ingroup multicore_lockout
  *

--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -16,7 +16,7 @@
 #endif
 
 // note that these are not reset by core reset, however for now, I think people resetting cores
-// and then doing this again without re-initializing pico_flash for that core, is probably
+// and then relying on multicore_lockout for that core without re-initializing, is probably
 // something we can live with breaking.
 //
 // whilst we could clear this in core 1 reset path, that doesn't necessarily catch all,

--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -15,6 +15,14 @@
 #include "pico/runtime.h"
 #endif
 
+// note that these are not reset by core reset, however for now, I think people resetting cores
+// and then doing this again without re-initializing pico_flash for that core, is probably
+// something we can live with breaking.
+//
+// whilst we could clear this in core 1 reset path, that doesn't necessarily catch all,
+// and means pulling in this array even if multicore_lockout is not used.
+static bool lockout_victim_initialized[NUM_CORES];
+
 static inline void multicore_fifo_push_blocking_inline(uint32_t data) {
     // We wait for the fifo to have some space
     while (!multicore_fifo_wready())
@@ -201,6 +209,7 @@ void multicore_lockout_victim_init(void) {
     uint core_num = get_core_num();
     irq_set_exclusive_handler(SIO_IRQ_PROC0 + core_num, multicore_lockout_handler);
     irq_set_enabled(SIO_IRQ_PROC0 + core_num, true);
+    lockout_victim_initialized[core_num] = true;
 }
 
 static bool multicore_lockout_handshake(uint32_t magic, absolute_time_t until) {
@@ -268,6 +277,10 @@ bool multicore_lockout_end_timeout_us(uint64_t timeout_us) {
     return multicore_lockout_end_block_until(make_timeout_time_us(timeout_us));
 }
 
-void multicore_lockout_end_blocking() {
+void multicore_lockout_end_blocking(void) {
     multicore_lockout_end_block_until(at_the_end_of_time);
+}
+
+bool multicore_lockout_victim_is_initialized(uint core_num) {
+    return lockout_victim_initialized[core_num];
 }


### PR DESCRIPTION
Added new  multicore_lockout_victim_is_initialzied method, so user initialization of the multicore_lockout independent of pico_flash will work with pico_flash