### PR TITLE
Allow disabling pico_stdio function wrapping

### DIFF
--- a/src/rp2_common/pico_stdio/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio/CMakeLists.txt
@@ -1,17 +1,48 @@
 if (NOT TARGET pico_stdio)
+    # library to be depended on - we make this depend on particular implementations using per target generator expressions
     pico_add_library(pico_stdio)
 
-    target_include_directories(pico_stdio_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
-
-    target_sources(pico_stdio INTERFACE
+    # no custom implementation; falls thru to compiler
+    pico_add_library(pico_stdio_compiler)
+    target_sources(pico_stdio_compiler INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/stdio.c
     )
 
-    pico_wrap_function(pico_stdio printf)
-    pico_wrap_function(pico_stdio vprintf)
-    pico_wrap_function(pico_stdio puts)
-    pico_wrap_function(pico_stdio putchar)
-    pico_wrap_function(pico_stdio getchar)
+    target_include_directories(pico_stdio_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+
+    # add alias "default" which is just pico
+    add_library(pico_stdio_default INTERFACE)
+    target_link_libraries(pico_stdio_default INTERFACE pico_stdio_pico)
+
+    set(PICO_DEFAULT_STDIO_IMPL pico_stdio_default)
+
+    target_link_libraries(pico_stdio INTERFACE
+            $<IF:$<BOOL:$<TARGET_PROPERTY:PICO_TARGET_STDIO_IMPL>>,$<TARGET_PROPERTY:PICO_TARGET_STDIO_IMPL>,${PICO_DEFAULT_STDIO_IMPL}>)
+
+    pico_add_library(pico_stdio_pico)
+    target_sources(pico_stdio_pico INTERFACE
+            ${CMAKE_CURRENT_LIST_DIR}/stdio.c
+    )
+    target_link_libraries(pico_stdio_pico INTERFACE pico_stdio_headers)
+
+    function(wrap_stdio_functions TARGET)
+        pico_wrap_function(${TARGET} printf)
+        pico_wrap_function(${TARGET} vprintf)
+        pico_wrap_function(${TARGET} puts)
+        pico_wrap_function(${TARGET} putchar)
+        pico_wrap_function(${TARGET} getchar)
+    endfunction()
+
+    wrap_stdio_functions(pico_stdio_pico)
+
+    macro(pico_set_stdio_implementation TARGET IMPL)
+        get_target_property(target_type ${TARGET} TYPE)
+        if ("EXECUTABLE" STREQUAL "${target_type}")
+            set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_IMPL "pico_stdio_${IMPL}")
+        else()
+            message(FATAL_ERROR "stdio implementation must be set on executable not library")
+        endif()
+    endmacro()
 
     if (TARGET pico_printf)
         pico_mirrored_target_link_libraries(pico_stdio INTERFACE pico_printf)

--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -225,6 +225,7 @@ typedef struct stdio_stack_buffer {
     char buf[PICO_STDIO_STACK_BUFFER_SIZE];
 } stdio_stack_buffer_t;
 
+#if LIB_PICO_PRINTF_PICO
 static void stdio_stack_buffer_flush(stdio_stack_buffer_t *buffer) {
     if (buffer->used) {
         for (stdio_driver_t *d = drivers; d; d = d->next) {
@@ -243,6 +244,7 @@ static void stdio_buffered_printer(char c, void *arg) {
     }
     buffer->buf[buffer->used++] = c;
 }
+#endif
 
 int WRAPPER_FUNC(vprintf)(const char *format, va_list va) {
     bool serialzed = stdout_serialize_begin();


### PR DESCRIPTION
This PR copies the approach used by pico_printf and applies it to pico_stdio to allow a developer to opt out of stdio printf/putchar/etc. wrappers. This is done with the use of a new function `pico_set_stdio_implementation` which works identically to `pico_set_printf_implementation` from `pico_printf`.

This enables a developer to opt out of stdio wrappers around the following functions:
  - printf
  - vprintf
  - puts
  - putchar
  - getchar

Additionally, in `pico_stdio`'s `stdio.c`, some additional `#if/#endif` are applied to shut up compiler warnings about unused functions when `pico_printf` compiler implementation is in use.

Fixes #1634 