### PR TITLE
Fix documentation issues when upgrading Doxygen to 1.9.8

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -52,6 +52,9 @@ EXTRACT_ALL            = NO
 ALWAYS_DETAILED_SEC    = NO
 #REPEAT_BRIEF           = NO
 
+# Needed to automatically extract implicit brief descriptions in recent versions of Doxygen
+JAVADOC_AUTOBRIEF      = YES
+
 # Need these next options to ensure that functions with modifiers do not confuse the Doxygen parser.
 # And any further function modifiers here.
 MACRO_EXPANSION        = YES

--- a/docs/DoxygenLayout.xml
+++ b/docs/DoxygenLayout.xml
@@ -3,7 +3,8 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title="Introduction"></tab>
-    <tab type="modules" visible="yes" title="API Documentation" intro="These are the libraries supplied in the Raspberry Pi Pico SDK"/>
+    <tab type="topics" visible="yes" title="API Documentation" intro="These are the libraries supplied in the Raspberry Pi Pico SDK"/>
+    <tab type="modules" visible="no" title="" intro=""/>
     <tab type="user" url="@ref examples_page" visible="yes" title="Examples" intro="Links to SDK examples"/>
     <tab type="usergroup" url="@ref weblinks_page" visible="yes" title="Additional Documentation" intro="Links to datasheets and documentation">
       <tab type="user" url="https://rptl.io/pico-datasheet" visible="yes" title="Raspberry Pi Pico Datasheet" intro=""/>


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-sdk/issues/1563

Between Doxygen 1.8.17 and Doxygen 1.9.8, the top-level "modules" tab type in the Doxygen layout has changed such that our "API Documentation" section is no longer generated and is instead considered of the type "topics". Update our layout XML to reflect this change and restore this critical section of the documentation.

As of Doxygen 1.8.19 (specifically, https://github.com/doxygen/doxygen/commit/327423e217337bf4e64515aba6cf78b9877bc165), the first line of a comment is no longer automatically extracted as a brief description unless we enable the JAVADOC_AUTOBRIEF setting. See https://www.doxygen.nl/manual/config.html#cfg_javadoc_autobrief:
> If the `JAVADOC_AUTOBRIEF` tag is set to `YES` then doxygen will interpret the first line (until the first dot) of a Javadoc-style comment as the brief description. If set to `NO`, the Javadoc-style will behave just like regular Qt-style comments (thus requiring an explicit @brief command for a brief description.)
