### PR TITLE
Some useful macros for ADC module

### DIFF
--- a/src/rp2_common/hardware_adc/include/hardware/adc.h
+++ b/src/rp2_common/hardware_adc/include/hardware/adc.h
@@ -49,6 +49,12 @@
 #define PARAM_ASSERTIONS_ENABLED_ADC 0
 #endif
 
+#define ADC_REFERENCE_VOLTAGE 3.3
+#define ADC_MAX 4095
+
+/* Converts GPIO pin number to ADC channel */
+#define ADC_PIN_TO_CHANNEL(Pin) ((Pin) - (26))
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Implementation of 2 simple values related to ADC (reference voltage and max read value) that make calculations of actual voltage readings easier.

Also, since there is a linear relationship between ADC channels and GPIO pins connected to ADC, a simple conversion macro can be added to convert (redefined) GPIO pins number from any configuration list to an ADC channel related to them.

Fixes #1512 
