### PR TITLE
Fixed an issue that caused incorrect settings when the SPI clock was …

### DIFF
--- a/src/rp2_common/hardware_spi/spi.c
+++ b/src/rp2_common/hardware_spi/spi.c
@@ -51,7 +51,7 @@ uint spi_set_baudrate(spi_inst_t *spi, uint baudrate) {
     // Find smallest prescale value which puts output frequency in range of
     // post-divide. Prescale is an even number from 2 to 254 inclusive.
     for (prescale = 2; prescale <= 254; prescale += 2) {
-        if (freq_in < (prescale + 2) * 256 * (uint64_t) baudrate)
+        if (freq_in < prescale * 256 * (uint64_t) baudrate)
             break;
     }
     invalid_params_if(SPI, prescale > 254); // Frequency too low


### PR DESCRIPTION
…less than 244,141Hz.

Fixed an issue that caused incorrect settings when the SPI clock was less than 244,141Hz.

For example, if clk_peri is 125MHz and you specify 150kHz

Before correction
prescale=2, postdiv=256,
125000000/(2*256)=244140.625Hz
Therefore, it exceeds 150kHz.

After correction
prescale=4, postdiv=209,
125000000/(4*209)=149521.5311004785Hz
This is the correct frequency.