### PR TITLE
Disable FIFO IRQ when doing reset of core1 (same as with launching)

### DIFF
--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -122,6 +122,7 @@ void multicore_reset_core1() {
     // check the pushed value
     uint32_t value = multicore_fifo_pop_blocking();
     assert(value == 0);
+    (void) value; // silence warning
 
     // restore interrupt state
     irq_set_enabled(SIO_IRQ_PROC0, enabled);


### PR DESCRIPTION
Adds code to disable `SIO_IRQ_PROC0` when calling `multicore_reset_core1`. Analogous behaviour to `multicore_launch_core1_raw`.

Fixes #1446.
