### PR TITLE
Fix boot2_is25lp080.S section naming

### DIFF
--- a/src/rp2_common/boot_stage2/boot2_is25lp080.S
+++ b/src/rp2_common/boot_stage2/boot2_is25lp080.S
@@ -82,7 +82,7 @@
 
 pico_default_asm_setup
 
-.section text
+.section .text
 regular_func _stage2_boot
     push {lr}
 


### PR DESCRIPTION
When the BOOT2.S files were updated, the section name in the IS25LP080 code was set to "text" and not ".text".

The missing "." causes the actual boot code to be thrown out since the rest of the infrastructure expects "section .text" and not "section text"

Re-add the missing period.

Fixes #1429 