### PR TITLE
CMake cmake_minimum_required Deprecation Warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.27)
 
 # Note: this CMakeLists.txt can be used as a top-level CMakeLists.txt for the SDK itself. For all other uses
 # it is included as a subdirectory via the pico_sdk_init() method provided by pico_sdk_init.cmake
@@ -61,4 +61,3 @@ if (NOT TARGET _pico_sdk_inclusion_marker)
         pico_promote_common_scope_vars()
     endif()
 endif()
-

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       1. Setup a `CMakeLists.txt` like:
 
           ```cmake
-          cmake_minimum_required(VERSION 3.13)
+          cmake_minimum_required(VERSION 3.13...3.27)
 
           # initialize pico-sdk from submodule
           # note: this must happen before project()

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       3. Setup a `CMakeLists.txt` like:
 
           ```cmake
-          cmake_minimum_required(VERSION 3.13)
+          cmake_minimum_required(VERSION 3.13...3.27)
 
           # initialize the SDK based on PICO_SDK_PATH
           # note: this must happen before project()

--- a/tools/elf2uf2/CMakeLists.txt
+++ b/tools/elf2uf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12...3.27)
 project(elf2uf2)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5...3.27)
 project(pioasm CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Fixes: #1545 

Recently, when building pioasm and/or elf2uf2, CMake warns about cmake_minimum_required:

```
[ 96%] Performing configure step for 'PioasmBuild'
loading initial cache file /home/gmt/Projects/pico/build/pico-sdk/src/rp2_common/pico_cyw43_driver/pioasm/tmp/PioasmBuild-cache-Release.cmake
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

#1477 reported the issue, but submitted patch is not correct.