### PR TITLE
Freertos background asserts if IPv6 is enabled

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
@@ -164,6 +164,10 @@ void cyw43_thread_lock_check(void) {
 #endif
 
 void cyw43_await_background_or_timeout_us(uint32_t timeout_us) {
+    if (__get_current_exception() > 0) {
+        async_context_wait_until(cyw43_async_context, make_timeout_time_us(timeout_us));
+        return;
+    }
     async_context_wait_for_work_until(cyw43_async_context, make_timeout_time_us(timeout_us));
 }
 


### PR DESCRIPTION
If LWIP_IPV6=1 a request to update the multicast list occurs in a callback in the low priority interrupt.

This makes an ioctl call into the driver, at the end of which is a call to cyw43_await_background_or_timeout_us (see CYW43_DO_IOCTL_WAIT). It is attempting to delay until there's "some work to do".

For Freertos this fails an assertion as an attempt is made to acquire a semaphore in interrupt context.

Fixes #1590
