### PR TITLE
PioAsm: Add a maximum version to supported CMake versions to avoid deprecation warning

### DIFF
--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...3.27)
 project(pioasm CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
CMake introduced a deprecation warning lately. PioAsm's CMakeLists file triggers it and is easy to fix.

Fixes #1483 