### PR TITLE
[pioasm] Fix build warning due to extra parameters

### DIFF
--- a/tools/pioasm/json_output.cpp
+++ b/tools/pioasm/json_output.cpp
@@ -102,7 +102,7 @@ struct json_output : public output_format {
                         program.sideset_opt ? "true" : "false",
                         program.sideset_pindirs ? "true" : "false");
             } else {
-                fprintf(out, "%s\"sideset\": {\"size\": 0, \"optional\": false, \"pindirs\": false},\n", tabs, program.origin.get());
+                fprintf(out, "%s\"sideset\": {\"size\": 0, \"optional\": false, \"pindirs\": false},\n", tabs);
             }
 
             output_symbols(out, true, tabs, program.symbols);


### PR DESCRIPTION
This is a follow up to https://github.com/raspberrypi/pico-sdk/pull/1394#issuecomment-1921733453 to fix the build warning from that pull and the original issue of https://github.com/raspberrypi/pico-sdk/issues/1393