### PR TITLE
Adding I2C Burst Reading/Writing feature

### DIFF
--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -131,7 +131,7 @@ void i2c_set_slave_mode(i2c_inst_t *i2c, bool slave, uint8_t addr) {
 }
 
 static int i2c_write_blocking_internal(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop,
-                                       check_timeout_fn timeout_check, struct timeout_state *ts) {
+                                       check_timeout_fn timeout_check, struct timeout_state *ts, bool burst) {
     invalid_params_if(HARDWARE_I2C, addr >= 0x80); // 7-bit addresses
     invalid_params_if(HARDWARE_I2C, i2c_reserved_addr(addr));
     // Synopsys hw accepts start/stop flags alongside data items in the same
@@ -238,29 +238,33 @@ static int i2c_write_blocking_internal(i2c_inst_t *i2c, uint8_t addr, const uint
     }
 
     // nostop means we are now at the end of a *message* but not the end of a *transfer*
-    i2c->restart_on_next = nostop;
+    i2c->restart_on_next = burst ? false : nostop;
     return rval;
 }
 
 int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop) {
-    return i2c_write_blocking_internal(i2c, addr, src, len, nostop, NULL, NULL);
+    return i2c_write_blocking_internal(i2c, addr, src, len, nostop, NULL, NULL, false);
 }
 
 int i2c_write_blocking_until(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop,
                              absolute_time_t until) {
     timeout_state_t ts;
-    return i2c_write_blocking_internal(i2c, addr, src, len, nostop, init_single_timeout_until(&ts, until), &ts);
+    return i2c_write_blocking_internal(i2c, addr, src, len, nostop, init_single_timeout_until(&ts, until), &ts, false);
 }
 
 int i2c_write_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop,
                                   uint timeout_per_char_us) {
     timeout_state_t ts;
     return i2c_write_blocking_internal(i2c, addr, src, len, nostop,
-                                       init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts);
+                                       init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts, false);
+}
+
+int i2c_write_blocking_burst_mode(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len) {
+    return i2c_write_blocking_internal(i2c, addr, src, len, true, NULL, NULL, true);
 }
 
 static int i2c_read_blocking_internal(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop,
-                               check_timeout_fn timeout_check, timeout_state_t *ts) {
+                               check_timeout_fn timeout_check, timeout_state_t *ts, bool burst) {
     invalid_params_if(HARDWARE_I2C, addr >= 0x80); // 7-bit addresses
     invalid_params_if(HARDWARE_I2C, i2c_reserved_addr(addr));
     invalid_params_if(HARDWARE_I2C, len == 0);
@@ -322,22 +326,26 @@ static int i2c_read_blocking_internal(i2c_inst_t *i2c, uint8_t addr, uint8_t *ds
         rval = byte_ctr;
     }
 
-    i2c->restart_on_next = nostop;
+    i2c->restart_on_next = burst ? false : nostop;
     return rval;
 }
 
 int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop) {
-    return i2c_read_blocking_internal(i2c, addr, dst, len, nostop, NULL, NULL);
+    return i2c_read_blocking_internal(i2c, addr, dst, len, nostop, NULL, NULL, false);
 }
 
 int i2c_read_blocking_until(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop, absolute_time_t until) {
     timeout_state_t ts;
-    return i2c_read_blocking_internal(i2c, addr, dst, len, nostop, init_single_timeout_until(&ts, until), &ts);
+    return i2c_read_blocking_internal(i2c, addr, dst, len, nostop, init_single_timeout_until(&ts, until), &ts, false);
 }
 
 int i2c_read_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop,
                                  uint timeout_per_char_us) {
     timeout_state_t ts;
     return i2c_read_blocking_internal(i2c, addr, dst, len, nostop,
-                                      init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts);
+                                      init_per_iteration_timeout_us(&ts, timeout_per_char_us), &ts, false);
+}
+
+int i2c_read_blocking_burst_mode(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len) {
+    return i2c_read_blocking_internal(i2c, addr, dst, len, true, NULL, NULL, true);
 }

--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -329,7 +329,7 @@ int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t
  * \param len Length of data in bytes to receive
  * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged or no device present.
  */
-int i2c_write_blocking_burst_mode(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len);
+int i2c_write_burst_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len);
 
 /*! \brief  Attempt to read specified number of bytes from address, blocking
  *  \ingroup hardware_i2c
@@ -357,7 +357,7 @@ int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, b
  * \param len Length of data in bytes to receive
  * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged or no device present.
  */
-int i2c_read_blocking_burst_mode(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len);
+int i2c_read_burst_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len);
 
 /*! \brief Determine non-blocking write space available
  *  \ingroup hardware_i2c

--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -316,6 +316,21 @@ int i2c_read_timeout_per_char_us(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, si
  */
 int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len, bool nostop);
 
+/*! \brief Attempt to write specified number of bytes to address, blocking in burst mode
+ *  \ingroup hardware_i2c
+ *
+ * This version of the function will not issue a stop and will not restart on the next write.
+ * This allows you to write consecutive bytes of data without having to resend a stop bit and
+ * (for example) without having to send address byte(s) repeatedly
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 7-bit address of device to read from
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged or no device present.
+ */
+int i2c_write_blocking_burst_mode(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t len);
+
 /*! \brief  Attempt to read specified number of bytes from address, blocking
  *  \ingroup hardware_i2c
  *
@@ -329,6 +344,20 @@ int i2c_write_blocking(i2c_inst_t *i2c, uint8_t addr, const uint8_t *src, size_t
  */
 int i2c_read_blocking(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len, bool nostop);
 
+/*! \brief  Attempt to read specified number of bytes from address, blocking in burst mode
+ *  \ingroup hardware_i2c
+ *
+ * This version of the function will not issue a stop and will not restart on the next read.
+ * This allows you to read consecutive bytes of data without having to resend a stop bit and
+ * (for example) without having to send address byte(s) repeatedly
+ *
+ * \param i2c Either \ref i2c0 or \ref i2c1
+ * \param addr 7-bit address of device to read from
+ * \param dst Pointer to buffer to receive data
+ * \param len Length of data in bytes to receive
+ * \return Number of bytes read, or PICO_ERROR_GENERIC if address not acknowledged or no device present.
+ */
+int i2c_read_blocking_burst_mode(i2c_inst_t *i2c, uint8_t addr, uint8_t *dst, size_t len);
 
 /*! \brief Determine non-blocking write space available
  *  \ingroup hardware_i2c


### PR DESCRIPTION
I realize that the C-SDK of Raspberry Pi Pico does not support the burst mode operation in I2C (only supports normal and repeated start in reading/writing). As burst mode is an important I2C feature that is sometimes required in communication with several I2C slaves. e.g. MAX3010X. Hopefully, we can consider adding this feature to the current SDK.

Thank you
