### PR TITLE
adc: adc_read() not check for error (#1575) v2

### DIFF
--- a/src/rp2_common/hardware_adc/include/hardware/adc.h
+++ b/src/rp2_common/hardware_adc/include/hardware/adc.h
@@ -128,15 +128,24 @@ static inline void adc_set_temp_sensor_enabled(bool enable) {
  *
  *  Performs an ADC conversion, waits for the result, and then returns it.
  *
- * \return Result of the conversion.
+ * \return Result of the conversion or negative value on error.
  */
-static inline uint16_t adc_read(void) {
+static inline int32_t adc_read(void) {
     hw_set_bits(&adc_hw->cs, ADC_CS_START_ONCE_BITS);
+    
+    while ((adc_hw->cs & (ADC_CS_READY_BITS|ADC_CS_ERR_BITS|ADC_CS_ERR_STICKY_BITS))==0) {
+         tight_loop_contents();
+    }
 
-    while (!(adc_hw->cs & ADC_CS_READY_BITS))
-        tight_loop_contents();
-
-    return (uint16_t) adc_hw->result;
+    if ((adc_hw->cs & ADC_CS_READY_BITS)>0) {
+        return adc_hw->result & 0xfff;
+    }
+    if ((adc_hw->cs & ADC_CS_ERR_BITS)>0) {
+        return -ADC_CS_ERR_BITS;
+    }
+    /* clear sticky bit */
+    hw_set_bits(&adc_hw->cs, ADC_CS_ERR_STICKY_BITS);
+    return -ADC_CS_ERR_STICKY_BITS;
 }
 
 /*! \brief Enable or disable free-running sampling mode


### PR DESCRIPTION
Implementation of adc_read() not check for errors in the ADC_CS register.
    
-  change the return type from uint16_t to int32_t
-  check for ADC_CS_READY_BITS and error ADC_CS_ERR_BITS or ADC_CS_ERR_STICKY_BITS    
- return the ADC value (12bits) or the negative value of ADC_CS_ERR_BITS or ADC_CS_ERR_STICKY_BITS depending on the error

v2: 
- update the code, optimize the workflow 
- no reset required , so removed it.