### PR TITLE
Fixed an issue that caused incorrect settings when the SPI clock was …

### DIFF
--- a/src/rp2_common/hardware_spi/spi.c
+++ b/src/rp2_common/hardware_spi/spi.c
@@ -51,7 +51,7 @@ uint spi_set_baudrate(spi_inst_t *spi, uint baudrate) {
     // Find smallest prescale value which puts output frequency in range of
     // post-divide. Prescale is an even number from 2 to 254 inclusive.
     for (prescale = 2; prescale <= 254; prescale += 2) {
-        if (freq_in < (prescale + 2) * 256 * (uint64_t) baudrate)
+        if (freq_in < prescale * 256 * (uint64_t) baudrate)
             break;
     }
     invalid_params_if(SPI, prescale > 254); // Frequency too low


### PR DESCRIPTION
…less than 244141Hz.

_Instructions: (please delete)_
 - _please do not submit against `master`, use `develop` instead_
 - _please make sure there is an associated issue for your PR, and reference it via "Fixes #num" in the description_
 - _please enter a detailed description_
