### PR TITLE
Add alarm_pool_remaining_time()

### DIFF
--- a/src/common/pico_time/include/pico/time.h
+++ b/src/common/pico_time/include/pico/time.h
@@ -558,6 +558,18 @@ static inline alarm_id_t alarm_pool_add_alarm_in_ms(alarm_pool_t *pool, uint32_t
  */
 bool alarm_pool_cancel_alarm(alarm_pool_t *pool, alarm_id_t alarm_id);
 
+/*!
+ * \brief Return the time remaining before the next trigger of an alarm
+ * \ingroup alarm
+ * 
+ * @param pool the alarm_pool containing the alarm
+ * @param alarm_id the alarm
+ * 
+ * @return >0 the number of microseconds before the next trigger
+ * @return 0 if either the given alarm is not in progress or it has passed
+ */
+uint32_t alarm_pool_remaining_time(alarm_pool_t *pool, alarm_id_t alarm_id);
+
 #if !PICO_TIME_DEFAULT_ALARM_POOL_DISABLED
 /*!
  * \brief Add an alarm callback to be called at a specific time

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -370,6 +370,17 @@ void alarm_pool_dump(alarm_pool_t *pool) {
     spin_unlock(pool->lock, save);
 }
 
+uint32_t alarm_pool_remaining_time(alarm_pool_t *pool, alarm_id_t alarm_id) {
+    uint32_t save = spin_lock_blocking(pool->lock);
+    pheap_node_id_t next_id = ph_peek_head(pool->heap);
+    spin_unlock(pool->lock, save);
+    if (alarm_id == next_id && timer_hw->alarm[alarm_pool_hardware_alarm_num(pool)] > timer_hw->timerawl) {
+        return timer_hw->alarm[alarm_pool_hardware_alarm_num(pool)] - timer_hw->timerawl;
+    } else {
+        return 0;
+    }
+}
+
 #if !PICO_TIME_DEFAULT_ALARM_POOL_DISABLED
 static int64_t sleep_until_callback(__unused alarm_id_t id, __unused void *user_data) {
     uint32_t save = spin_lock_blocking(sleep_notifier.spin_lock);


### PR DESCRIPTION
Add a function that returns the time remaining before triggering for a given pool and alarm id
It uses difference between an alarm register and the timerawl register. (see [RP2040 datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf) chapter 4.6.3)
It also check that the alarm for which we're asking the remaining time is the actual one running on the hardware timer (and not in the alarm pool)

Refer to #1628



