### PR TITLE
Add cyw43_spi_set_clock_divisor() to allow CYW43 to work with over/underclocked RP2040

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -497,6 +497,25 @@ void cyw43_arch_gpio_put(uint wl_gpio, bool value);
  */
 bool cyw43_arch_gpio_get(uint wl_gpio);
 
+#if CYW43_USE_SPI
+/*!
+ * \brief Adjust the SPI clock divisor to support over/underclocking the RP2040
+ * \ingroup pico_cyw43_arch
+ * 
+ * Altering the RP2040 system clock can cause glitches or outright failure in SPI
+ * communication with the WiFi/Bluetooth processor.  This method allows the user to
+ * alter to default SPI clock divisor of 2.0 to something that will allow proper communication
+ * of the CYW43 chip i.e. (1,0) for underclocking or (4,0) for overclocking.
+ * 
+ * \note The default SPI clock divisor is (2,0).  This method does not check for validity 
+ * of the supplied parameters.
+ *
+ * \param divisor the integer part of the SPI clock divisor
+ * \param divisor the fractional part of the SPI clock divisor
+ */
+void cyw43_spi_set_clock_divisor(int divisor,int fraction);
+#endif 
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -513,7 +513,7 @@ bool cyw43_arch_gpio_get(uint wl_gpio);
  * \param divisor the integer part of the SPI clock divisor
  * \param divisor the fractional part of the SPI clock divisor
  */
-void cyw43_spi_set_clock_divisor(int divisor,int fraction);
+void cyw43_set_pio_clock_divisor(int divisor,int fraction);
 #endif 
 
 #ifdef __cplusplus

--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -84,6 +84,16 @@ typedef struct {
 
 static bus_data_t bus_data_instance;
 
+int cyw43_spi_clock_div_int = CLOCK_DIV;
+int cyw43_spi_clock_div_frac = CLOCK_DIV_MINOR;
+
+// Allow the user to adjust the SPI clock speed 
+// prior to initialization.
+void cyw43_spi_set_clock_divisor(int clock_div_int, int clock_div_frac) {
+    cyw43_spi_clock_div_int = clock_div_int;
+    cyw43_spi_clock_div_frac = clock_div_frac;
+}
+
 int cyw43_spi_init(cyw43_int_t *self) {
     // Only does something if CYW43_LOGIC_DEBUG=1
     logic_debug_init();
@@ -117,7 +127,8 @@ int cyw43_spi_init(cyw43_int_t *self) {
     bus_data->pio_offset = pio_add_program(bus_data->pio, &SPI_PROGRAM_FUNC);
     pio_sm_config config = SPI_PROGRAM_GET_DEFAULT_CONFIG_FUNC(bus_data->pio_offset);
 
-    sm_config_set_clkdiv_int_frac(&config, CLOCK_DIV, CLOCK_DIV_MINOR);
+    sm_config_set_clkdiv_int_frac(&config, cyw43_spi_clock_div_int, cyw43_spi_clock_div_frac);
+    
     hw_write_masked(&padsbank0_hw->io[CLOCK_PIN],
                     (uint)PADS_DRIVE_STRENGTH << PADS_BANK0_GPIO0_DRIVE_LSB,
                     PADS_BANK0_GPIO0_DRIVE_BITS

--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -84,8 +84,8 @@ typedef struct {
 
 static bus_data_t bus_data_instance;
 
-int cyw43_spi_clock_div_int = CLOCK_DIV;
-int cyw43_spi_clock_div_frac = CLOCK_DIV_MINOR;
+static int cyw43_spi_clock_div_int = CLOCK_DIV;
+static int cyw43_spi_clock_div_frac = CLOCK_DIV_MINOR;
 
 // Allow the user to adjust the SPI clock speed 
 // prior to initialization.

--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -84,14 +84,14 @@ typedef struct {
 
 static bus_data_t bus_data_instance;
 
-static int cyw43_spi_clock_div_int = CLOCK_DIV;
-static int cyw43_spi_clock_div_frac = CLOCK_DIV_MINOR;
+static int cyw43_pio_clock_div_int = CLOCK_DIV;
+static int cyw43_pio_clock_div_frac = CLOCK_DIV_MINOR;
 
 // Allow the user to adjust the SPI clock speed 
 // prior to initialization.
-void cyw43_spi_set_clock_divisor(int clock_div_int, int clock_div_frac) {
-    cyw43_spi_clock_div_int = clock_div_int;
-    cyw43_spi_clock_div_frac = clock_div_frac;
+void cyw43_set_pio_clock_divisor(int clock_div_int, int clock_div_frac) {
+    cyw43_pio_clock_div_int = clock_div_int;
+    cyw43_pio_clock_div_frac = clock_div_frac;
 }
 
 int cyw43_spi_init(cyw43_int_t *self) {
@@ -127,7 +127,7 @@ int cyw43_spi_init(cyw43_int_t *self) {
     bus_data->pio_offset = pio_add_program(bus_data->pio, &SPI_PROGRAM_FUNC);
     pio_sm_config config = SPI_PROGRAM_GET_DEFAULT_CONFIG_FUNC(bus_data->pio_offset);
 
-    sm_config_set_clkdiv_int_frac(&config, cyw43_spi_clock_div_int, cyw43_spi_clock_div_frac);
+    sm_config_set_clkdiv_int_frac(&config, cyw43_pio_clock_div_int, cyw43_pio_clock_div_frac);
     
     hw_write_masked(&padsbank0_hw->io[CLOCK_PIN],
                     (uint)PADS_DRIVE_STRENGTH << PADS_BANK0_GPIO0_DRIVE_LSB,


### PR DESCRIPTION
Fixes issues #1297 and #1392

This is a straightforward patch to allow the Pico W to work with the WiFi/BT module when heavily over- or underclocked.  The previous code had the SPI clock divisor hardcoded to a value of 2, this allows the programmer to explicitly set it to any value they'd like.

In both instances, simply set the desired clock divisor PRIOR to initializing the WiFi module:

    set_sys_clock_khz(48000, true);      // cyw43 init will hang or fail, see issue #1392
    cyw43_spi_set_clock_divisor(1,0);   // Speed up the SPI bus so it will work
    if (cyw43_arch_init_with_country(CYW43_COUNTRY_USA)) { ...
    
or

    set_sys_clock_khz(266000, true);      // cyw43 init will fail for reasons similar to #1297
    cyw43_spi_set_clock_divisor(4,0);     // Slow down the SPI bus 
    if (cyw43_arch_init_with_country(CYW43_COUNTRY_USA)) { ...
