### PR TITLE
Make it easier to configure default baud rate

### DIFF
--- a/src/rp2_common/hardware_uart/CMakeLists.txt
+++ b/src/rp2_common/hardware_uart/CMakeLists.txt
@@ -1,3 +1,9 @@
 pico_simple_hardware_target(uart)
 
 pico_mirrored_target_link_libraries(hardware_uart INTERFACE hardware_resets hardware_clocks)
+
+# PICO_CONFIG: PICO_DEFAULT_UART_BAUD_RATE, Define the default UART baudrate, max=921600, default=115200, group=hardware_uart
+if (PICO_DEFAULT_UART_BAUD_RATE)
+target_compile_definitions(hardware_uart INTERFACE
+        PICO_DEFAULT_UART_BAUD_RATE=${PICO_DEFAULT_UART_BAUD_RATE})
+endif()


### PR DESCRIPTION
To make stdio logging quicker it's probably a good idea to set the default uart speed 921600, but it's only configurable by adding this define to your project. Make it configurable from the cmake command line.
