### PR TITLE
Reformatting doxygen comment markup (RPI docs team)

### DIFF
--- a/src/common/boot_picoboot/include/boot/picoboot.h
+++ b/src/common/boot_picoboot/include/boot/picoboot.h
@@ -18,7 +18,7 @@
 /** \file picoboot.h
 *  \defgroup boot_picoboot boot_picoboot
 *
-* Header file for the PICOBOOT USB interface exposed by an RP2040 in BOOTSEL mode.
+* \brief Header file for the PICOBOOT USB interface exposed by an RP2040 in BOOTSEL mode.
 */
 
 #define PICOBOOT_MAGIC 0x431fd10bu

--- a/src/common/boot_uf2/include/boot/uf2.h
+++ b/src/common/boot_uf2/include/boot/uf2.h
@@ -13,7 +13,7 @@
 /** \file uf2.h
 *  \defgroup boot_uf2 boot_uf2
 *
-* Header file for the UF2 format supported by an RP2040 in BOOTSEL mode.
+* \brief Header file for the UF2 format supported by an RP2040 in BOOTSEL mode.
 */
 
 #define UF2_MAGIC_START0 0x0A324655u

--- a/src/common/pico_base/include/pico.h
+++ b/src/common/pico_base/include/pico.h
@@ -10,7 +10,7 @@
 /** \file pico.h
  *  \defgroup pico_base pico_base
  *
- * Core types and macros for the Raspberry Pi Pico SDK. This header is intended to be included by all source code
+ * \brief Core types and macros for the Raspberry Pi Pico SDK. This header is intended to be included by all source code
  * as it includes configuration headers and overrides in the correct order
  *
  * This header may be included by assembly code

--- a/src/common/pico_binary_info/include/pico/binary_info.h
+++ b/src/common/pico_binary_info/include/pico/binary_info.h
@@ -10,7 +10,7 @@
 /** \file binary_info.h
  *  \defgroup pico_binary_info pico_binary_info
  *
- * Binary info is intended for embedding machine readable information with the binary in FLASH.
+ * \brief Binary info is intended for embedding machine readable information with the binary in FLASH.
  *
  * Example uses include:
  *

--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -29,12 +29,12 @@
 #define __bi_enclosure_check(x) (x)
 #endif
 /**
- * Declare some binary information that will be included if the contain source file/line is compiled into the binary
+ * \brief Declare some binary information that will be included if the contain source file/line is compiled into the binary
  * \ingroup pico_binary_info
  */
 #define bi_decl(_decl) __bi_mark_enclosure _decl; __bi_decl(__bi_ptr_lineno_var_name, &__bi_lineno_var_name.core, ".binary_info.keep.", __used);
 /**
- * Declare some binary information that will be included if the function containing the decl is linked into the binary.
+ * \brief Declare some binary information that will be included if the function containing the decl is linked into the binary.
  * The SDK uses --gc-sections, so functions that are never called will be removed by the linker, and any associated
  * binary information declared this way will also be stripped
  * \ingroup pico_binary_info

--- a/src/common/pico_bit_ops/include/pico/bit_ops.h
+++ b/src/common/pico_bit_ops/include/pico/bit_ops.h
@@ -16,7 +16,7 @@ extern "C" {
 /** \file bit_ops.h
 *  \defgroup pico_bit_ops pico_bit_ops
 *
-* Optimized bit manipulation functions.
+* \brief Optimized bit manipulation functions.
 * Additionally provides  replacement implementations of the compiler built-ins __builtin_popcount, __builtin_clz
 * and __bulitin_ctz
 */

