### PR TITLE
Resolve #1506 by adding CMake policy CMP0057

### DIFF
--- a/pico_sdk_init.cmake
+++ b/pico_sdk_init.cmake
@@ -6,6 +6,8 @@
 # same directory)
 
 if (NOT TARGET _pico_sdk_pre_init_marker)
+    cmake_policy(SET CMP0057 NEW) # allow use of if() IN_LIST
+    
     add_library(_pico_sdk_pre_init_marker INTERFACE)
 
     function(pico_is_top_level_project VAR)


### PR DESCRIPTION
Fixes https://github.com/raspberrypi/pico-sdk/issues/1506.

Adds CMake policy CMP0057 to pico_sdk_init.cmake to allow use of if() IN_LIST.