### PR TITLE
rp2_common/pico_standard_link: linker script fixes

### DIFF
--- a/src/rp2_common/pico_standard_link/memmap_blocked_ram.ld
+++ b/src/rp2_common/pico_standard_link/memmap_blocked_ram.ld
@@ -117,8 +117,13 @@ SECTIONS
     __binary_info_end = .;
     . = ALIGN(4);
 
-   .ram_vector_table (NOLOAD): {
+    .ram_vector_table (NOLOAD): {
         *(.ram_vector_table)
+    } > RAM
+
+    .uninitialized_data (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
     } > RAM
 
     .data : {
@@ -172,11 +177,6 @@ SECTIONS
     } > RAM AT> FLASH
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
-
-    .uninitialized_data (NOLOAD): {
-        . = ALIGN(4);
-        *(.uninitialized_data*)
-    } > RAM
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/src/rp2_common/pico_standard_link/memmap_copy_to_ram.ld
+++ b/src/rp2_common/pico_standard_link/memmap_copy_to_ram.ld
@@ -96,8 +96,13 @@ SECTIONS
     . = ALIGN(4);
 
     /* Vector table goes first in RAM, to avoid large alignment hole */
-   .ram_vector_table (NOLOAD): {
+    .ram_vector_table (NOLOAD): {
         *(.ram_vector_table)
+    } > RAM
+
+    .uninitialized_data (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
     } > RAM
 
     .text : {
@@ -174,11 +179,6 @@ SECTIONS
     } > RAM AT> FLASH
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
-
-    .uninitialized_data (NOLOAD): {
-        . = ALIGN(4);
-        *(.uninitialized_data*)
-    } > RAM
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/src/rp2_common/pico_standard_link/memmap_default.ld
+++ b/src/rp2_common/pico_standard_link/memmap_default.ld
@@ -117,8 +117,13 @@ SECTIONS
     __binary_info_end = .;
     . = ALIGN(4);
 
-   .ram_vector_table (NOLOAD): {
+    .ram_vector_table (NOLOAD): {
         *(.ram_vector_table)
+    } > RAM
+
+    .uninitialized_data (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
     } > RAM
 
     .data : {
@@ -172,11 +177,6 @@ SECTIONS
     } > RAM AT> FLASH
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
-
-    .uninitialized_data (NOLOAD): {
-        . = ALIGN(4);
-        *(.uninitialized_data*)
-    } > RAM
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {


### PR DESCRIPTION
The resulting elf binaries contained an unusual section that leads to an error when `objcopy` attempts to update a section (e.g. when using the picowota combined build mechanism).

This is due to the order of sections, where two `RAM` sections were separate by a `RAM AT>FLASH` section. The documentation of `ld` describes that the `AT>FLASH` is effectively "sticky", so that the next `RAM` section behaves as if `AT>FLASH` was specified (which is not intended). By moving the RAM-only sections together, this issue is solved.

Fixes #1538 (see this issue for a detailed analysis)