### PR TITLE
Fix: Pad the hour field with leading zeros in datetime_to_str()

### DIFF
--- a/src/common/pico_util/datetime.c
+++ b/src/common/pico_util/datetime.c
@@ -30,7 +30,7 @@ static const char *DATETIME_DOWS[7] = {
 void datetime_to_str(char *buf, uint buf_size, const datetime_t *t) {
     snprintf(buf,
              buf_size,
-             "%s %d %s %d:%02d:%02d %d",
+             "%s %d %s %02d:%02d:%02d %d",
              DATETIME_DOWS[t->dotw],
              t->day,
              DATETIME_MONTHS[t->month - 1],


### PR DESCRIPTION
In the datetime_to_str() function, the hour field was not zero-padded while other time fields (minutes and seconds) were padded with leading zeros. This caused a lack of visual consistency in the output, potentially leading to confusion in interpreting the data.

This commit fixes the issue by adding zero-padding to the hour field, ensuring a consistent and easily readable datetime format.