### PR TITLE
Add gpio_set_function_mask function

### DIFF
--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -262,3 +262,11 @@ void gpio_init_mask(uint gpio_mask) {
     }
 }
 
+void gpio_set_function_mask(uint gpio_mask, enum gpio_function fn) {
+    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
+        if (gpio_mask & 1) {
+            gpio_set_function(i, fn);
+        }
+        gpio_mask >>= 1;
+    }
+}

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -185,6 +185,15 @@ static inline void check_gpio_param(__unused uint gpio) {
  */
 void gpio_set_function(uint gpio, enum gpio_function fn);
 
+/*! \brief Select the function for multiple GPIOs
+ *  \ingroup hardware_gpio
+ *
+ * \sa gpio_set_function
+ * \param gpio_mask Mask with 1 bit per GPIO number to set the function for
+ * \param fn Which GPIO function select to use from list \ref gpio_function 
+*/
+void gpio_set_function_mask(uint gpio_mask, enum gpio_function fn);
+
 /*! \brief Determine current GPIO function
  *  \ingroup hardware_gpio
  *

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -190,7 +190,7 @@ void gpio_set_function(uint gpio, enum gpio_function fn);
  *
  * \sa gpio_set_function
  * \param gpio_mask Mask with 1 bit per GPIO number to set the function for
- * \param fn Which GPIO function select to use from list \ref gpio_function 
+ * \param fn Which GPIO function select to use from list \ref gpio_function
 */
 void gpio_set_function_mask(uint gpio_mask, enum gpio_function fn);
 


### PR DESCRIPTION
Similar to gpio_init_mask, gpio_set_function_mask allows setting multiple GPIO functions with one call.