--- a/src/common/pico_divider/include/pico/divider.h
+++ b/src/common/pico_divider/include/pico/divider.h
@@ -16,7 +16,7 @@ extern "C" {
 
 /**
  * \defgroup pico_divider pico_divider
- * Optimized 32 and 64 bit division functions accelerated by the RP2040 hardware divider.
+ * \brief Optimized 32 and 64 bit division functions accelerated by the RP2040 hardware divider.
  * Additionally provides integration with the C `/` and `%` operators
  */
 

--- a/src/common/pico_stdlib/include/pico/stdlib.h
+++ b/src/common/pico_stdlib/include/pico/stdlib.h
@@ -20,7 +20,7 @@ extern "C" {
 /** \file stdlib.h
  *  \defgroup pico_stdlib pico_stdlib
  *
- * Aggregation of a core subset of Raspberry Pi Pico SDK libraries used by most executables along with some additional
+ * \brief Aggregation of a core subset of Raspberry Pi Pico SDK libraries used by most executables along with some additional
  * utility methods. Including pico_stdlib gives you everything you need to get a basic program running
  * which prints to stdout or flashes a LED
  *

--- a/src/common/pico_sync/include/pico/lock_core.h
+++ b/src/common/pico_sync/include/pico/lock_core.h
@@ -74,6 +74,7 @@ void lock_init(lock_core_t *core, uint lock_num);
 #ifndef lock_owner_id_t
 /*! \brief  type to use to store the 'owner' of a lock.
  *  \ingroup lock_core
+ *
  * By default this is int8_t as it only needs to store the core number or -1, however it may be
  * overridden if a larger type is required (e.g. for an RTOS task id)
  */
@@ -90,6 +91,7 @@ void lock_init(lock_core_t *core, uint lock_num);
 #ifndef lock_get_caller_owner_id
 /*! \brief  return the owner id for the caller
  *  \ingroup lock_core
+ *
  * By default this returns the calling core number, but may be overridden (e.g. to return an RTOS task id)
  */
 #define lock_get_caller_owner_id() ((lock_owner_id_t)get_core_num())

--- a/src/common/pico_sync/include/pico/sync.h
+++ b/src/common/pico_sync/include/pico/sync.h
@@ -9,7 +9,7 @@
 
 /** \file pico/sync.h
  *  \defgroup pico_sync pico_sync
- * Synchronization primitives and mutual exclusion
+ * \brief Synchronization primitives and mutual exclusion
  */
 
 #include "pico/sem.h"

--- a/src/common/pico_time/include/pico/time.h
+++ b/src/common/pico_time/include/pico/time.h
@@ -17,7 +17,7 @@ extern "C" {
 /** \file time.h
  *  \defgroup pico_time pico_time
  *
- * API for accurate timestamps, sleeping, and time based callbacks
+ * \brief API for accurate timestamps, sleeping, and time based callbacks
  *
  * \note The functions defined here provide a much more powerful and user friendly wrapping around the
  * low level hardware timer functionality. For these functions (and any other SDK functionality

--- a/src/common/pico_usb_reset_interface/include/pico/usb_reset_interface.h
+++ b/src/common/pico_usb_reset_interface/include/pico/usb_reset_interface.h
@@ -10,7 +10,7 @@
 /** \file usb_reset_interface.h
  *  \defgroup pico_usb_reset_interface pico_usb_reset_interface
  *
- * Definition for the reset interface that may be exposed by the pico_stdio_usb library
+ * \brief Definition for the reset interface that may be exposed by the pico_stdio_usb library
  */
 
 // VENDOR sub-class for the reset interface

--- a/src/common/pico_util/include/pico/util/pheap.h
+++ b/src/common/pico_util/include/pico/util/pheap.h
@@ -21,7 +21,7 @@ extern "C" {
 /**
  * \file pheap.h
  * \defgroup util_pheap pheap
- * Pairing Heap Implementation
+ * \brief Pairing Heap Implementation
  * \ingroup pico_util
  *
  * pheap defines a simple pairing heap. The implementation simply tracks array indexes, it is up to
@@ -53,7 +53,7 @@ typedef struct pheap_node {
 } pheap_node_t;
 
 /**
- * A user comparator function for nodes in a pairing heap.
+ * \brief A user comparator function for nodes in a pairing heap.
  *
  * \return true if a < b in natural order. Note this relative ordering must be stable from call to call.
  */
@@ -71,7 +71,7 @@ typedef struct pheap {
 } pheap_t;
 
 /**
- * Create a pairing heap, which effectively maintains an efficient sorted ordering
+ * \brief Create a pairing heap, which effectively maintains an efficient sorted ordering
  * of nodes. The heap itself stores no user per-node state, it is expected
  * that the user maintains a companion array. A comparator function must
  * be provided so that the heap implementation can determine the relative ordering of nodes
@@ -86,13 +86,13 @@ typedef struct pheap {
 pheap_t *ph_create(uint max_nodes, pheap_comparator comparator, void *user_data);
 
 /**
- * Removes all nodes from the pairing heap
+ * \brief Removes all nodes from the pairing heap
  * \param heap the heap
  */
 void ph_clear(pheap_t *heap);
 
 /**
- * De-allocates a pairing heap
+ * \brief De-allocates a pairing heap
  *
  * Note this method must *ONLY* be called on heaps created by ph_create()
  * \param heap the heap
@@ -135,7 +135,7 @@ static pheap_node_id_t ph_merge_nodes(pheap_t *heap, pheap_node_id_t a, pheap_no
 }
 
 /**
- * Allocate a new node from the unused space in the heap
+ * \brief Allocate a new node from the unused space in the heap
  *
  * \param heap the heap
  * \return an identifier for the node, or 0 if the heap is full
@@ -151,7 +151,7 @@ static inline pheap_node_id_t ph_new_node(pheap_t *heap) {
 }
 
 /**
- * Inserts a node into the heap.
+ * \brief Inserts a node into the heap.
  *
  * This method inserts a node (previously allocated by ph_new_node())
  * into the heap, determining the correct order by calling
@@ -170,7 +170,7 @@ static inline pheap_node_id_t ph_insert_node(pheap_t *heap, pheap_node_id_t id) 
 }
 
 /**
- * Returns the head node in the heap, i.e. the node
+ * \brief Returns the head node in the heap, i.e. the node
  * which compares first, but without removing it from the heap.
  *
  * \param heap the heap
@@ -181,7 +181,7 @@ static inline pheap_node_id_t ph_peek_head(pheap_t *heap) {
 }
 
 /**
- * Remove the head node from the pairing heap. This head node is
+ * \brief Remove the head node from the pairing heap. This head node is
  * the node which compares first in the logical ordering provided
  * by the comparator.
  *
@@ -198,7 +198,7 @@ static inline pheap_node_id_t ph_peek_head(pheap_t *heap) {
 pheap_node_id_t ph_remove_head(pheap_t *heap, bool free);
 
 /**
- * Remove the head node from the pairing heap. This head node is
+ * \brief Remove the head node from the pairing heap. This head node is
  * the node which compares first in the logical ordering provided
  * by the comparator.
  *
@@ -214,7 +214,7 @@ static inline pheap_node_id_t ph_remove_and_free_head(pheap_t *heap) {
 }
 
 /**
- * Remove and free an arbitrary node from the pairing heap. This is a more
+ * \brief Remove and free an arbitrary node from the pairing heap. This is a more
  * costly operation than removing the head via ph_remove_and_free_head()
  *
  * @param heap the heap
@@ -224,7 +224,7 @@ static inline pheap_node_id_t ph_remove_and_free_head(pheap_t *heap) {
 bool ph_remove_and_free_node(pheap_t *heap, pheap_node_id_t id);
 
 /**
- * Determine if the heap contains a given node. Note containment refers
+ * \brief Determine if the heap contains a given node. Note containment refers
  * to whether the node is inserted (ph_insert_node()) vs allocated (ph_new_node())
  *
  * @param heap the heap
@@ -237,7 +237,7 @@ static inline bool ph_contains_node(pheap_t *heap, pheap_node_id_t id) {
 
 
 /**
- * Free a node that is not currently in the heap, but has been allocated
+ * \brief Free a node that is not currently in the heap, but has been allocated
  *
  * @param heap the heap
  * @param id the id of the node
@@ -255,7 +255,7 @@ static inline void ph_free_node(pheap_t *heap, pheap_node_id_t id) {
 }
 
 /**
- * Print a representation of the heap for debugging
+ * \brief Print a representation of the heap for debugging
  *
  * @param heap the heap
  * @param dump_key a method to print a node value
@@ -264,7 +264,7 @@ static inline void ph_free_node(pheap_t *heap, pheap_node_id_t id) {
 void ph_dump(pheap_t *heap, void (*dump_key)(pheap_node_id_t id, void *user_data), void *user_data);
 
 /**
- * Initialize a statically allocated heap (ph_create() using the C heap).
+ * \brief Initialize a statically allocated heap (ph_create() using the C heap).
  * The heap member `nodes` must be allocated of size max_nodes.
  *
  * @param heap the heap
@@ -275,7 +275,7 @@ void ph_dump(pheap_t *heap, void (*dump_key)(pheap_node_id_t id, void *user_data
 void ph_post_alloc_init(pheap_t *heap, uint max_nodes, pheap_comparator comparator, void *user_data);
 
 /**
- * Define a statically allocated pairing heap. This must be initialized
+ * \brief Define a statically allocated pairing heap. This must be initialized
  * by ph_post_alloc_init
  */
 #define PHEAP_DEFINE_STATIC(name, _max_nodes) \

--- a/src/common/pico_util/include/pico/util/queue.h
+++ b/src/common/pico_util/include/pico/util/queue.h
@@ -17,7 +17,7 @@
 
 /** \file queue.h
  * \defgroup queue queue
- * Multi-core and IRQ safe queue implementation.
+ * \brief Multi-core and IRQ safe queue implementation.
  *
  * Note that this queue stores values of a specified size, and pushed values are copied into the queue
  * \ingroup pico_util

--- a/src/rp2_common/cmsis/stub/CMSIS/Core/Include/mpu_armv7.h
+++ b/src/rp2_common/cmsis/stub/CMSIS/Core/Include/mpu_armv7.h
@@ -78,7 +78,7 @@
    (MPU_RBAR_VALID_Msk))
 
 /**
-* MPU Memory Access Attributes
+* \brief MPU Memory Access Attributes
 * 
 * \param TypeExtField      Type extension field, allows you to configure memory access type, for example strongly ordered, peripheral.
 * \param IsShareable       Region is shareable between multiple bus masters.
@@ -92,7 +92,7 @@
    (((IsBufferable) << MPU_RASR_B_Pos)   & MPU_RASR_B_Msk))
 
 /**
-* MPU Region Attribute and Size Register Value
+* \brief MPU Region Attribute and Size Register Value
 * 
 * \param DisableExec       Instruction access disable bit, 1= disable instruction fetches.
 * \param AccessPermission  Data access permissions, allows you to configure read/write access for User and Privileged mode.
@@ -109,7 +109,7 @@
    (((MPU_RASR_ENABLE_Msk))))
 
 /**
-* MPU Region Attribute and Size Register Value
+* \brief MPU Region Attribute and Size Register Value
 * 
 * \param DisableExec       Instruction access disable bit, 1= disable instruction fetches.
 * \param AccessPermission  Data access permissions, allows you to configure read/write access for User and Privileged mode.
@@ -124,7 +124,7 @@
   ARM_MPU_RASR_EX(DisableExec, AccessPermission, ARM_MPU_ACCESS_(TypeExtField, IsShareable, IsCacheable, IsBufferable), SubRegionDisable, Size)
 
 /**
-* MPU Memory Access Attribute for strongly ordered memory.
+* \brief MPU Memory Access Attribute for strongly ordered memory.
 *  - TEX: 000b
 *  - Shareable
 *  - Non-cacheable
@@ -133,7 +133,7 @@
 #define ARM_MPU_ACCESS_ORDERED ARM_MPU_ACCESS_(0U, 1U, 0U, 0U)
 
 /**
-* MPU Memory Access Attribute for device memory.
+* \brief MPU Memory Access Attribute for device memory.
 *  - TEX: 000b (if shareable) or 010b (if non-shareable)
 *  - Shareable or non-shareable
 *  - Non-cacheable
@@ -144,7 +144,7 @@
 #define ARM_MPU_ACCESS_DEVICE(IsShareable) ((IsShareable) ? ARM_MPU_ACCESS_(0U, 1U, 0U, 1U) : ARM_MPU_ACCESS_(2U, 0U, 0U, 0U))
 
 /**
-* MPU Memory Access Attribute for normal memory.
+* \brief MPU Memory Access Attribute for normal memory.
 *  - TEX: 1BBb (reflecting outer cacheability rules)
 *  - Shareable or non-shareable
 *  - Cacheable or non-cacheable (reflecting inner cacheability rules)
@@ -157,28 +157,28 @@
 #define ARM_MPU_ACCESS_NORMAL(OuterCp, InnerCp, IsShareable) ARM_MPU_ACCESS_((4U | (OuterCp)), IsShareable, ((InnerCp) >> 1U), ((InnerCp) & 1U))
 
 /**
-* MPU Memory Access Attribute non-cacheable policy.
+* \brief MPU Memory Access Attribute non-cacheable policy.
 */
 #define ARM_MPU_CACHEP_NOCACHE 0U
 
 /**
-* MPU Memory Access Attribute write-back, write and read allocate policy.
+* \brief MPU Memory Access Attribute write-back, write and read allocate policy.
 */
 #define ARM_MPU_CACHEP_WB_WRA 1U
 
 /**
-* MPU Memory Access Attribute write-through, no write allocate policy.
+* \brief MPU Memory Access Attribute write-through, no write allocate policy.
 */
 #define ARM_MPU_CACHEP_WT_NWA 2U
 
 /**
-* MPU Memory Access Attribute write-back, no write allocate policy.
+* \brief MPU Memory Access Attribute write-back, no write allocate policy.
 */
 #define ARM_MPU_CACHEP_WB_NWA 3U
 
 
 /**
-* Struct for a single MPU Region
+* \brief Struct for a single MPU Region
 */
 typedef struct {
   uint32_t RBAR; //!< The region base address register value (RBAR)

--- a/src/rp2_common/hardware_adc/include/hardware/adc.h
+++ b/src/rp2_common/hardware_adc/include/hardware/adc.h
@@ -14,7 +14,7 @@
 /** \file hardware/adc.h
  *  \defgroup hardware_adc hardware_adc
  *
- * Analog to Digital Converter (ADC) API
+ * \brief Analog to Digital Converter (ADC) API
  *
  * The RP2040 has an internal analogue-digital converter (ADC) with the following features:
  * - SAR ADC

--- a/src/rp2_common/hardware_base/include/hardware/address_mapped.h
+++ b/src/rp2_common/hardware_base/include/hardware/address_mapped.h
@@ -13,7 +13,7 @@
 /** \file address_mapped.h
  *  \defgroup hardware_base hardware_base
  *
- *  Low-level types and (atomic) accessors for memory-mapped hardware registers
+ *  \brief Low-level types and (atomic) accessors for memory-mapped hardware registers
  *
  *  `hardware_base` defines the low level types and access functions for memory mapped hardware registers. It is included
  *  by default by all other hardware libraries.

--- a/src/rp2_common/hardware_claim/include/hardware/claim.h
+++ b/src/rp2_common/hardware_claim/include/hardware/claim.h
@@ -13,7 +13,7 @@
 /** \file claim.h
  *  \defgroup hardware_claim hardware_claim
  *
- *  Lightweight hardware resource management
+ *  \brief Lightweight hardware resource management
  *
  * `hardware_claim` provides a simple API for management of hardware resources at runtime.
  *

--- a/src/rp2_common/hardware_clocks/include/hardware/clocks.h
+++ b/src/rp2_common/hardware_clocks/include/hardware/clocks.h
@@ -17,7 +17,7 @@ extern "C" {
 /** \file hardware/clocks.h
  *  \defgroup hardware_clocks hardware_clocks
  *
- * Clock Management API
+ * \brief Clock Management API
  *
  * This API provides a high level interface to the clock functions.
  *

--- a/src/rp2_common/hardware_divider/include/hardware/divider.h
+++ b/src/rp2_common/hardware_divider/include/hardware/divider.h
@@ -13,7 +13,7 @@
 /** \file hardware/divider.h
  *  \defgroup hardware_divider hardware_divider
  *
- * Low-level hardware-divider access
+ * \brief Low-level hardware-divider access
  *
  * The SIO contains an 8-cycle signed/unsigned divide/modulo circuit, per core. Calculation is started by writing a dividend
  * and divisor to the two argument registers, DIVIDEND and DIVISOR. The divider calculates the quotient / and remainder % of

--- a/src/rp2_common/hardware_dma/include/hardware/dma.h
+++ b/src/rp2_common/hardware_dma/include/hardware/dma.h
@@ -19,7 +19,7 @@ extern "C" {
 /** \file hardware/dma.h
  *  \defgroup hardware_dma hardware_dma
  *
- * DMA Controller API
+ * \brief DMA Controller API
  *
  * The RP2040 Direct Memory Access (DMA) master performs bulk data transfers on a processor’s
  * behalf. This leaves processors free to attend to other tasks, or enter low-power sleep states. The

--- a/src/rp2_common/hardware_exception/include/hardware/exception.h
+++ b/src/rp2_common/hardware_exception/include/hardware/exception.h
@@ -13,7 +13,7 @@
 /** \file exception.h
  *  \defgroup hardware_exception hardware_exception
  *
- * Methods for setting processor exception handlers
+ * \brief Methods for setting processor exception handlers
  *
  * Exceptions are identified by a \ref exception_number which is a number from -15 to -1; these are the numbers relative to
  * the index of the first IRQ vector in the vector table. (i.e. vector table index is exception_num plus 16)

--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -12,7 +12,7 @@
 /** \file flash.h
  *  \defgroup hardware_flash hardware_flash
  *
- * Low level flash programming and erase API
+ * \brief Low level flash programming and erase API
  *
  * Note these functions are *unsafe* if you are using both cores, and the other 
  * is executing from flash concurrently with the operation. In this could be the 

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -25,7 +25,7 @@ extern "C" {
 /** \file gpio.h
  *  \defgroup hardware_gpio hardware_gpio
  *
- * General Purpose Input/Output (GPIO) API
+ * \brief General Purpose Input/Output (GPIO) API
  *
  * RP2040 has 36 multi-functional General Purpose Input / Output (GPIO) pins, divided into two banks. In a typical use case,
  * the pins in the QSPI bank (QSPI_SS, QSPI_SCLK and QSPI_SD0 to QSPI_SD3) are used to execute code from an external

--- a/src/rp2_common/hardware_i2c/include/hardware/i2c.h
+++ b/src/rp2_common/hardware_i2c/include/hardware/i2c.h
@@ -24,7 +24,7 @@ extern "C" {
 /** \file hardware/i2c.h
  *  \defgroup hardware_i2c hardware_i2c
  *
- * I2C Controller API
+ * \brief I2C Controller API
  *
  * The I2C bus is a two-wire serial interface, consisting of a serial data line SDA and a serial clock SCL. These wires carry
  * information between the devices connected to the bus. Each device is recognized by a unique 7-bit address and can operate as

--- a/src/rp2_common/hardware_interp/include/hardware/interp.h
+++ b/src/rp2_common/hardware_interp/include/hardware/interp.h
@@ -23,7 +23,7 @@ extern "C" {
 /** \file hardware/interp.h
  *  \defgroup hardware_interp hardware_interp
  *
- * Hardware Interpolator API
+ * \brief Hardware Interpolator API
  *
  * Each core is equipped with two interpolators (INTERP0 and INTERP1) which can be used to accelerate
  * tasks by combining certain pre-configured simple operations into a single processor cycle. Intended

--- a/src/rp2_common/hardware_irq/include/hardware/irq.h
+++ b/src/rp2_common/hardware_irq/include/hardware/irq.h
@@ -33,7 +33,7 @@
 /** \file irq.h
  *  \defgroup hardware_irq hardware_irq
  *
- * Hardware interrupt handling
+ * \brief Hardware interrupt handling
  *
  * The RP2040 uses the standard ARM nested vectored interrupt controller (NVIC).
  *

--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -22,7 +22,7 @@
 /** \file hardware/pio.h
  *  \defgroup hardware_pio hardware_pio
  *
- * Programmable I/O (PIO) API
+ * \brief Programmable I/O (PIO) API
  *
  * A programmable input/output block (PIO) is a versatile hardware interface which
  * can support a number of different IO standards. There are two PIO blocks in the RP2040.

--- a/src/rp2_common/hardware_pll/include/hardware/pll.h
+++ b/src/rp2_common/hardware_pll/include/hardware/pll.h
@@ -17,7 +17,7 @@ extern "C" {
 /** \file hardware/pll.h
  *  \defgroup hardware_pll hardware_pll
  *
- * Phase Locked Loop control APIs
+ * \brief Phase Locked Loop control APIs
  *
  * There are two PLLs in RP2040. They are:
  *   - pll_sys - Used to generate up to a 133MHz system clock

--- a/src/rp2_common/hardware_pwm/include/hardware/pwm.h
+++ b/src/rp2_common/hardware_pwm/include/hardware/pwm.h
@@ -23,7 +23,7 @@ extern "C" {
 /** \file hardware/pwm.h
  *  \defgroup hardware_pwm hardware_pwm
  *
- * Hardware Pulse Width Modulation (PWM) API
+ * \brief Hardware Pulse Width Modulation (PWM) API
  *
  * The RP2040 PWM block has 8 identical slices. Each slice can drive two PWM output signals, or
  * measure the frequency or duty cycle of an input signal. This gives a total of up to 16 controllable

--- a/src/rp2_common/hardware_resets/include/hardware/resets.h
+++ b/src/rp2_common/hardware_resets/include/hardware/resets.h
@@ -13,7 +13,7 @@
 /** \file hardware/resets.h
  *  \defgroup hardware_resets hardware_resets
  *
- * Hardware Reset API
+ * \brief Hardware Reset API
  *
  * The reset controller allows software control of the resets to all of the peripherals that are not
  * critical to boot the processor in the RP2040.

--- a/src/rp2_common/hardware_rtc/include/hardware/rtc.h
+++ b/src/rp2_common/hardware_rtc/include/hardware/rtc.h
@@ -13,7 +13,7 @@
 /** \file hardware/rtc.h
  *  \defgroup hardware_rtc hardware_rtc
  *
- * Hardware Real Time Clock API
+ * \brief Hardware Real Time Clock API
  *
  * The RTC keeps track of time in human readable format and generates events when the time is equal
  * to a preset value. Think of a digital clock, not epoch time used by most computers. There are seven

--- a/src/rp2_common/hardware_spi/include/hardware/spi.h
+++ b/src/rp2_common/hardware_spi/include/hardware/spi.h
@@ -23,7 +23,7 @@ extern "C" {
 /** \file hardware/spi.h
  *  \defgroup hardware_spi hardware_spi
  *
- * Hardware SPI API
+ * \brief Hardware SPI API
  *
  * RP2040 has 2 identical instances of the Serial Peripheral Interface (SPI) controller.
  *
@@ -42,7 +42,7 @@ extern "C" {
 // PICO_CONFIG: PICO_DEFAULT_SPI_CSN_PIN, Define the default SPI CSN pin, min=0, max=29, group=hardware_spi
 
 /**
- * Opaque type representing an SPI instance.
+ * \brief Opaque type representing an SPI instance.
  */
 typedef struct spi_inst spi_inst_t;
 
@@ -99,6 +99,7 @@ typedef enum {
 
 /*! \brief Initialise SPI instances
  *  \ingroup hardware_spi
+ *
  * Puts the SPI into a known state, and enable it. Must be called before other
  * functions.
  *
@@ -113,6 +114,7 @@ uint spi_init(spi_inst_t *spi, uint baudrate);
 
 /*! \brief Deinitialise SPI instances
  *  \ingroup hardware_spi
+ *
  * Puts the SPI into a disabled state. Init will need to be called to reenable the device
  * functions.
  *

--- a/src/rp2_common/hardware_sync/include/hardware/sync.h
+++ b/src/rp2_common/hardware_sync/include/hardware/sync.h
@@ -18,7 +18,7 @@ extern "C" {
 /** \file hardware/sync.h
  *  \defgroup hardware_sync hardware_sync
  *
- * Low level hardware spin locks, barrier and processor event APIs
+ * \brief Low level hardware spin locks, barrier and processor event APIs
  *
  * Spin Locks
  * ----------

--- a/src/rp2_common/hardware_timer/include/hardware/timer.h
+++ b/src/rp2_common/hardware_timer/include/hardware/timer.h
@@ -17,7 +17,7 @@ extern "C" {
 /** \file hardware/timer.h
  *  \defgroup hardware_timer hardware_timer
  *
- * Low-level hardware timer API
+ * \brief Low-level hardware timer API
  *
  * This API provides medium level access to the timer HW.
  * See also \ref pico_time which provides higher levels functionality using the hardware timer.

--- a/src/rp2_common/hardware_uart/include/hardware/uart.h
+++ b/src/rp2_common/hardware_uart/include/hardware/uart.h
@@ -42,7 +42,7 @@ extern "C" {
 /** \file hardware/uart.h
  *  \defgroup hardware_uart hardware_uart
  *
- * Hardware UART API
+ * \brief Hardware UART API
  *
  * RP2040 has 2 identical instances of a UART peripheral, based on the ARM PL011. Each UART can be connected to a number
  * of GPIO pins as defined in the GPIO muxing.

--- a/src/rp2_common/hardware_vreg/include/hardware/vreg.h
+++ b/src/rp2_common/hardware_vreg/include/hardware/vreg.h
@@ -17,7 +17,7 @@ extern "C" {
 /** \file vreg.h
  *  \defgroup hardware_vreg hardware_vreg
  *
- * Voltage Regulation API
+ * \brief Voltage Regulation API
  *
  */
 

--- a/src/rp2_common/hardware_watchdog/include/hardware/watchdog.h
+++ b/src/rp2_common/hardware_watchdog/include/hardware/watchdog.h
@@ -13,7 +13,7 @@
 /** \file hardware/watchdog.h
  *  \defgroup hardware_watchdog hardware_watchdog
  *
- * Hardware Watchdog Timer API
+ * \brief Hardware Watchdog Timer API
  *
  * Supporting functions for the Pico hardware watchdog timer.
  *
@@ -106,7 +106,7 @@ bool watchdog_caused_reboot(void);
 bool watchdog_enable_caused_reboot(void);
 
 /**
- * @brief Returns the number of microseconds before the watchdog will reboot the chip.
+ * \brief Returns the number of microseconds before the watchdog will reboot the chip.
  * \ingroup hardware_watchdog
  *
  * @return The number of microseconds before the watchdog will reboot the chip.

--- a/src/rp2_common/hardware_xosc/include/hardware/xosc.h
+++ b/src/rp2_common/hardware_xosc/include/hardware/xosc.h
@@ -26,7 +26,7 @@ extern "C" {
 /** \file hardware/xosc.h
  *  \defgroup hardware_xosc hardware_xosc
  *
- * Crystal Oscillator (XOSC) API
+ * \brief Crystal Oscillator (XOSC) API
  */
 
 /*! \brief  Initialise the crystal oscillator system

--- a/src/rp2_common/pico_async_context/include/pico/async_context.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context.h
@@ -7,7 +7,7 @@
 /** \file pico/async_context.h
  *  \defgroup pico_async_context pico_async_context
  *
- * An \ref async_context provides a logically single-threaded context for performing work, and responding
+ * \brief An \ref async_context provides a logically single-threaded context for performing work, and responding
  * to asynchronous events. Thus an async_context instance is suitable for servicing third-party libraries
  * that are not re-entrant.
  *
@@ -89,11 +89,11 @@ typedef struct async_context async_context_t;
  */
 typedef struct async_work_on_timeout {
     /*!
-     * private link list pointer
+     * \brief private link list pointer
      */
     struct async_work_on_timeout *next;
     /*!
-     * Method called when the timeout is reached; may not be NULL
+     * \brief Method called when the timeout is reached; may not be NULL
      *
      * Note, that when this method is called, the timeout has been removed from the async_context, so
      * if you want the timeout to repeat, you should re-add it during this callback
@@ -102,12 +102,12 @@ typedef struct async_work_on_timeout {
      */
     void (*do_work)(async_context_t *context, struct async_work_on_timeout *timeout);
     /*!
-     * The next timeout time; this should only be modified during the above methods
+     * \brief The next timeout time; this should only be modified during the above methods
      * or via async_context methods
      */
     absolute_time_t next_time;
     /*!
-     * User data associated with the timeout instance
+     * \brief User data associated with the timeout instance
      */
     void *user_data;
 } async_at_time_worker_t;
@@ -124,22 +124,22 @@ typedef struct async_work_on_timeout {
  */
 typedef struct async_when_pending_worker {
     /*!
-     * private link list pointer
+     * \brief private link list pointer
      */
     struct async_when_pending_worker *next;
     /*!
-     * Called by the async_context when the worker has been marked as having "work pending"
+     * \brief Called by the async_context when the worker has been marked as having "work pending"
      *
      * @param context the async_context
      * @param worker the function to be called when work is pending
      */
     void (*do_work)(async_context_t *context, struct async_when_pending_worker *worker);
     /**
-     * True if the worker need do_work called
+     * \brief True if the worker need do_work called
      */
     bool work_pending;
     /*!
-     * User data associated with the worker instance
+     * \brief User data associated with the worker instance
      */
     void *user_data;
 } async_when_pending_worker_t;

--- a/src/rp2_common/pico_async_context/include/pico/async_context_freertos.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context_freertos.h
@@ -11,7 +11,7 @@
  *  \defgroup async_context_freertos async_context_freertos
  *  \ingroup pico_async_context
  *  
- * async_context_freertos provides an implementation of \ref async_context that handles asynchronous
+ * \brief async_context_freertos provides an implementation of \ref async_context that handles asynchronous
  * work in a separate FreeRTOS task.
  */
 #include "pico/async_context.h"
@@ -40,15 +40,15 @@ typedef struct async_context_freertos async_context_freertos_t;
  */
 typedef struct async_context_freertos_config {
     /**
-     * Task priority for the async_context task
+     * \brief Task priority for the async_context task
      */
     UBaseType_t task_priority;
     /**
-     * Stack size for the async_context task
+     * \brief Stack size for the async_context task
      */
     configSTACK_DEPTH_TYPE task_stack_size;
     /**
-     * the core ID (see \ref portGET_CORE_ID()) to pin the task to.
+     * \brief the core ID (see \ref portGET_CORE_ID()) to pin the task to.
      * This is only relevant in SMP mode.
      */
 #if configUSE_CORE_AFFINITY && configNUM_CORES > 1

--- a/src/rp2_common/pico_async_context/include/pico/async_context_poll.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context_poll.h
@@ -11,7 +11,7 @@
  *  \defgroup async_context_poll async_context_poll
  *  \ingroup pico_async_context
  *
- * async_context_poll provides an implementation of \ref async_context that is intended for use with a simple
+ * \brief async_context_poll provides an implementation of \ref async_context that is intended for use with a simple
  * polling loop on one core. It is not thread safe.
  *
  * The \ref async_context_poll() method must be called periodically to handle asynchronous work that may now be

--- a/src/rp2_common/pico_async_context/include/pico/async_context_threadsafe_background.h
+++ b/src/rp2_common/pico_async_context/include/pico/async_context_threadsafe_background.h
@@ -11,7 +11,7 @@
  *  \defgroup async_context_threadsafe_background async_context_threadsafe_background
  *  \ingroup pico_async_context
  *  
- * async_context_threadsafe_background provides an implementation of \ref async_context that handles asynchronous
+ * \brief async_context_threadsafe_background provides an implementation of \ref async_context that handles asynchronous
  * work in a low priority IRQ, and there is no need for the user to poll for work.
  *
  * \note The workers used with this async_context MUST be safe to call from an IRQ.
@@ -37,11 +37,11 @@ typedef struct async_context_threadsafe_background async_context_threadsafe_back
  */
 typedef struct async_context_threadsafe_background_config {
 /**
- * the priority of the low priority IRQ
+ * \brief the priority of the low priority IRQ
  */
     uint8_t low_priority_irq_handler_priority;
     /**
-     * a specific alarm pool to use (or NULL to use ta default)
+     * \brief a specific alarm pool to use (or NULL to use ta default)
      *
      * \note this alarm pool MUST be on the same core as the async_context
      *

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -11,7 +11,7 @@
 
 /** \file bootrom.h
  * \defgroup pico_bootrom pico_bootrom
- * Access to functions and data in the RP2040 bootrom
+ * \brief Access to functions and data in the RP2040 bootrom
  *
  * This header may be included by assembly code
  */

--- a/src/rp2_common/pico_bootsel_via_double_reset/pico_bootsel_via_double_reset.c
+++ b/src/rp2_common/pico_bootsel_via_double_reset/pico_bootsel_via_double_reset.c
@@ -23,7 +23,7 @@
 
 /** \defgroup pico_bootsel_via_double_reset pico_bootsel_via_double_reset
  *
- * When the 'pico_bootsel_via_double_reset' library is linked, a function is
+ * \brief When the 'pico_bootsel_via_double_reset' library is linked, a function is
  * injected before main() which will detect when the system has been reset
  * twice in quick succession, and enter the USB ROM bootloader (BOOTSEL mode)
  * when this happens. This allows a double tap of a reset button on a

--- a/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
+++ b/src/rp2_common/pico_cyw43_arch/include/pico/cyw43_arch.h
@@ -46,7 +46,7 @@ extern "C" {
 /** \file pico/cyw43_arch.h
  *  \defgroup pico_cyw43_arch pico_cyw43_arch
  *
- * Architecture for integrating the CYW43 driver (for the wireless on Pico W) and lwIP (for TCP/IP stack) into the SDK. It is also necessary for accessing the on-board LED on Pico W
+ * \brief Architecture for integrating the CYW43 driver (for the wireless on Pico W) and lwIP (for TCP/IP stack) into the SDK. It is also necessary for accessing the on-board LED on Pico W
  *
  * Both the low level \c cyw43_driver and the lwIP stack require periodic servicing, and have limitations
  * on whether they can be called from multiple cores/threads.

--- a/src/rp2_common/pico_cyw43_driver/include/pico/cyw43_driver.h
+++ b/src/rp2_common/pico_cyw43_driver/include/pico/cyw43_driver.h
@@ -10,7 +10,7 @@
 /** \file pico/cyw43_driver.h
  *  \defgroup pico_cyw43_driver pico_cyw43_driver
  *
- * A wrapper around the lower level cyw43_driver, that integrates it with \ref pico_async_context
+ * \brief A wrapper around the lower level cyw43_driver, that integrates it with \ref pico_async_context
  * for handling background work.
  */
 

--- a/src/rp2_common/pico_double/include/pico/double.h
+++ b/src/rp2_common/pico_double/include/pico/double.h
@@ -18,7 +18,7 @@ extern "C" {
 /** \file double.h
 *  \defgroup pico_double pico_double
 *
-* Optimized double-precision floating point functions
+* \brief Optimized double-precision floating point functions
 *
 * (Replacement) optimized implementations are provided of the following compiler built-ins
 * and math library functions:

--- a/src/rp2_common/pico_flash/include/pico/flash.h
+++ b/src/rp2_common/pico_flash/include/pico/flash.h
@@ -15,7 +15,7 @@
 /** \file pico/flash.h
  *  \defgroup pico_flash pico_flash
  *
- * High level flash API
+ * \brief High level flash API
  *
  * Flash cannot be erased or written to when in XIP mode. However the system cannot directly access memory in the flash
  * address space when not in XIP mode.
@@ -57,7 +57,7 @@ extern "C" {
 #endif
 
 /**
- * Initialize a core such that the other core can lock it out during \ref flash_safe_execute.
+ * \brief Initialize a core such that the other core can lock it out during \ref flash_safe_execute.
  * \ingroup pico_flash
  *
  * \note This is not necessary for FreeRTOS SMP, but should be used when launching via \ref multicore_launch_core1
@@ -66,14 +66,14 @@ extern "C" {
 bool flash_safe_execute_core_init(void);
 
 /**
- * De-initialize work done by \ref flash_safe_execute_core_init
+ * \brief De-initialize work done by \ref flash_safe_execute_core_init
  * \ingroup pico_flash
  * \return true on success
  */
 bool flash_safe_execute_core_deinit(void);
 
 /**
- * Execute a function with IRQs disabled and with the other core also not executing/reading flash
+ * \brief Execute a function with IRQs disabled and with the other core also not executing/reading flash
  * \ingroup pico_flash
  *
  * \param func the function to call
@@ -125,7 +125,7 @@ typedef struct {
 } flash_safety_helper_t;
 
 /**
- * Internal method to return the flash safety helper implementation.
+ * \brief Internal method to return the flash safety helper implementation.
  * \ingroup pico_flash
  *
  * Advanced users can provide their own implementation of this function to perform

--- a/src/rp2_common/pico_float/include/pico/float.h
+++ b/src/rp2_common/pico_float/include/pico/float.h
@@ -19,7 +19,7 @@ extern "C" {
 /** \file float.h
 * \defgroup pico_float pico_float
 *
-* Optimized single-precision floating point functions
+* \brief Optimized single-precision floating point functions
 *
 * (Replacement) optimized implementations are provided of the following compiler built-ins
 * and math library functions:

--- a/src/rp2_common/pico_i2c_slave/include/pico/i2c_slave.h
+++ b/src/rp2_common/pico_i2c_slave/include/pico/i2c_slave.h
@@ -17,7 +17,7 @@ extern "C" {
 /** \file pico/i2c_slave.h
  * \defgroup pico_i2c_slave pico_i2c_slave
  *
- * Functions providing an interrupt driven I2C slave interface.
+ * \brief Functions providing an interrupt driven I2C slave interface.
  *
  * This I2C slave helper library configures slave mode and hooks the relevant I2C IRQ
  * so that a user supplied handler is called with enumerated I2C events.
@@ -32,9 +32,9 @@ extern "C" {
  */
 typedef enum i2c_slave_event_t
 {
-    I2C_SLAVE_RECEIVE, /**< Data from master is available for reading. Slave must read from Rx FIFO. */
-    I2C_SLAVE_REQUEST, /**< Master is requesting data. Slave must write into Tx FIFO. */
-    I2C_SLAVE_FINISH, /**< Master has sent a Stop or Restart signal. Slave may prepare for the next transfer. */
+    I2C_SLAVE_RECEIVE, ///< Data from master is available for reading. Slave must read from Rx FIFO.
+    I2C_SLAVE_REQUEST, ///< Master is requesting data. Slave must write into Tx FIFO.
+    I2C_SLAVE_FINISH, ///< Master has sent a Stop or Restart signal. Slave may prepare for the next transfer.
 } i2c_slave_event_t;
 
 /**

--- a/src/rp2_common/pico_int64_ops/include/pico/int64_ops.h
+++ b/src/rp2_common/pico_int64_ops/include/pico/int64_ops.h
@@ -12,7 +12,7 @@
 /** \file int64_ops.h
  *  \defgroup pico_int64_ops pico_int64_ops
  *
- * Optimized replacement implementations of the compiler built-in 64 bit multiplication
+ * \brief Optimized replacement implementations of the compiler built-in 64 bit multiplication
  *
  * This library does not provide any additional functions
 */

--- a/src/rp2_common/pico_malloc/include/pico/malloc.h
+++ b/src/rp2_common/pico_malloc/include/pico/malloc.h
@@ -10,7 +10,7 @@
 /** \file malloc.h
 *  \defgroup pico_malloc pico_malloc
 *
-* Multi-core safety for malloc, calloc and free
+* \brief Multi-core safety for malloc, calloc and free
 *
 * This library does not provide any additional functions
 */

--- a/src/rp2_common/pico_mem_ops/include/pico/mem_ops.h
+++ b/src/rp2_common/pico_mem_ops/include/pico/mem_ops.h
@@ -12,7 +12,7 @@
 /** \file mem_ops.h
  *  \defgroup pico_mem_ops pico_mem_ops
  *
- * Provides optimized replacement implementations of the compiler built-in memcpy, memset and related functions:
+ * \brief Provides optimized replacement implementations of the compiler built-in memcpy, memset and related functions:
  *
  * - memset, memcpy
  * - __aeabi_memset, __aeabi_memset4, __aeabi_memset8, __aeabi_memcpy, __aeabi_memcpy4, __aeabi_memcpy8

--- a/src/rp2_common/pico_multicore/include/pico/multicore.h
+++ b/src/rp2_common/pico_multicore/include/pico/multicore.h
@@ -17,7 +17,7 @@ extern "C" {
 
 /** \file multicore.h
  *  \defgroup pico_multicore pico_multicore
- * Adds support for running code on the second processor core (core 1)
+ * \brief Adds support for running code on the second processor core (core 1)
  *
  * \subsection multicore_example Example
  * \addtogroup pico_multicore

--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -10,7 +10,7 @@
 /** \file platform.h
  *  \defgroup pico_platform pico_platform
  *
- * Macros and definitions (and functions when included by non assembly code) for the RP2 family device / architecture
+ * \brief Macros and definitions (and functions when included by non assembly code) for the RP2 family device / architecture
  * to provide a common abstraction over low level compiler / platform specifics.
  *
  * This header may be included by assembly code

--- a/src/rp2_common/pico_printf/include/pico/printf.h
+++ b/src/rp2_common/pico_printf/include/pico/printf.h
@@ -35,7 +35,7 @@
 /** \file printf.h
  *  \defgroup pico_printf pico_printf
  *
- * Compact replacement for printf by Marco Paland (info@paland.com)
+ * \brief Compact replacement for printf by Marco Paland (info@paland.com)
  */
 
 #ifdef __cplusplus
@@ -70,7 +70,7 @@ bool weak_raw_vprintf(const char *fmt, va_list args);
 #endif
 
 /**
- * printf with output function
+ * \brief printf with output function
  * You may use this as dynamic alternative to printf() with its fixed _putchar() output
  * \param out An output function which takes one character and an argument pointer
  * \param arg An argument pointer for user data passed to output function

--- a/src/rp2_common/pico_rand/include/pico/rand.h
+++ b/src/rp2_common/pico_rand/include/pico/rand.h
@@ -16,7 +16,7 @@ extern "C" {
 /** \file pico/rand.h
  *  \defgroup pico_rand pico_rand
  *
- * Random Number Generator API
+ * \brief Random Number Generator API
  *
  * This module generates random numbers at runtime utilizing a number of possible entropy
  * sources and uses those sources to modify the state of a 128-bit 'Pseudo

--- a/src/rp2_common/pico_runtime/include/pico/runtime.h
+++ b/src/rp2_common/pico_runtime/include/pico/runtime.h
@@ -13,7 +13,7 @@ extern "C" {
 
 /** \file runtime.h
 *  \defgroup pico_runtime pico_runtime
-* Aggregate runtime support including @ref pico_bit_ops, @ref pico_divider, @ref pico_double, @ref pico_int64_ops, @ref pico_float, @ref pico_malloc, @ref pico_mem_ops and @ref pico_standard_link
+* \brief Aggregate runtime support including @ref pico_bit_ops, @ref pico_divider, @ref pico_double, @ref pico_int64_ops, @ref pico_float, @ref pico_malloc, @ref pico_mem_ops and @ref pico_standard_link
 */
 
 

--- a/src/rp2_common/pico_stdio/include/pico/stdio.h
+++ b/src/rp2_common/pico_stdio/include/pico/stdio.h
@@ -9,7 +9,7 @@
 
 /** \file stdio.h
 *  \defgroup pico_stdio pico_stdio
-* Customized stdio support allowing for input and output from UART, USB, semi-hosting etc.
+* \brief Customized stdio support allowing for input and output from UART, USB, semi-hosting etc.
 *
 * Note the API for adding additional input output devices is not yet considered stable
 */

--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -16,7 +16,7 @@ extern "C" {
 /** \file pico/unique_id.h
  *  \defgroup pico_unique_id pico_unique_id
  *
- * Unique device ID access API
+ * \brief Unique device ID access API
  *
  * RP2040 does not have an on-board unique identifier (all instances of RP2040
  * silicon are identical and have no persistent state). However, RP2040 boots

--- a/src/rp2_common/tinyusb/doc.h
+++ b/src/rp2_common/tinyusb/doc.h
@@ -1,7 +1,7 @@
 /**
  * \defgroup tinyusb_device tinyusb_device
- * <a href="https://github.com/hathach/tinyusb">TinyUSB</a> Device-mode support for the RP2040. The TinyUSB documentation site can be found <a href="https://docs.tinyusb.org/en/latest/">here</a>.
+ * \brief <a href="https://github.com/hathach/tinyusb">TinyUSB</a> Device-mode support for the RP2040. The TinyUSB documentation site can be found <a href="https://docs.tinyusb.org/en/latest/">here</a>.
  *
  * \defgroup tinyusb_host tinyusb_host
- * <a href="https://github.com/hathach/tinyusb">TinyUSB</a> Host-mode support for the RP2040.
+ * \brief <a href="https://github.com/hathach/tinyusb">TinyUSB</a> Host-mode support for the RP2040.
  */


### PR DESCRIPTION
This PR reformats the doxygen comment markup to make the generated documentation compatible with doxygen versions > 1.8.17, per discussion with @aallan and @mudge . Here's a summary of the changes:

- Implicit brief descriptions are made explicit, using the `\brief` tag
- Implicit detailed descriptions are separated from brief descriptions by a blank line
- Inline table markup is updated to use `///<` delimiters

Going forward, here are some notes to help maintain compatibility with higher doxygen versions:

### Brief Descriptions

Brief descriptions must always be preceded by `\brief`. Here are several examples:

```
/**
 * \brief I2C slave event types.
 * \ingroup pico_i2c_slave
 */
typedef enum i2c_slave_event_t
...
```

```
/**
 * \file pheap.h
 * \defgroup util_pheap pheap
 * \brief Pairing Heap Implementation
 * \ingroup pico_util
 *
 * pheap defines a simple pairing heap. The implementation simply tracks array indexes, it is up to
 * the user to provide storage for heap entries and a comparison function.
 *
 * NOTE: This class is not safe for concurrent usage. It should be externally protected. Furthermore
 * if used concurrently, the caller needs to protect around their use of the returned id.
 * For example, ph_remove_and_free_head returns the id of an element that is no longer in the heap.
 * The user can still use this to look at the data in their companion array, however obviously further operations
 * on the heap may cause them to overwrite that data as the id may be reused on subsequent operations
 *
 */
// PICO_CONFIG: PICO_PHEAP_MAX_ENTRIES, Maximum number of entries in the pheap, min=1, max=65534, default=255, group=pico_util
#ifndef PICO_PHEAP_MAX_ENTRIES
...
```

```
/** \file multicore.h
 *  \defgroup pico_multicore pico_multicore
 * \brief Adds support for running code on the second processor core (core 1)
 *
 * \subsection multicore_example Example
 * \addtogroup pico_multicore
 * \include multicore.c
*/

// PICO_CONFIG: PICO_CORE1_STACK_SIZE, Stack size for core 1, min=0x100, max=0x10000, default=PICO_STACK_SIZE (0x800), group=pico_multicore
#ifndef PICO_CORE1_STACK_SIZE
...
```

### Detailed Descriptions

To add a detailed description, add a blank line after the brief description, or use the `\details` tag. 

Here is an example of an implicit detailed description, where the description text is preceded by a blank line:

```
/** \file pico/divider.h
* \brief High level APIs including combined quotient and remainder functions for 32 and 64 bit accelerated by the hardware divider
* \ingroup pico_divider
*
* These functions all call __aeabi_idiv0 or __aebi_ldiv0 on division by zero
* passing the largest applicably signed value
*
* Functions with unsafe in their name do not save/restore divider state, so are unsafe to call from interrupts. Unsafe functions are slightly faster.
*/
```

And here is the same text with an explicit detailed description:

```
/** \file pico/divider.h
* \brief High level APIs including combined quotient and remainder functions for 32 and 64 bit accelerated by the hardware divider
* \ingroup pico_divider
* \details These functions all call __aeabi_idiv0 or __aebi_ldiv0 on division by zero
* passing the largest applicably signed value
*
* Functions with unsafe in their name do not save/restore divider state, so are unsafe to call from interrupts. Unsafe functions are slightly faster.
*/
```

### Inline enum documentation

You can generate a table for enum types using inline comments like this (note the `///<` opening delimeter and lack of a closing delimeter):

```
/**
 * \brief I2C slave event types.
 * \ingroup pico_i2c_slave
 */
typedef enum i2c_slave_event_t
{
    I2C_SLAVE_RECEIVE, ///< Data from master is available for reading. Slave must read from Rx FIFO.
    I2C_SLAVE_REQUEST, ///< Master is requesting data. Slave must write into Tx FIFO.
    I2C_SLAVE_FINISH, ///< Master has sent a Stop or Restart signal. Slave may prepare for the next transfer.
} i2c_slave_event_t;
```