### PR TITLE
Sets PICO_DEOPTIMIZED_DEBUG to be enabled by default

### DIFF
--- a/cmake/preload/toolchains/pico_arm_clang.cmake
+++ b/cmake/preload/toolchains/pico_arm_clang.cmake
@@ -38,7 +38,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
-option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 0)
+option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 1)
 
 # Oz is preferred for Clang (verses CMake default -Os) see also https://gitlab.kitware.com/cmake/cmake/-/issues/22458
 set(CMAKE_C_FLAGS_MINSIZEREL "-Oz -DNDEBUG")

--- a/cmake/preload/toolchains/pico_arm_clang_arm.cmake
+++ b/cmake/preload/toolchains/pico_arm_clang_arm.cmake
@@ -37,7 +37,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
-option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 0)
+option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 1)
 
 set(ARM_TOOLCHAIN_COMMON_FLAGS " --cpu=Cortex-M0plus")
 include(${CMAKE_CURRENT_LIST_DIR}/set_flags.cmake)

--- a/cmake/preload/toolchains/pico_arm_gcc.cmake
+++ b/cmake/preload/toolchains/pico_arm_gcc.cmake
@@ -45,7 +45,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
-option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 0)
+option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 1)
 
 # on ARM -mcpu should not be mixed with -march
 set(ARM_TOOLCHAIN_COMMON_FLAGS " -mcpu=cortex-m0plus -mthumb")


### PR DESCRIPTION
Optimizing a debug build with PICO_DEOPTIMIZED DEBUG disabled (the current default) results in breakpoints not being possible in certain functions.  This change makes the default behaviour of PICO_DEOPTIMIZED_DEBUG to be enabled, so that debug builds will fully work as expected when no explicit value for the option is passed.

Since the cache stores the default value of PICO_DEOPTIMIZED DEBUG, you will need to delete the CMakeCache.txt previously generated in your project directory for this change to default behaviour to take effect in existing projects.

This commit is related to pull request #1620 in the primary repository.

See Issue #1618 in the primary repository for additional context.