### PR TITLE
corrected issue#1536 - used correct define to create a configuration …

### DIFF
--- a/src/rp2_common/pico_i2c_slave/i2c_slave.c
+++ b/src/rp2_common/pico_i2c_slave/i2c_slave.c
@@ -69,7 +69,7 @@ void i2c_slave_init(i2c_inst_t *i2c, uint8_t address, i2c_slave_handler_t handle
     i2c_hw_t *hw = i2c_get_hw(i2c);
     // unmask necessary interrupts
     hw->intr_mask =
-            I2C_IC_INTR_MASK_M_RX_FULL_BITS | I2C_IC_INTR_MASK_M_RD_REQ_BITS | I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS |
+            I2C_IC_INTR_MASK_M_RX_FULL_BITS | I2C_IC_INTR_MASK_M_RD_REQ_BITS | I2C_IC_INTR_MASK_M_TX_ABRT_BITS |
             I2C_IC_INTR_MASK_M_STOP_DET_BITS | I2C_IC_INTR_MASK_M_START_DET_BITS;
 
     // enable interrupt for current core


### PR DESCRIPTION
This pull request fixes an issue related to the mask that configure I2C port. 
Current version of software uses `I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS` as a submask. It is misleading. 
If configuration will need to be changed `I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS` might not be changed. 
Better solution is to use `I2C_IC_INTR_MASK_M_TX_ABRT_BITS` that is self explanatory and we are sure that I2C configuration mask will be correct in case of further update.
This pull request solves issue#1536