### PR TITLE
Improved const correctness of rtc functions

### DIFF
--- a/src/rp2_common/hardware_rtc/include/hardware/rtc.h
+++ b/src/rp2_common/hardware_rtc/include/hardware/rtc.h
@@ -54,7 +54,7 @@ void rtc_init(void);
  * \param t Pointer to a \ref datetime_t structure contains time to set
  * \return true if set, false if the passed in datetime was invalid.
  */
-bool rtc_set_datetime(datetime_t *t);
+bool rtc_set_datetime(const datetime_t *t);
 
 /*! \brief Get the current time from the RTC
  *  \ingroup hardware_rtc
@@ -76,7 +76,7 @@ bool rtc_running(void);
  *  \param t Pointer to a \ref datetime_t structure containing a time in the future to fire the alarm. Any values set to -1 will not be matched on.
  *  \param user_callback pointer to a \ref rtc_callback_t to call when the alarm fires
  */
-void rtc_set_alarm(datetime_t *t, rtc_callback_t user_callback);
+void rtc_set_alarm(const datetime_t *t, rtc_callback_t user_callback);
 
 /*! \brief Enable the RTC alarm (if inactive)
  *  \ingroup hardware_rtc

--- a/src/rp2_common/hardware_rtc/rtc.c
+++ b/src/rp2_common/hardware_rtc/rtc.c
@@ -39,7 +39,7 @@ void rtc_init(void) {
     rtc_hw->clkdiv_m1 = rtc_freq;
 }
 
-static bool valid_datetime(datetime_t *t) {
+static bool valid_datetime(const datetime_t *t) {
     // Valid ranges taken from RTC doc. Note when setting an RTC alarm
     // these values are allowed to be -1 to say "don't match this value"
     if (!(t->year >= 0 && t->year <= 4095)) return false;
@@ -52,7 +52,7 @@ static bool valid_datetime(datetime_t *t) {
     return true;
 }
 
-bool rtc_set_datetime(datetime_t *t) {
+bool rtc_set_datetime(const datetime_t *t) {
     if (!valid_datetime(t)) {
         return false;
     }
@@ -131,7 +131,7 @@ static void rtc_irq_handler(void) {
     }
 }
 
-static bool rtc_alarm_repeats(datetime_t *t) {
+static bool rtc_alarm_repeats(const datetime_t *t) {
     // If any value is set to -1 then we don't match on that value
     // hence the alarm will eventually repeat
     if (t->year  < 0) return true;
@@ -144,7 +144,7 @@ static bool rtc_alarm_repeats(datetime_t *t) {
     return false;
 }
 
-void rtc_set_alarm(datetime_t *t, rtc_callback_t user_callback) {
+void rtc_set_alarm(const datetime_t *t, rtc_callback_t user_callback) {
     rtc_disable_alarm();
 
     // Only add to setup if it isn't -1


### PR DESCRIPTION
This PR fixes #1454 by adding `const` qualifiers to the `datetime_t *` argument of various RTC functions which do not modify the parameter. I have encountered this issue in my personal and professional projects, and it leads to a lot of `static_cast`-ing in C++ projects.
