### PR TITLE
Rename configNUMBER_OF_CORES to configNUM_CORES

### DIFF
--- a/src/rp2_common/pico_async_context/async_context_freertos.c
+++ b/src/rp2_common/pico_async_context/async_context_freertos.c
@@ -12,7 +12,7 @@
 
 #include "semphr.h"
 
-#if configNUM_CORES > 1 && !defined(configUSE_CORE_AFFINITY)
+#if configNUMBER_OF_CORES > 1 && !defined(configUSE_CORE_AFFINITY)
 #error async_context_freertos requires configUSE_CORE_AFFINITY under SMP
 #endif
 
@@ -125,7 +125,7 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
         async_context_deinit(&self->core);
         return false;
     }
-#if configNUM_CORES > 1
+#if configNUMBER_OF_CORES > 1
     UBaseType_t core_id = config->task_core_id;
     if (core_id == (UBaseType_t)-1) {
         core_id = portGET_CORE_ID();

--- a/src/rp2_common/pico_async_context/include/pico/async_context_freertos.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context_freertos.h
@@ -51,7 +51,7 @@ typedef struct async_context_freertos_config {
      * the core ID (see \ref portGET_CORE_ID()) to pin the task to.
      * This is only relevant in SMP mode.
      */
-#if configUSE_CORE_AFFINITY && configNUM_CORES > 1
+#if configUSE_CORE_AFFINITY && configNUMBER_OF_CORES > 1
     UBaseType_t task_core_id;
 #endif
 } async_context_freertos_config_t;
@@ -90,7 +90,7 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
     async_context_freertos_config_t config = {
             .task_priority = ASYNC_CONTEXT_DEFAULT_FREERTOS_TASK_PRIORITY,
             .task_stack_size = ASYNC_CONTEXT_DEFAULT_FREERTOS_TASK_STACK_SIZE,
-#if configUSE_CORE_AFFINITY && configNUM_CORES > 1
+#if configUSE_CORE_AFFINITY && configNUMBER_OF_CORES > 1
             .task_core_id = (UBaseType_t)-1, // none
 #endif
     };

--- a/src/rp2_common/pico_flash/flash.c
+++ b/src/rp2_common/pico_flash/flash.c
@@ -15,7 +15,7 @@
 #include "task.h"
 // now we have FreeRTOS header we can check core count... we can only use FreeRTOS SMP mechanism
 // with two cores
-#if configNUM_CORES == 2
+#if configNUMBER_OF_CORES == 2
 #if configUSE_CORE_AFFINITY
 #define PICO_FLASH_SAFE_EXECUTE_USE_FREERTOS_SMP 1
 #else

--- a/src/rp2_common/pico_flash/include/pico/flash.h
+++ b/src/rp2_common/pico_flash/include/pico/flash.h
@@ -37,7 +37,7 @@
  *
  * There are conditions where safety would not be guaranteed:
  *
- * 1. FreeRTOS smp with `configNUM_CORES=1` - FreeRTOS still uses pico_multicore in this case, so \ref flash_safe_execute
+ * 1. FreeRTOS smp with `configNUMBER_OF_CORES=1` - FreeRTOS still uses pico_multicore in this case, so \ref flash_safe_execute
  * cannot know what the other core is doing, and there is no way to force code execution between a FreeRTOS core
  * and a non FreeRTOS core.
  * 2. FreeRTOS non SMP with pico_multicore - Again, there is no way to force code execution between a FreeRTOS core and


### PR DESCRIPTION
The Freertos SMP branch has been merged into main with configNUM_CORES renamed to configNUMBER_OF_CORES

Fixes #1526
