### PR TITLE
Remove unused parameter warning in async_context_freertos

### DIFF
--- a/src/rp2_common/pico_async_context/async_context_freertos.c
+++ b/src/rp2_common/pico_async_context/async_context_freertos.c
@@ -262,7 +262,7 @@ static void async_context_freertos_set_work_pending(async_context_t *self_base, 
     async_context_freertos_wake_up(self_base);
 }
 
-static void async_context_freertos_wait_until(async_context_t *self_base, absolute_time_t until) {
+static void async_context_freertos_wait_until(__unused async_context_t *self_base, absolute_time_t until) {
     assert(!portCHECK_IF_IN_ISR());
     TickType_t ticks = sensible_ticks_until(until);
     vTaskDelay(ticks);


### PR DESCRIPTION
Fixes #1573

Removes the unused parameter warning when building for FreeRTOS