### PR TITLE
Resolve #1506 by adding CMake policy CMP0057

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install cmake
-          brew tap ArmMbed/homebrew-formulae
-          brew install arm-none-eabi-gcc
+          brew install --cask gcc-arm-embedded
 
       - name: Build Project
         # bash required otherwise this mysteriously (no error) fails at "Generating cyw43_bus_pio_spi.pio.h"

--- a/pico_sdk_init.cmake
+++ b/pico_sdk_init.cmake
@@ -6,6 +6,8 @@
 # same directory)
 
 if (NOT TARGET _pico_sdk_pre_init_marker)
+    cmake_policy(SET CMP0057 NEW) # allow use of if() IN_LIST
+    
     add_library(_pico_sdk_pre_init_marker INTERFACE)
 
     function(pico_is_top_level_project VAR)

--- a/pico_sdk_version.cmake
+++ b/pico_sdk_version.cmake
@@ -6,10 +6,10 @@ set(PICO_SDK_VERSION_MAJOR 1)
 set(PICO_SDK_VERSION_MINOR 5)
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_REVISION, SDK version revision, type=int, group=pico_base
 # PICO_CMAKE_CONFIG: PICO_SDK_VERSION_REVISION, SDK version revision, type=int, group=pico_base
-set(PICO_SDK_VERSION_REVISION 1)
+set(PICO_SDK_VERSION_REVISION 2)
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_PRE_RELEASE_ID, optional SDK pre-release version identifier, type=string, group=pico_base
 # PICO_CMAKE_CONFIG: PICO_SDK_VERSION_PRE_RELEASE_ID, optional SDK pre-release version identifier, type=string, group=pico_base
-#set(PICO_SDK_VERSION_PRE_RELEASE_ID develop)
+set(PICO_SDK_VERSION_PRE_RELEASE_ID develop)
 
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_STRING, SDK version, type=string, group=pico_base
 # PICO_CMAKE_CONFIG: PICO_SDK_VERSION_STRING, SDK version, type=string, group=pico_base

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -334,7 +334,6 @@ static void alarm_pool_dump_key(pheap_node_id_t id, void *user_data) {
 
 static int64_t repeating_timer_callback(__unused alarm_id_t id, void *user_data) {
     repeating_timer_t *rt = (repeating_timer_t *)user_data;
-    assert(rt->alarm_id == id);
     if (rt->callback(rt)) {
         return rt->delay_us;
     } else {

--- a/src/rp2_common/boot_stage2/boot2_is25lp080.S
+++ b/src/rp2_common/boot_stage2/boot2_is25lp080.S
@@ -82,7 +82,7 @@
 
 pico_default_asm_setup
 
-.section text
+.section .text
 regular_func _stage2_boot
     push {lr}
 

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -370,7 +370,7 @@ enum gpio_drive_strength gpio_get_drive_strength(uint gpio);
  * Events is a bitmask of the following \ref gpio_irq_level values:
  *
  * bit | constant            | interrupt
- * ----|----------------------------------------------------------
+ * ----|---------------------|------------------------------------
  *   0 | GPIO_IRQ_LEVEL_LOW  | Continuously while level is low
  *   1 | GPIO_IRQ_LEVEL_HIGH | Continuously while level is high
  *   2 | GPIO_IRQ_EDGE_FALL  | On each transition from high to low

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -118,7 +118,7 @@ typedef void *(*rom_table_lookup_fn)(uint16_t *table, uint32_t code);
 
 #if PICO_C_COMPILER_IS_GNU && (__GNUC__ >= 12)
 // Convert a 16 bit pointer stored at the given rom address into a 32 bit pointer
-static inline void *rom_hword_as_ptr(uint16_t rom_address) {
+static __force_inline void *rom_hword_as_ptr(uint16_t rom_address) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
     return (void *)(uintptr_t)*(uint16_t *)(uintptr_t)rom_address;

--- a/tools/elf2uf2/CMakeLists.txt
+++ b/tools/elf2uf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 project(elf2uf2)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.13)
 project(pioasm CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Fixes #1506.

Adds CMake policy CMP0057 to `pico_sdk_init.cmake` to allow use of `if() IN_LIST`.