### PR TITLE
Fix documentation for gpio_set_irq_enabled

### DIFF
--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -370,7 +370,7 @@ enum gpio_drive_strength gpio_get_drive_strength(uint gpio);
  * Events is a bitmask of the following \ref gpio_irq_level values:
  *
  * bit | constant            | interrupt
- * ----|----------------------------------------------------------
+ * ----|---------------------|------------------------------------
  *   0 | GPIO_IRQ_LEVEL_LOW  | Continuously while level is low
  *   1 | GPIO_IRQ_LEVEL_HIGH | Continuously while level is high
  *   2 | GPIO_IRQ_EDGE_FALL  | On each transition from high to low


### PR DESCRIPTION
Add missing column separator for the table of gpio_irq_level values.

Without this, the table does not render properly in the documentation, see https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#rpip536c200e4b39640e0bd5

Fixes https://github.com/raspberrypi/pico-sdk/issues/1469
