### PR TITLE
Fix #1442: Allow adding alternative .gatt file import paths 

### DIFF
--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -232,8 +232,7 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
 
     # Make a GATT header file from a BTstack GATT file
     # Pass the target library name library type and path to the GATT input file
-    # To add additional directories to the gatt #import path, one "[custom_path]"
-    # argument for each custom_path to the end of the argument list.
+    # To add additional directories to the gatt #import path, add them to the end of the argument list.
     function(pico_btstack_make_gatt_header TARGET_LIB TARGET_TYPE GATT_FILE)
             find_package (Python3 REQUIRED COMPONENTS Interpreter)
             get_filename_component(GATT_NAME "${GATT_FILE}" NAME_WE)

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -238,21 +238,17 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
             find_package (Python3 REQUIRED COMPONENTS Interpreter)
             get_filename_component(GATT_NAME "${GATT_FILE}" NAME_WE)
             get_filename_component(GATT_PATH "${GATT_FILE}" PATH)
-            set(GATT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
-            set(GATT_HEADER "${GATT_BINARY_DIR}/${GATT_NAME}.h")
             set(TARGET_GATT "${TARGET_LIB}_gatt_header")
-            set (ExtraGattPaths "")
-            foreach(arg IN LISTS ARGN)
-                string(PREPEND arg "-I")
-                string(APPEND ExtraGattPaths ${arg} " ")
-            endforeach()
+            set(GATT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/${TARGET_GATT}")
+            set(GATT_HEADER "${GATT_BINARY_DIR}/${GATT_NAME}.h")
+            list(TRANSFORM ARGN PREPEND "-I")
             add_custom_target(${TARGET_GATT} DEPENDS ${GATT_HEADER})
             add_custom_command(
                     OUTPUT ${GATT_HEADER}
                     DEPENDS ${GATT_FILE}
                     WORKING_DIRECTORY ${GATT_PATH}
                     COMMAND ${CMAKE_COMMAND} -E make_directory ${GATT_BINARY_DIR} &&
-                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ExtraGattPaths}
+                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ARGN}
                     VERBATIM)
             add_dependencies(${TARGET_LIB}
                     ${TARGET_GATT}

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -232,6 +232,8 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
 
     # Make a GATT header file from a BTstack GATT file
     # Pass the target library name library type and path to the GATT input file
+    # To add additional directories to the gatt #import path, one "-I[custom_path]"
+    # argument for each custom_path to the end of the argument list.
     function(pico_btstack_make_gatt_header TARGET_LIB TARGET_TYPE GATT_FILE)
             find_package (Python3 REQUIRED COMPONENTS Interpreter)
             get_filename_component(GATT_NAME "${GATT_FILE}" NAME_WE)
@@ -246,7 +248,7 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
                     DEPENDS ${GATT_FILE}
                     WORKING_DIRECTORY ${GATT_PATH}
                     COMMAND ${CMAKE_COMMAND} -E make_directory ${GATT_BINARY_DIR} &&
-                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER}
+                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ARGN}
                     VERBATIM)
             add_dependencies(${TARGET_LIB}
                     ${TARGET_GATT}

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -232,7 +232,7 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
 
     # Make a GATT header file from a BTstack GATT file
     # Pass the target library name library type and path to the GATT input file
-    # To add additional directories to the gatt #import path, one "-I[custom_path]"
+    # To add additional directories to the gatt #import path, one "[custom_path]"
     # argument for each custom_path to the end of the argument list.
     function(pico_btstack_make_gatt_header TARGET_LIB TARGET_TYPE GATT_FILE)
             find_package (Python3 REQUIRED COMPONENTS Interpreter)
@@ -241,14 +241,18 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
             set(GATT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
             set(GATT_HEADER "${GATT_BINARY_DIR}/${GATT_NAME}.h")
             set(TARGET_GATT "${TARGET_LIB}_gatt_header")
-
+            set (ExtraGattPaths "")
+            foreach(arg IN LISTS ARGN)
+                string(PREPEND arg "-I")
+                string(APPEND ExtraGattPaths ${arg} " ")
+            endforeach()
             add_custom_target(${TARGET_GATT} DEPENDS ${GATT_HEADER})
             add_custom_command(
                     OUTPUT ${GATT_HEADER}
                     DEPENDS ${GATT_FILE}
                     WORKING_DIRECTORY ${GATT_PATH}
                     COMMAND ${CMAKE_COMMAND} -E make_directory ${GATT_BINARY_DIR} &&
-                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ARGN}
+                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ExtraGattPaths}
                     VERBATIM)
             add_dependencies(${TARGET_LIB}
                     ${TARGET_GATT}


### PR DESCRIPTION
This fix uses the `ARGN` symbol in CMake to extend the number of arguments you can add to `pico_btstack_make_gatt_header()`. The additional arguments should be of the form `-I${Include path}` so the Python script can find your custom `#import <my_gatt.gatt>` files.
