### PR TITLE
pico_generate_pio_header: Create OUTPUT_DIR

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -26,6 +26,7 @@ function(pico_generate_pio_header TARGET PIO)
     endif()
 
     if (pico_generate_pio_header_OUTPUT_DIR)
+        file(MAKE_DIRECTORY ${pico_generate_pio_header_OUTPUT_DIR})
         get_filename_component(HEADER_DIR ${pico_generate_pio_header_OUTPUT_DIR} ABSOLUTE)
     else()
         set(HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
Previously, if a custom OUTPUT_DIR was specified but didn't exist then this command would fail.

Resolves: https://github.com/raspberrypi/pico-sdk/issues/1609

