### PR TITLE
tools: fix cmake deprecation warnings

### DIFF
--- a/tools/elf2uf2/CMakeLists.txt
+++ b/tools/elf2uf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 project(elf2uf2)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.13)
 project(pioasm CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
When running a project build against Pico C/C++ SDK on a Fedora 38 development machine with

~~~sh
$ cmake --version
cmake version 3.27.2
~~~

you get deprecation warnings for the `tools` sub-directory

~~~
...
[13/108] Performing configure step for 'PioasmBuild'
loading initial cache file /[REDACTED]/build/pico-sdk/src/rp2_common/pico_cyw43_driver/pioasm/tmp/PioasmBuild-cache-Release.cmake
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
...
~~~

Raising the minimum CMake version to the same version as is already required in the top-level `CMakeLists.txt` removes the build warning.