### PR TITLE
Bug 1668 - method to prevent SYS_CLK being re-init'ed, for example after it was left running in 'lightsleep'

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install cmake
-          brew tap ArmMbed/homebrew-formulae
-          brew install arm-none-eabi-gcc
+          brew install --cask gcc-arm-embedded
 
       - name: Build Project
         # bash required otherwise this mysteriously (no error) fails at "Generating cyw43_bus_pio_spi.pio.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.27)
 
 # Note: this CMakeLists.txt can be used as a top-level CMakeLists.txt for the SDK itself. For all other uses
 # it is included as a subdirectory via the pico_sdk_init() method provided by pico_sdk_init.cmake
@@ -61,4 +61,3 @@ if (NOT TARGET _pico_sdk_inclusion_marker)
         pico_promote_common_scope_vars()
     endif()
 endif()
-

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       3. Setup a `CMakeLists.txt` like:
 
           ```cmake
-          cmake_minimum_required(VERSION 3.13)
+          cmake_minimum_required(VERSION 3.13...3.27)
 
           # initialize the SDK based on PICO_SDK_PATH
           # note: this must happen before project()
@@ -79,7 +79,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       1. Setup a `CMakeLists.txt` like:
 
           ```cmake
-          cmake_minimum_required(VERSION 3.13)
+          cmake_minimum_required(VERSION 3.13...3.27)
 
           # initialize pico-sdk from submodule
           # note: this must happen before project()

--- a/pico_sdk_version.cmake
+++ b/pico_sdk_version.cmake
@@ -6,10 +6,10 @@ set(PICO_SDK_VERSION_MAJOR 1)
 set(PICO_SDK_VERSION_MINOR 5)
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_REVISION, SDK version revision, type=int, group=pico_base
 # PICO_CMAKE_CONFIG: PICO_SDK_VERSION_REVISION, SDK version revision, type=int, group=pico_base
-set(PICO_SDK_VERSION_REVISION 1)
+set(PICO_SDK_VERSION_REVISION 2)
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_PRE_RELEASE_ID, optional SDK pre-release version identifier, type=string, group=pico_base
 # PICO_CMAKE_CONFIG: PICO_SDK_VERSION_PRE_RELEASE_ID, optional SDK pre-release version identifier, type=string, group=pico_base
-#set(PICO_SDK_VERSION_PRE_RELEASE_ID develop)
+set(PICO_SDK_VERSION_PRE_RELEASE_ID develop)
 
 # PICO_BUILD_DEFINE: PICO_SDK_VERSION_STRING, SDK version, type=string, group=pico_base
 # PICO_CMAKE_CONFIG: PICO_SDK_VERSION_STRING, SDK version, type=string, group=pico_base

--- a/src/boards/include/boards/metrotech_xerxes_rp2040.h
+++ b/src/boards/include/boards/metrotech_xerxes_rp2040.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+#ifndef _BOARDS_METROTECH_XERXES_RP2040_H
+#define _BOARDS_METROTECH_XERXES_RP2040_H
+
+
+#define USR_SW_PIN          18
+#define USR_BTN_PIN         24
+#define USR_LED_PIN         25
+    
+#define UART1_TX_PIN        8
+#define UART1_RX_PIN        9
+    
+#define UART0_TX_PIN        16
+#define UART0_RX_PIN        17
+    
+#define SPI0_MISO_PIN       0   
+#define SPI0_CSN_PIN        1
+#define SPI0_CLK_PIN        2
+#define SPI0_MOSI_PIN       3
+    
+#define I2C0_SDA_PIN        4
+#define I2C0_SCL_PIN        5
+    
+#define EXT_3V3_EN_PIN      6
+    
+#define RS_EN_PIN           19
+#define RS_TX_PIN           UART0_TX_PIN
+#define RS_RX_PIN           UART0_RX_PIN
+
+#define ADC0_PIN            26  // ADC0 and PWM5_A share the same pin
+#define ADC1_PIN            27  // ADC1 and PWM5_B share the same pin
+#define ADC2_PIN            28  // ADC2 and PWM6_A share the same pin
+#define ADC3_PIN            29  // ADC3 and PWM6_B share the same pin
+
+#define TMP0_PIN            22  // TMP0 and I2C1 share the same pin
+#define TMP1_PIN            23  // TMP1 and I2C1 share the same pin
+
+#define I2C1_SDA_PIN        22  // I2C1 and TMP0 share the same pin
+#define I2C1_SCL_PIN        23  // I2C1 and TMP1 share the same pin
+
+#define PWM0_A_PIN          0   // PWM0_A and SPI0_MISO share the same pin
+#define PWM0_B_PIN          1   // PWM0_B and SPI0_CSN share the same pin
+#define PWM1_A_PIN          2   // PWM1_A and SPI0_CLK share the same pin
+#define PWM1_B_PIN          3   // PWM1_B and SPI0_MOSI share the same pin
+#define PWM2_A_PIN          4   // PWM2_A and I2C0_SDA share the same pin
+#define PWM2_B_PIN          5   // PWM2_B and I2C0_SCL share the same pin
+#define PWM3_A_PIN          22  // PWM3_A and TMP0 share the same pin
+#define PWM3_B_PIN          23  // PWM3_B and TMP1 share the same pin
+#define PWM4_A_PIN          24  // PWM4_A and USR_BTN share the same pin
+#define PWM4_B_PIN          25  // PWM4_B and USR_LED share the same pin
+#define PWM5_A_PIN          26  // PWM5_A and ADC0 share the same pin
+#define PWM5_B_PIN          27  // PWM5_B and ADC1 share the same pin
+#define PWM6_A_PIN          28  // PWM6_A and ADC2 share the same pin
+#define PWM6_B_PIN          29  // PWM6_B and ADC3 share the same pin
+
+#define CLK_GPIN1_PIN       22  // CLK_GPIN1 and TMP0 share the same pin
+#define CLK_GPOUT1_PIN      23  // CLK_GPOUT1 and TMP1 share the same pin
+
+/// @brief Mask of pins that are used by the shield and not used by the board, eq. 0x3fc0033f
+#define SHIELD_MASK         1 << SPI0_MISO_PIN | 1 << SPI0_CSN_PIN | 1 << SPI0_CLK_PIN | 1 << SPI0_MOSI_PIN | \
+                            1 << I2C0_SDA_PIN | 1 << I2C0_SCL_PIN | \
+                            1 << UART1_TX_PIN | 1 << UART1_RX_PIN | \
+                            1 << ADC0_PIN | 1 << ADC1_PIN | 1 << ADC2_PIN | 1 << ADC3_PIN | \
+                            1 << TMP0_PIN | 1 << TMP1_PIN
+
+
+// For board detection
+#define XERXES_RP2040
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN UART0_TX_PIN
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN UART0_RX_PIN
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN USR_LED_PIN
+#endif
+// no PICO_DEFAULT_WS2812_PIN
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN I2C0_SDA_PIN
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN I2C0_SCL_PIN
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN SPI0_CLK_PIN
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN SPI0_MOSI_PIN
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN SPI0_MISO_PIN
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN SPI0_CSN_PIN
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef __CLKDIV 
+#define __CLKDIV 4
+#endif // !__CLKDIV
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+/**
+ * @brief divisor for SPI clock (default 4), must be divisible by 2
+ * 
+ * This is critical for some flash chips, and can be set to 4 for some, 
+ * but needs to be at least 32 for others. Set using -DCLKDIV=<N*2> in cmake.
+ * @note Increasing this value will help with BOOTLOOPs, but will slow down the flash chip.
+ */
+#define PICO_FLASH_SPI_CLKDIV __CLKDIV
+#endif // !PICO_FLASH_SPI_CLKDIV
+
+
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 16
+#endif // !PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+
+#ifndef PICO_FLASH_SIZE_BYTES
+/**
+ * @brief 16MiB, Flash size in bytes
+ * 
+ * This is the size of the flash chip on the board, not the size of the flash chip that is used for the bootloader.
+ */
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif // !PICO_FLASH_SIZE_BYTES
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED 
+#define PICO_RP2040_B0_SUPPORTED  0
+#endif // !PICO_RP2040_B0_SUPPORTED
+
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // _BOARDS_METROTECH_XERXES_RP2040_H

--- a/src/boards/include/boards/pololu_zumo_2040_robot.h
+++ b/src/boards/include/boards/pololu_zumo_2040_robot.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+#ifndef _POLOLU_ZUMO_2040_ROBOT_H
+#define _POLOLU_ZUMO_2040_ROBOT_H
+
+// For board detection
+#define POLOLU_ZUMO_2040_ROBOT
+
+#define PICO_DEFAULT_LED_PIN 25
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+#define PICO_FLASH_SPI_CLKDIV 2
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+
+// All boards have at least the B1 revision
+#define PICO_RP2040_B0_SUPPORTED 0
+
+#endif

--- a/src/boards/include/boards/waveshare_rp2040_zero.h
+++ b/src/boards/include/boards/waveshare_rp2040_zero.h
@@ -64,7 +64,7 @@
 #define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
 
 #ifndef PICO_FLASH_SPI_CLKDIV
-#define PICO_FLASH_SPI_CLKDIV 2
+#define PICO_FLASH_SPI_CLKDIV 4
 #endif
 
 #ifndef PICO_FLASH_SIZE_BYTES
@@ -72,7 +72,7 @@
 #endif
 
 // All boards have B1 RP2040
-#ifndef PICO_RP2040_B0_SUPPORTED 
+#ifndef PICO_RP2040_B0_SUPPORTED
 #define PICO_RP2040_B0_SUPPORTED  0
 #endif
 

--- a/src/boards/include/boards/weact_studio_rp2040_16mb.h
+++ b/src/boards/include/boards/weact_studio_rp2040_16mb.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/weact_studio_rp2040_16mb.h"
+
+#ifndef _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+#define _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+
+// For board detection
+#define WEACT_STUDIO_RP2040_16MB
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+#endif

--- a/src/boards/include/boards/weact_studio_rp2040_2mb.h
+++ b/src/boards/include/boards/weact_studio_rp2040_2mb.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/weact_studio_rp2040_16mb.h"
+
+#ifndef _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+#define _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+
+// For board detection
+#define WEACT_STUDIO_RP2040_16MB
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
+
+#endif

--- a/src/boards/include/boards/weact_studio_rp2040_4mb.h
+++ b/src/boards/include/boards/weact_studio_rp2040_4mb.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/weact_studio_rp2040_16mb.h"
+
+#ifndef _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+#define _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+
+// For board detection
+#define WEACT_STUDIO_RP2040_16MB
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+#endif

--- a/src/boards/include/boards/weact_studio_rp2040_8mb.h
+++ b/src/boards/include/boards/weact_studio_rp2040_8mb.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/weact_studio_rp2040_16mb.h"
+
+#ifndef _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+#define _BOARDS_WEACT_STUDIO_RP2040_16MB_H
+
+// For board detection
+#define WEACT_STUDIO_RP2040_16MB
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
+#endif
+
+#endif

--- a/src/common/pico_sync/include/pico/mutex.h
+++ b/src/common/pico_sync/include/pico/mutex.h
@@ -20,7 +20,7 @@ extern "C" {
  *
  * Mutexes are application level locks usually used protecting data structures that might be used by
  * multiple threads of execution. Unlike critical sections, the mutex protected code is not necessarily
- * required/expected to complete quickly, as no other sytem wide locks are held on account of an acquired mutex.
+ * required/expected to complete quickly, as no other system wide locks are held on account of an acquired mutex.
  *
  * When acquired, the mutex has an owner (see \ref lock_get_caller_owner_id) which with the plain SDK is just
  * the acquiring core, but in an RTOS it could be a task, or an IRQ handler context.

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -334,7 +334,6 @@ static void alarm_pool_dump_key(pheap_node_id_t id, void *user_data) {
 
 static int64_t repeating_timer_callback(__unused alarm_id_t id, void *user_data) {
     repeating_timer_t *rt = (repeating_timer_t *)user_data;
-    assert(rt->alarm_id == id);
     if (rt->callback(rt)) {
         return rt->delay_us;
     } else {

--- a/src/rp2_common/boot_stage2/boot2_is25lp080.S
+++ b/src/rp2_common/boot_stage2/boot2_is25lp080.S
@@ -82,7 +82,7 @@
 
 pico_default_asm_setup
 
-.section text
+.section .text
 regular_func _stage2_boot
     push {lr}
 

--- a/src/rp2_common/hardware_clocks/clocks.c
+++ b/src/rp2_common/hardware_clocks/clocks.c
@@ -20,6 +20,51 @@
 // customary 32 or 32.768kHz 'slow clock' crystals and provides good timing resolution.
 #define RTC_CLOCK_FREQ_HZ       (USB_CLK_KHZ * KHZ / 1024)
 
+// Clocks which are dependant on CLK_SYS
+#define CLOCKS_SLEEP_EN0_CLK_SYS_DEPENDANTS_BITS   ( \
+		CLOCKS_SLEEP_EN0_CLK_SYS_SRAM3_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_SRAM2_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_SRAM1_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_SRAM0_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_SPI1_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_SPI0_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_SIO_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_RTC_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_ROSC_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_ROM_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_RESETS_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_PWM_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_PSM_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_PLL_USB_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_PLL_SYS_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_PIO1_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_PIO0_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_PADS_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_VREG_AND_CHIP_RESET_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_JTAG_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_IO_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_I2C1_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_I2C0_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_DMA_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_BUSFABRIC_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_BUSCTRL_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_ADC_BITS | \
+		CLOCKS_SLEEP_EN0_CLK_SYS_CLOCKS_BITS )
+
+#define CLOCKS_SLEEP_EN1_CLK_SYS_DEPENDANTS_BITS   ( \
+		CLOCKS_SLEEP_EN1_CLK_SYS_XOSC_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_XIP_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_WATCHDOG_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_USBCTRL_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_UART1_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_UART0_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_TIMER_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_TBMAN_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_SYSINFO_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_SYSCFG_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_SRAM5_BITS | \
+		CLOCKS_SLEEP_EN1_CLK_SYS_SRAM4_BITS )
+
 check_hw_layout(clocks_hw_t, clk[clk_adc].selected, CLOCKS_CLK_ADC_SELECTED_OFFSET);
 check_hw_layout(clocks_hw_t, fc0.result, CLOCKS_FC0_RESULT_OFFSET);
 check_hw_layout(clocks_hw_t, ints, CLOCKS_INTS_OFFSET);
@@ -118,7 +163,11 @@ bool clock_configure(enum clock_index clk_index, uint32_t src, uint32_t auxsrc, 
 }
 /// \end::clock_configure[]
 
-void clocks_init(void) {
+void clocks_init() {
+    clocks_reinit(0, 0);
+}
+
+void clocks_reinit(uint32_t sleep_en0, uint32_t sleep_en1) {
     // Start tick in watchdog, the argument is in 'cycles per microsecond' i.e. MHz
     watchdog_start_tick(XOSC_KHZ / KHZ);
 
@@ -138,15 +187,20 @@ void clocks_init(void) {
     xosc_init();
 
     // Before we touch PLLs, switch sys and ref cleanly away from their aux sources.
-    hw_clear_bits(&clocks_hw->clk[clk_sys].ctrl, CLOCKS_CLK_SYS_CTRL_SRC_BITS);
-    while (clocks_hw->clk[clk_sys].selected != 0x1)
-        tight_loop_contents();
+    if (((sleep_en0 & CLOCKS_SLEEP_EN0_CLK_SYS_DEPENDANTS_BITS) == 0) &
+        ((sleep_en1 & CLOCKS_SLEEP_EN1_CLK_SYS_DEPENDANTS_BITS) == 0)) {
+		hw_clear_bits(&clocks_hw->clk[clk_sys].ctrl, CLOCKS_CLK_SYS_CTRL_SRC_BITS);
+		while (clocks_hw->clk[clk_sys].selected != 0x1)
+			tight_loop_contents();
+	}
     hw_clear_bits(&clocks_hw->clk[clk_ref].ctrl, CLOCKS_CLK_REF_CTRL_SRC_BITS);
     while (clocks_hw->clk[clk_ref].selected != 0x1)
         tight_loop_contents();
 
     /// \tag::pll_init[]
-    pll_init(pll_sys, PLL_COMMON_REFDIV, PLL_SYS_VCO_FREQ_KHZ * KHZ, PLL_SYS_POSTDIV1, PLL_SYS_POSTDIV2);
+    if (((sleep_en0 & CLOCKS_SLEEP_EN0_CLK_SYS_DEPENDANTS_BITS) == 0) &
+        ((sleep_en1 & CLOCKS_SLEEP_EN1_CLK_SYS_DEPENDANTS_BITS) == 0))
+        pll_init(pll_sys, PLL_COMMON_REFDIV, PLL_SYS_VCO_FREQ_KHZ * KHZ, PLL_SYS_POSTDIV1, PLL_SYS_POSTDIV2);
     pll_init(pll_usb, PLL_COMMON_REFDIV, PLL_USB_VCO_FREQ_KHZ * KHZ, PLL_USB_POSTDIV1, PLL_USB_POSTDIV2);
     /// \end::pll_init[]
 
@@ -160,11 +214,14 @@ void clocks_init(void) {
 
     /// \tag::configure_clk_sys[]
     // CLK SYS = PLL SYS (usually) 125MHz / 1 = 125MHz
-    clock_configure(clk_sys,
+    if (((sleep_en0 & CLOCKS_SLEEP_EN0_CLK_SYS_DEPENDANTS_BITS) == 0) &
+        ((sleep_en1 & CLOCKS_SLEEP_EN1_CLK_SYS_DEPENDANTS_BITS) == 0)) {
+		clock_configure(clk_sys,
                     CLOCKS_CLK_SYS_CTRL_SRC_VALUE_CLKSRC_CLK_SYS_AUX,
                     CLOCKS_CLK_SYS_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS,
                     SYS_CLK_KHZ * KHZ,
                     SYS_CLK_KHZ * KHZ);
+	}
     /// \end::configure_clk_sys[]
 
     // CLK USB = PLL USB 48MHz / 1 = 48MHz

--- a/src/rp2_common/hardware_clocks/include/hardware/clocks.h
+++ b/src/rp2_common/hardware_clocks/include/hardware/clocks.h
@@ -164,6 +164,7 @@ extern "C" {
  *  Must be called before any other clock function.
  */
 void clocks_init(void);
+void clocks_reinit(uint32_t sleep_en0, uint32_t sleep_en1);
 
 /*! \brief Configure the specified clock
  *  \ingroup hardware_clocks

--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -66,20 +66,20 @@ void __no_inline_not_in_flash_func(flash_range_erase)(uint32_t flash_offs, size_
 #endif
     invalid_params_if(FLASH, flash_offs & (FLASH_SECTOR_SIZE - 1));
     invalid_params_if(FLASH, count & (FLASH_SECTOR_SIZE - 1));
-    rom_connect_internal_flash_fn connect_internal_flash = (rom_connect_internal_flash_fn)rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
-    rom_flash_exit_xip_fn flash_exit_xip = (rom_flash_exit_xip_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
-    rom_flash_range_erase_fn flash_range_erase = (rom_flash_range_erase_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_RANGE_ERASE);
-    rom_flash_flush_cache_fn flash_flush_cache = (rom_flash_flush_cache_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
-    assert(connect_internal_flash && flash_exit_xip && flash_range_erase && flash_flush_cache);
+    rom_connect_internal_flash_fn connect_internal_flash_func = (rom_connect_internal_flash_fn)rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
+    rom_flash_exit_xip_fn flash_exit_xip_func = (rom_flash_exit_xip_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
+    rom_flash_range_erase_fn flash_range_erase_func = (rom_flash_range_erase_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_RANGE_ERASE);
+    rom_flash_flush_cache_fn flash_flush_cache_func = (rom_flash_flush_cache_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
+    assert(connect_internal_flash_func && flash_exit_xip_func && flash_range_erase_func && flash_flush_cache_func);
     flash_init_boot2_copyout();
 
     // No flash accesses after this point
     __compiler_memory_barrier();
 
-    connect_internal_flash();
-    flash_exit_xip();
-    flash_range_erase(flash_offs, count, FLASH_BLOCK_SIZE, FLASH_BLOCK_ERASE_CMD);
-    flash_flush_cache(); // Note this is needed to remove CSn IO force as well as cache flushing
+    connect_internal_flash_func();
+    flash_exit_xip_func();
+    flash_range_erase_func(flash_offs, count, FLASH_BLOCK_SIZE, FLASH_BLOCK_ERASE_CMD);
+    flash_flush_cache_func(); // Note this is needed to remove CSn IO force as well as cache flushing
     flash_enable_xip_via_boot2();
 }
 
@@ -89,18 +89,18 @@ void __no_inline_not_in_flash_func(flash_range_program)(uint32_t flash_offs, con
 #endif
     invalid_params_if(FLASH, flash_offs & (FLASH_PAGE_SIZE - 1));
     invalid_params_if(FLASH, count & (FLASH_PAGE_SIZE - 1));
-    rom_connect_internal_flash_fn connect_internal_flash = (rom_connect_internal_flash_fn)rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
-    rom_flash_exit_xip_fn flash_exit_xip = (rom_flash_exit_xip_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
-    rom_flash_range_program_fn flash_range_program = (rom_flash_range_program_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_RANGE_PROGRAM);
+    rom_connect_internal_flash_fn connect_internal_flash_func = (rom_connect_internal_flash_fn)rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
+    rom_flash_exit_xip_fn flash_exit_xip_func = (rom_flash_exit_xip_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
+    rom_flash_range_program_fn flash_range_program_func = (rom_flash_range_program_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_RANGE_PROGRAM);
     rom_flash_flush_cache_fn flash_flush_cache = (rom_flash_flush_cache_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
-    assert(connect_internal_flash && flash_exit_xip && flash_range_program && flash_flush_cache);
+    assert(connect_internal_flash_func && flash_exit_xip_func && flash_range_program_func && flash_flush_cache);
     flash_init_boot2_copyout();
 
     __compiler_memory_barrier();
 
-    connect_internal_flash();
-    flash_exit_xip();
-    flash_range_program(flash_offs, data, count);
+    connect_internal_flash_func();
+    flash_exit_xip_func();
+    flash_range_program_func(flash_offs, data, count);
     flash_flush_cache(); // Note this is needed to remove CSn IO force as well as cache flushing
     flash_enable_xip_via_boot2();
 }
@@ -122,14 +122,14 @@ static void __no_inline_not_in_flash_func(flash_cs_force)(bool high) {
 }
 
 void __no_inline_not_in_flash_func(flash_do_cmd)(const uint8_t *txbuf, uint8_t *rxbuf, size_t count) {
-    rom_connect_internal_flash_fn connect_internal_flash = (rom_connect_internal_flash_fn)rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
-    rom_flash_exit_xip_fn flash_exit_xip = (rom_flash_exit_xip_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
-    rom_flash_flush_cache_fn flash_flush_cache = (rom_flash_flush_cache_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
-    assert(connect_internal_flash && flash_exit_xip && flash_flush_cache);
+    rom_connect_internal_flash_fn connect_internal_flash_func = (rom_connect_internal_flash_fn)rom_func_lookup_inline(ROM_FUNC_CONNECT_INTERNAL_FLASH);
+    rom_flash_exit_xip_fn flash_exit_xip_func = (rom_flash_exit_xip_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_EXIT_XIP);
+    rom_flash_flush_cache_fn flash_flush_cache_func = (rom_flash_flush_cache_fn)rom_func_lookup_inline(ROM_FUNC_FLASH_FLUSH_CACHE);
+    assert(connect_internal_flash_func && flash_exit_xip_func && flash_flush_cache_func);
     flash_init_boot2_copyout();
     __compiler_memory_barrier();
-    connect_internal_flash();
-    flash_exit_xip();
+    connect_internal_flash_func();
+    flash_exit_xip_func();
 
     flash_cs_force(0);
     size_t tx_remaining = count;
@@ -151,7 +151,7 @@ void __no_inline_not_in_flash_func(flash_do_cmd)(const uint8_t *txbuf, uint8_t *
     }
     flash_cs_force(1);
 
-    flash_flush_cache();
+    flash_flush_cache_func();
     flash_enable_xip_via_boot2();
 }
 #endif

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -344,7 +344,7 @@ enum gpio_slew_rate gpio_get_slew_rate(uint gpio);
  */
 void gpio_set_drive_strength(uint gpio, enum gpio_drive_strength drive);
 
-/*! \brief Determine current slew rate for a specified GPIO
+/*! \brief Determine current drive strength for a specified GPIO
  *  \ingroup hardware_gpio
  *
  * \sa gpio_set_drive_strength

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -370,7 +370,7 @@ enum gpio_drive_strength gpio_get_drive_strength(uint gpio);
  * Events is a bitmask of the following \ref gpio_irq_level values:
  *
  * bit | constant            | interrupt
- * ----|----------------------------------------------------------
+ * ----|---------------------|------------------------------------
  *   0 | GPIO_IRQ_LEVEL_LOW  | Continuously while level is low
  *   1 | GPIO_IRQ_LEVEL_HIGH | Continuously while level is high
  *   2 | GPIO_IRQ_EDGE_FALL  | On each transition from high to low

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -493,6 +493,8 @@ void gpio_acknowledge_irq(uint gpio, uint32_t event_mask);
  * This method adds such an explicit GPIO IRQ handler, and disables the "default" callback for the specified GPIOs.
  *
  * \note Multiple raw handlers should not be added for the same GPIOs, and this method will assert if you attempt to.
+ * Internally, this function calls \ref irq_add_shared_handler, which will assert if the maximum number of shared handlers
+ * (configurable via PICO_MAX_IRQ_SHARED_HANDLERS) would be exceeded.
  *
  * A raw handler should check for whichever GPIOs and events it handles, and acknowledge them itself; it might look something like:
  *
@@ -526,6 +528,8 @@ void gpio_add_raw_irq_handler_with_order_priority_masked(uint gpio_mask, irq_han
  * This method adds such a callback, and disables the "default" callback for the specified GPIO.
  *
  * \note Multiple raw handlers should not be added for the same GPIO, and this method will assert if you attempt to.
+ * Internally, this function calls \ref irq_add_shared_handler, which will assert if the maximum number of shared handlers
+ * (configurable via PICO_MAX_IRQ_SHARED_HANDLERS) would be exceeded.
  *
  * A raw handler should check for whichever GPIOs and events it handles, and acknowledge them itself; it might look something like:
  *
@@ -556,6 +560,8 @@ static inline void gpio_add_raw_irq_handler_with_order_priority(uint gpio, irq_h
  * This method adds such a callback, and disables the "default" callback for the specified GPIOs.
  *
  * \note Multiple raw handlers should not be added for the same GPIOs, and this method will assert if you attempt to.
+ * Internally, this function calls \ref irq_add_shared_handler, which will assert if the maximum number of shared handlers
+ * (configurable via PICO_MAX_IRQ_SHARED_HANDLERS) would be exceeded.
  *
  * A raw handler should check for whichever GPIOs and events it handles, and acknowledge them itself; it might look something like:
  *
@@ -586,6 +592,8 @@ void gpio_add_raw_irq_handler_masked(uint gpio_mask, irq_handler_t handler);
  * This method adds such a callback, and disables the "default" callback for the specified GPIO.
  *
  * \note Multiple raw handlers should not be added for the same GPIO, and this method will assert if you attempt to.
+ * Internally, this function calls \ref irq_add_shared_handler, which will assert if the maximum number of shared handlers
+ * (configurable via PICO_MAX_IRQ_SHARED_HANDLERS) would be exceeded.
  *
  * A raw handler should check for whichever GPIOs and events it handles, and acknowledge them itself; it might look something like:
  *

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -100,7 +100,7 @@ extern struct irq_handler_chain_slot {
     irq_handler_t handler;
 } irq_handler_chain_slots[PICO_MAX_SHARED_IRQ_HANDLERS];
 
-static int8_t irq_hander_chain_free_slot_head;
+static int8_t irq_handler_chain_free_slot_head;
 
 static inline bool is_shared_irq_raw_handler(irq_handler_t raw_handler) {
     return (uintptr_t)raw_handler - (uintptr_t)irq_handler_chain_slots < sizeof(irq_handler_chain_slots);
@@ -212,10 +212,10 @@ void irq_add_shared_handler(uint num, irq_handler_t handler, uint8_t order_prior
 #else
     spin_lock_t *lock = spin_lock_instance(PICO_SPINLOCK_ID_IRQ);
     uint32_t save = spin_lock_blocking(lock);
-    hard_assert(irq_hander_chain_free_slot_head >= 0); // we must have a slot
-    struct irq_handler_chain_slot *slot = &irq_handler_chain_slots[irq_hander_chain_free_slot_head];
-    int8_t slot_index = irq_hander_chain_free_slot_head;
-    irq_hander_chain_free_slot_head = slot->link;
+    hard_assert(irq_handler_chain_free_slot_head >= 0); // we must have a slot
+    struct irq_handler_chain_slot *slot = &irq_handler_chain_slots[irq_handler_chain_free_slot_head];
+    int8_t slot_index = irq_handler_chain_free_slot_head;
+    irq_handler_chain_free_slot_head = slot->link;
     irq_handler_t vtable_handler = get_vtable()[16 + num];
     if (!is_shared_irq_raw_handler(vtable_handler)) {
         // start new chain
@@ -332,8 +332,8 @@ void irq_remove_handler(uint num, irq_handler_t handler) {
                             0xbd01;                                                                // pop {r0, pc}
 
                     // add old next slot back to free list
-                    next_slot->link = irq_hander_chain_free_slot_head;
-                    irq_hander_chain_free_slot_head = next_slot_index;
+                    next_slot->link = irq_handler_chain_free_slot_head;
+                    irq_handler_chain_free_slot_head = next_slot_index;
                 } else {
                     // Slot being removed is at the end of the chain
                     if (!exception) {
@@ -347,8 +347,8 @@ void irq_remove_handler(uint num, irq_handler_t handler) {
                             vtable_handler = __unhandled_user_irq;
                         }
                         // add slot back to free list
-                        to_free_slot->link = irq_hander_chain_free_slot_head;
-                        irq_hander_chain_free_slot_head = get_slot_index(to_free_slot);
+                        to_free_slot->link = irq_handler_chain_free_slot_head;
+                        irq_handler_chain_free_slot_head = get_slot_index(to_free_slot);
                     } else {
                         // since we are the last slot we know that our inst3 hasn't executed yet, so we change
                         // it to bl to irq_handler_chain_remove_tail which will remove the slot.
@@ -418,8 +418,8 @@ void irq_add_tail_to_free_list(struct irq_handler_chain_slot *slot) {
         assert(found);
     }
     // add slot to free list
-    slot->link = irq_hander_chain_free_slot_head;
-    irq_hander_chain_free_slot_head = slot_index;
+    slot->link = irq_handler_chain_free_slot_head;
+    irq_handler_chain_free_slot_head = slot_index;
     spin_unlock(lock, save);
 }
 #endif

--- a/src/rp2_common/hardware_sync/include/hardware/sync.h
+++ b/src/rp2_common/hardware_sync/include/hardware/sync.h
@@ -262,7 +262,9 @@ __force_inline static void spin_lock_unsafe_blocking(spin_lock_t *lock) {
     // Note we don't do a wfe or anything, because by convention these spin_locks are VERY SHORT LIVED and NEVER BLOCK and run
     // with INTERRUPTS disabled (to ensure that)... therefore nothing on our core could be blocking us, so we just need to wait on another core
     // anyway which should be finished soon
-    while (__builtin_expect(!*lock, 0));
+    while (__builtin_expect(!*lock, 0)) {
+        tight_loop_contents();
+    }
     __mem_fence_acquire();
 }
 

--- a/src/rp2_common/hardware_watchdog/include/hardware/watchdog.h
+++ b/src/rp2_common/hardware_watchdog/include/hardware/watchdog.h
@@ -30,17 +30,22 @@
 extern "C" {
 #endif
 
+// PICO_CONFIG: PARAM_ASSERTIONS_ENABLED_WATCHDOG, Enable/disable assertions in the watchdog module, type=bool, default=0, group=hardware_watchdog
+#ifndef PARAM_ASSERTIONS_ENABLED_WATCHDOG
+#define PARAM_ASSERTIONS_ENABLED_WATCHDOG 0
+#endif
+
 /*! \brief Define actions to perform at watchdog timeout
  *  \ingroup hardware_watchdog
  *
  * \note If \ref watchdog_start_tick value does not give a 1MHz clock to the watchdog system, then the \p delay_ms
- * parameter will not be in microseconds. See the datasheet for more details.
+ * parameter will not be in milliseconds. See the datasheet for more details.
  *
  * By default the SDK assumes a 12MHz XOSC and sets the \ref watchdog_start_tick appropriately.
  *
  * \param pc If Zero, a standard boot will be performed, if non-zero this is the program counter to jump to on reset.
  * \param sp If \p pc is non-zero, this will be the stack pointer used.
- * \param delay_ms Initial load value. Maximum value 0x7fffff, approximately 8.3s.
+ * \param delay_ms Initial load value. Maximum value 8388, approximately 8.3s.
  */
 void watchdog_reboot(uint32_t pc, uint32_t sp, uint32_t delay_ms);
 
@@ -63,7 +68,7 @@ void watchdog_update(void);
  * \ingroup hardware_watchdog
  *
  * \note If \ref watchdog_start_tick value does not give a 1MHz clock to the watchdog system, then the \p delay_ms
- * parameter will not be in microseconds. See the datasheet for more details.
+ * parameter will not be in milliseconds. See the datasheet for more details.
  *
  * By default the SDK assumes a 12MHz XOSC and sets the \ref watchdog_start_tick appropriately.
  *
@@ -72,7 +77,7 @@ void watchdog_update(void);
  * onto the RPI-RP2), then this value will be cleared, and so \ref watchdog_enable_caused_reboot will
  * return false.
  *
- * \param delay_ms Number of milliseconds before watchdog will reboot without watchdog_update being called. Maximum of 0x7fffff, which is approximately 8.3 seconds
+ * \param delay_ms Number of milliseconds before watchdog will reboot without watchdog_update being called. Maximum of 8388, which is approximately 8.3 seconds
  * \param pause_on_debug If the watchdog should be paused when the debugger is stepping through code
  */
 void watchdog_enable(uint32_t delay_ms, bool pause_on_debug);

--- a/src/rp2_common/hardware_watchdog/watchdog.c
+++ b/src/rp2_common/hardware_watchdog/watchdog.c
@@ -12,6 +12,7 @@
 
 /// \tag::watchdog_start_tick[]
 void watchdog_start_tick(uint cycles) {
+    valid_params_if(WATCHDOG, cycles <= 0x1ffu);
     // Important: This function also provides a tick reference to the timer
     watchdog_hw->tick = cycles | WATCHDOG_TICK_ENABLE_BITS;
 }
@@ -34,6 +35,7 @@ uint32_t watchdog_get_count(void) {
 // tag::watchdog_enable[]
 // Helper function used by both watchdog_enable and watchdog_reboot
 void _watchdog_enable(uint32_t delay_ms, bool pause_on_debug) {
+    valid_params_if(WATCHDOG, delay_ms <= 8388); // i.e. floor(0xffffff / 2000)
     hw_clear_bits(&watchdog_hw->ctrl, WATCHDOG_CTRL_ENABLE_BITS);
 
     // Reset everything apart from ROSC and XOSC

--- a/src/rp2_common/hardware_xosc/xosc.c
+++ b/src/rp2_common/hardware_xosc/xosc.c
@@ -37,7 +37,9 @@ void xosc_init(void) {
     hw_set_bits(&xosc_hw->ctrl, XOSC_CTRL_ENABLE_VALUE_ENABLE << XOSC_CTRL_ENABLE_LSB);
 
     // Wait for XOSC to be stable
-    while(!(xosc_hw->status & XOSC_STATUS_STABLE_BITS));
+    while(!(xosc_hw->status & XOSC_STATUS_STABLE_BITS)) {
+        tight_loop_contents();
+    }
 }
 
 void xosc_disable(void) {
@@ -46,12 +48,16 @@ void xosc_disable(void) {
     tmp |= (XOSC_CTRL_ENABLE_VALUE_DISABLE << XOSC_CTRL_ENABLE_LSB);
     xosc_hw->ctrl = tmp;
     // Wait for stable to go away
-    while(xosc_hw->status & XOSC_STATUS_STABLE_BITS);
+    while(xosc_hw->status & XOSC_STATUS_STABLE_BITS) {
+        tight_loop_contents();
+    }
 }
 
 void xosc_dormant(void) {
     // WARNING: This stops the xosc until woken up by an irq
     xosc_hw->dormant = XOSC_DORMANT_VALUE_DORMANT;
     // Wait for it to become stable once woken up
-    while(!(xosc_hw->status & XOSC_STATUS_STABLE_BITS));
+    while(!(xosc_hw->status & XOSC_STATUS_STABLE_BITS)) {
+        tight_loop_contents();
+    }
 }

--- a/src/rp2_common/pico_async_context/async_context_freertos.c
+++ b/src/rp2_common/pico_async_context/async_context_freertos.c
@@ -262,7 +262,7 @@ static void async_context_freertos_set_work_pending(async_context_t *self_base, 
     async_context_freertos_wake_up(self_base);
 }
 
-static void async_context_freertos_wait_until(async_context_t *self_base, absolute_time_t until) {
+static void async_context_freertos_wait_until(__unused async_context_t *self_base, absolute_time_t until) {
     assert(!portCHECK_IF_IN_ISR());
     TickType_t ticks = sensible_ticks_until(until);
     vTaskDelay(ticks);

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -118,7 +118,7 @@ typedef void *(*rom_table_lookup_fn)(uint16_t *table, uint32_t code);
 
 #if PICO_C_COMPILER_IS_GNU && (__GNUC__ >= 12)
 // Convert a 16 bit pointer stored at the given rom address into a 32 bit pointer
-static inline void *rom_hword_as_ptr(uint16_t rom_address) {
+static __force_inline void *rom_hword_as_ptr(uint16_t rom_address) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
     return (void *)(uintptr_t)*(uint16_t *)(uintptr_t)rom_address;

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -232,21 +232,22 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
 
     # Make a GATT header file from a BTstack GATT file
     # Pass the target library name library type and path to the GATT input file
+    # To add additional directories to the gatt #import path, add them to the end of the argument list.
     function(pico_btstack_make_gatt_header TARGET_LIB TARGET_TYPE GATT_FILE)
             find_package (Python3 REQUIRED COMPONENTS Interpreter)
             get_filename_component(GATT_NAME "${GATT_FILE}" NAME_WE)
             get_filename_component(GATT_PATH "${GATT_FILE}" PATH)
-            set(GATT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
-            set(GATT_HEADER "${GATT_BINARY_DIR}/${GATT_NAME}.h")
             set(TARGET_GATT "${TARGET_LIB}_gatt_header")
-
+            set(GATT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated/${TARGET_GATT}")
+            set(GATT_HEADER "${GATT_BINARY_DIR}/${GATT_NAME}.h")
+            list(TRANSFORM ARGN PREPEND "-I")
             add_custom_target(${TARGET_GATT} DEPENDS ${GATT_HEADER})
             add_custom_command(
                     OUTPUT ${GATT_HEADER}
                     DEPENDS ${GATT_FILE}
                     WORKING_DIRECTORY ${GATT_PATH}
                     COMMAND ${CMAKE_COMMAND} -E make_directory ${GATT_BINARY_DIR} &&
-                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER}
+                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ARGN}
                     VERBATIM)
             add_dependencies(${TARGET_LIB}
                     ${TARGET_GATT}

--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -89,5 +89,32 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
                 )
     endif()
 
+    # Set an ip address in a compile definition
+    # target name, target type, compile definition name to set then address in a string
+    # This can be used to set the following compile definitions
+    # CYW43_DEFAULT_IP_ADDRESS
+    # CYW43_DEFAULT_IP_MASK
+    # CYW43_DEFAULT_IP_GATEWAY
+    # CYW43_DEFAULT_IP_DNS
+    # CYW43_DEFAULT_AP_IP_ADDRESS
+    # e.g. pico_configure_ip4_address(picow_tcpip_server_background PRIVATE CYW43_DEFAULT_IP_ADDRESS "10.3.15.204")
+    function(pico_configure_ip4_address TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
+            string(REGEX MATCHALL "[0-9]+" IP_ADDRESS_LIST ${IP_ADDRESS_STR})
+            list(LENGTH IP_ADDRESS_LIST IP_ADDRESS_COMPONENT_COUNT)
+            if (NOT ${IP_ADDRESS_COMPONENT_COUNT} EQUAL 4)
+                    message(FATAL_ERROR "wrong number of components in ip address 4 != ${IP_ADDRESS_COMPONENT_COUNT}")
+            endif()
+            set(IP_ADDRESS_HEX "0x0")
+            foreach(IP_COMPONENT ${IP_ADDRESS_LIST})
+                    if (${IP_COMPONENT} GREATER 255)
+                            message(FATAL_ERROR "ip address component too big ${IP_COMPONENT} > 255")
+                    endif()
+                    math(EXPR IP_ADDRESS_HEX "(${IP_ADDRESS_HEX} << 8 ) | ${IP_COMPONENT}" OUTPUT_FORMAT HEXADECIMAL)
+            endforeach()
+            target_compile_definitions(${TARGET_LIB} ${TARGET_TYPE}
+                    ${DEF_NAME}=${IP_ADDRESS_HEX}
+                    )
+    endfunction()
+
     pico_promote_common_scope_vars()
 endif()

--- a/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus_driver.c
+++ b/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus_driver.c
@@ -613,7 +613,7 @@ static cybt_result_t cybt_mem_read(uint32_t mem_addr, uint8_t *p_data, uint32_t 
             transfer_size = 0x1000 - (mem_addr & 0xFFF);
         }
         cyw43_ll_read_backplane_mem(cyw43_ll, mem_addr, transfer_size, p_data);
-        cybt_debug("  read_mem addr 0x%08lx len %ld\n", transfer_size, mem_addr);
+        cybt_debug("  read_mem addr 0x%08lx len %ld\n", mem_addr, transfer_size);
         DUMP_BYTES(p_data, transfer_size);
         data_len -= transfer_size;
         p_data += transfer_size;

--- a/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
@@ -164,6 +164,10 @@ void cyw43_thread_lock_check(void) {
 #endif
 
 void cyw43_await_background_or_timeout_us(uint32_t timeout_us) {
+    if (__get_current_exception() > 0) {
+        async_context_wait_until(cyw43_async_context, make_timeout_time_us(timeout_us));
+        return;
+    }
     async_context_wait_for_work_until(cyw43_async_context, make_timeout_time_us(timeout_us));
 }
 

--- a/src/rp2_common/pico_lwip/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/CMakeLists.txt
@@ -302,5 +302,6 @@ if (EXISTS ${PICO_LWIP_PATH}/${LWIP_TEST_PATH})
             pico_lwip_contrib_freertos
             pico_rand)
 
+    pico_add_subdirectory(tools)
     pico_promote_common_scope_vars()
 endif()

--- a/src/rp2_common/pico_lwip/tools/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/tools/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Compile the http content into a source file "pico_fsdata.inc" in a format suitable for the lwip httpd server
+# Pass the target library name library type and the list of httpd content
+function(pico_set_lwip_httpd_content TARGET_LIB TARGET_TYPE)
+    find_package (Python3 REQUIRED COMPONENTS Interpreter)
+    set(HTTPD_CONTENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+    set(HTTPD_CONTENT_TARGET "${TARGET_LIB}_pico_set_lwip_httpd_content")
+    set(HTTPD_CONTENT_OUTPUT_NAME "pico_fsdata.inc")
+    set(HTTPD_CONTENT_TOOL "${PICO_SDK_PATH}/src/rp2_common/pico_lwip/tools/makefsdata.py")
+    add_custom_target(${HTTPD_CONTENT_TARGET} DEPENDS ${HTTPD_CONTENT_BINARY_DIR}/${HTTPD_CONTENT_OUTPUT_NAME})
+    add_custom_command(
+        OUTPUT ${HTTPD_CONTENT_BINARY_DIR}/${HTTPD_CONTENT_OUTPUT_NAME}
+        DEPENDS ${HTTPD_CONTENT_TOOL} ${ARGN}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${HTTPD_CONTENT_BINARY_DIR} &&
+            ${Python3_EXECUTABLE} ${HTTPD_CONTENT_TOOL} -i ${ARGN} -o ${HTTPD_CONTENT_BINARY_DIR}/${HTTPD_CONTENT_OUTPUT_NAME}
+        VERBATIM)
+    target_include_directories(${TARGET_LIB} ${TARGET_TYPE}
+        ${HTTPD_CONTENT_BINARY_DIR}
+        )
+    add_dependencies(${TARGET_LIB} ${HTTPD_CONTENT_TARGET})
+endfunction()

--- a/src/rp2_common/pico_lwip/tools/makefsdata.py
+++ b/src/rp2_common/pico_lwip/tools/makefsdata.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+
+file_types = {
+    "html": "text/html",
+    "htm":  "text/html",
+    "shtml": "text/html",
+    "shtm": "text/html",
+    "ssi":  "text/html",
+    "gif":  "image/gif",
+    "png":  "image/png",
+    "jpg":  "image/jpeg",
+    "bmp":  "image/bmp",
+    "ico":  "image/x-icon",
+    "class": "application/octet-stream",
+    "cls":  "application/octet-stream",
+    "js":   "application/javascript",
+    "ram":  "application/javascript",
+    "css":  "text/css",
+    "swf":  "application/x-shockwave-flash",
+    "xml":  "text/xml",
+    "xsl":  "application/pdf",
+    "pdf":  "text/xml",
+    "json": "application/json",
+    "svg":  "image/svg+xml"
+}
+
+response_types = {
+  200: "HTTP/1.0 200 OK",
+  400: "HTTP/1.0 400 Bad Request",
+  404: "HTTP/1.0 404 File not found",
+  501: "HTTP/1.0 501 Not Implemented",
+}
+
+PAYLOAD_ALIGNMENT = 4
+HTTPD_SERVER_AGENT = "lwIP/2.2.0d (http://savannah.nongnu.org/projects/lwip)"
+LWIP_HTTPD_SSI_EXTENSIONS = [".shtml", ".shtm", ".ssi", ".xml", ".json"]
+
+def process_file(input_dir, file):
+    results = []
+
+    # Check content type
+    content_type = file_types[file.suffix[1:].lower()]
+    if content_type is None:
+        raise RuntimeError(f"Unsupported file type {file.suffix}")
+
+    # file name
+    data = f"/{file.relative_to(input_dir)}\x00"
+    comment = f"\"/{file.relative_to(input_dir)}\" ({len(data)} chars)"
+    while(len(data) % PAYLOAD_ALIGNMENT != 0):
+        data += "\x00"
+    results.append({'data': bytes(data, "utf-8"), 'comment': comment});
+
+    # Header
+    response_type = 200
+    for response_id in response_types:
+        if file.name.startswith(f"{response_id}."):
+            response_type = response_id
+            break
+    data = f"{response_types[response_type]}\r\n"
+    comment = f"\"{response_types[response_type]}\" ({len(data)} chars)"
+    results.append({'data': bytes(data, "utf-8"), 'comment': comment});
+
+    # user agent
+    data = f"Server: {HTTPD_SERVER_AGENT}\r\n"
+    comment = f"\"Server: {HTTPD_SERVER_AGENT}\" ({len(data)} chars)"
+    results.append({'data': bytes(data, "utf-8"), 'comment': comment});
+
+    if file.suffix not in LWIP_HTTPD_SSI_EXTENSIONS:
+        # content length
+        file_size = file.stat().st_size
+        data = f"Content-Length: {file_size}\r\n"
+        comment = f"\"Content-Length: {file_size}\" ({len(data)} chars)"
+        results.append({'data': bytes(data, "utf-8"), 'comment': comment});
+
+    # content type
+    data = f"Content-Type: {content_type}\r\n\r\n"
+    comment = f"\"Content-Type: {content_type}\" ({len(data)} chars)"
+    results.append({'data': bytes(data, "utf-8"), 'comment': comment});
+
+    # file contents
+    data = file.read_bytes()
+    comment = f"raw file data ({len(data)} bytes)"
+    results.append({'data': data, 'comment': comment});
+
+    return results;
+
+def process_file_list(fd, input):
+    data = []
+    fd.write("#include \"lwip/apps/fs.h\"\n")
+    fd.write("\n")
+    # generate the page contents
+    input_dir = None
+    for name in input:
+        file = Path(name)
+        if not file.is_file():
+            raise RuntimeError(f"File not found: {name}")
+        # Take the input directory from the first file
+        if input_dir is None:
+            input_dir = file.parent
+        results = process_file(input_dir, file)
+
+        # make a variable name
+        var_name = str(file.relative_to(input_dir))
+        var_name = var_name.replace(".", "_")
+        var_name = var_name.replace("/", "_")
+        data_var = f"data_{var_name}"
+        file_var = f"file_{var_name}"
+
+        # variable containing the raw data
+        fd.write(f"static const unsigned char {data_var}[] = {{\n")
+        for entry in results:
+            fd.write(f"\n    /* {entry['comment']} */\n")
+            byte_count = 0;
+            for b in entry['data']:
+                if byte_count % 16 == 0:
+                    fd.write("    ")
+                byte_count += 1
+                fd.write(f"0x{b:02x},")
+                if byte_count % 16 == 0:
+                    fd.write("\n")
+            if byte_count % 16 != 0:
+                 fd.write("\n")
+        fd.write(f"}};\n\n")
+
+        # set the flags
+        flags = "FS_FILE_FLAGS_HEADER_INCLUDED"
+        if file.suffix not in LWIP_HTTPD_SSI_EXTENSIONS:
+            flags += " | FS_FILE_FLAGS_HEADER_PERSISTENT"
+        else:
+            flags += " | FS_FILE_FLAGS_SSI"
+
+        # add variable details to the list
+        data.append({'data_var': data_var, 'file_var': file_var, 'name_size': len(results[0]['data']), 'flags': flags})
+
+    # generate the page details
+    last_var = "NULL"
+    for entry in data:
+        fd.write(f"const struct fsdata_file {entry['file_var']}[] = {{{{\n")
+        fd.write(f"    {last_var},\n")
+        fd.write(f"    {entry['data_var']},\n")
+        fd.write(f"    {entry['data_var']} + {entry['name_size']},\n")
+        fd.write(f"    sizeof({entry['data_var']}) - {entry['name_size']},\n")
+        fd.write(f"    {entry['flags']},\n")
+        fd.write(f"}}}};\n\n")
+        last_var = entry['file_var']
+    fd.write(f"#define FS_ROOT {last_var}\n")
+    fd.write(f"#define FS_NUMFILES {len(data)}\n")
+
+def run_tool():
+    parser = argparse.ArgumentParser(prog="makefsdata.py", description="Generates a source file for the lwip httpd server")
+    parser.add_argument(
+        "-i",
+        "--input",
+        help="input files to add as http content",
+        required=True,
+        nargs='+'
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="name of the source file to generate",
+        required=True,
+    )
+    args = parser.parse_args()
+    print(args.input)
+    with open(args.output, "w") as fd:
+        process_file_list(fd, args.input)
+
+if __name__ == "__main__":
+    run_tool()

--- a/src/rp2_common/pico_malloc/pico_malloc.c
+++ b/src/rp2_common/pico_malloc/pico_malloc.c
@@ -13,6 +13,10 @@
 auto_init_mutex(malloc_mutex);
 #endif
 
+#if PICO_DEBUG_MALLOC
+#include <stdio.h>
+#endif
+
 extern void *REAL_FUNC(malloc)(size_t size);
 extern void *REAL_FUNC(calloc)(size_t count, size_t size);
 extern void *REAL_FUNC(realloc)(void *mem, size_t size);

--- a/src/rp2_common/pico_standard_link/memmap_blocked_ram.ld
+++ b/src/rp2_common/pico_standard_link/memmap_blocked_ram.ld
@@ -117,8 +117,13 @@ SECTIONS
     __binary_info_end = .;
     . = ALIGN(4);
 
-   .ram_vector_table (NOLOAD): {
+    .ram_vector_table (NOLOAD): {
         *(.ram_vector_table)
+    } > RAM
+
+    .uninitialized_data (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
     } > RAM
 
     .data : {
@@ -172,11 +177,6 @@ SECTIONS
     } > RAM AT> FLASH
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
-
-    .uninitialized_data (NOLOAD): {
-        . = ALIGN(4);
-        *(.uninitialized_data*)
-    } > RAM
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/src/rp2_common/pico_standard_link/memmap_copy_to_ram.ld
+++ b/src/rp2_common/pico_standard_link/memmap_copy_to_ram.ld
@@ -96,8 +96,13 @@ SECTIONS
     . = ALIGN(4);
 
     /* Vector table goes first in RAM, to avoid large alignment hole */
-   .ram_vector_table (NOLOAD): {
+    .ram_vector_table (NOLOAD): {
         *(.ram_vector_table)
+    } > RAM
+
+    .uninitialized_data (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
     } > RAM
 
     .text : {
@@ -174,11 +179,6 @@ SECTIONS
     } > RAM AT> FLASH
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
-
-    .uninitialized_data (NOLOAD): {
-        . = ALIGN(4);
-        *(.uninitialized_data*)
-    } > RAM
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/src/rp2_common/pico_standard_link/memmap_default.ld
+++ b/src/rp2_common/pico_standard_link/memmap_default.ld
@@ -117,8 +117,13 @@ SECTIONS
     __binary_info_end = .;
     . = ALIGN(4);
 
-   .ram_vector_table (NOLOAD): {
+    .ram_vector_table (NOLOAD): {
         *(.ram_vector_table)
+    } > RAM
+
+    .uninitialized_data (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
     } > RAM
 
     .data : {
@@ -172,11 +177,6 @@ SECTIONS
     } > RAM AT> FLASH
     /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
     __etext = LOADADDR(.data);
-
-    .uninitialized_data (NOLOAD): {
-        . = ALIGN(4);
-        *(.uninitialized_data*)
-    } > RAM
 
     /* Start and end symbols must be word-aligned */
     .scratch_x : {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -26,6 +26,7 @@ function(pico_generate_pio_header TARGET PIO)
     endif()
 
     if (pico_generate_pio_header_OUTPUT_DIR)
+        file(MAKE_DIRECTORY ${pico_generate_pio_header_OUTPUT_DIR})
         get_filename_component(HEADER_DIR ${pico_generate_pio_header_OUTPUT_DIR} ABSOLUTE)
     else()
         set(HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}")

--- a/tools/elf2uf2/CMakeLists.txt
+++ b/tools/elf2uf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 project(elf2uf2)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tools/elf2uf2/CMakeLists.txt
+++ b/tools/elf2uf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.27)
 project(elf2uf2)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/tools/elf2uf2/main.cpp
+++ b/tools/elf2uf2/main.cpp
@@ -129,7 +129,7 @@ int check_address_range(const address_ranges& valid_ranges, uint32_t addr, uint3
     for(const auto& range : valid_ranges) {
         if (range.from <= addr && range.to >= addr + size) {
             if (range.type == address_range::type::NO_CONTENTS && !uninitialized) {
-                return fail(ERROR_INCOMPATIBLE, "ELF contains memory contents for uninitialized memory at %p", addr);
+                return fail(ERROR_INCOMPATIBLE, "ELF contains memory contents for uninitialized memory at %08x", addr);
             }
             ar = range;
             if (verbose) {

--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.13)
 project(pioasm CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(pioasm
 target_sources(pioasm PRIVATE c_sdk_output.cpp)
 target_sources(pioasm PRIVATE python_output.cpp)
 target_sources(pioasm PRIVATE hex_output.cpp)
+target_sources(pioasm PRIVATE json_output.cpp)
 target_sources(pioasm PRIVATE ada_output.cpp)
 target_sources(pioasm PRIVATE ${PIOASM_EXTRA_SOURCE_FILES})
 

--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.13...3.27)
 project(pioasm CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/tools/pioasm/json_output.cpp
+++ b/tools/pioasm/json_output.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <algorithm>
+#include <iostream>
+#include "output_format.h"
+#include "pio_disassembler.h"
+
+struct json_output : public output_format {
+    struct factory {
+        factory() {
+            output_format::add(new json_output());
+        }
+    };
+
+    json_output() : output_format("json") {}
+
+    std::string get_description() override {
+        return "Machine-formatted output for integrating with external tools";
+    }
+
+    void output_symbols(FILE *out, bool output_labels, std::string prefix, const std::vector<compiled_source::symbol> &symbols) {
+
+        fprintf(out, "%s\"publicSymbols\": {\n", prefix.c_str());
+        bool first = true;
+        for (const auto &s : symbols) {
+            if (!s.is_label) {
+                // output trailing comma if necessary
+                if (!first) {
+                    fprintf(out, ",\n");
+                } else {
+                    first = false;
+                }
+                fprintf(out, "%s\t\"%s\": %d", prefix.c_str(), s.name.c_str(), s.value);
+            }
+        }
+        if (!first)
+            fprintf(out, "\n");
+        fprintf(out, "%s},\n", prefix.c_str());
+
+        if (!output_labels)
+            return;
+
+        fprintf(out, "%s\"publicLabels\": {\n", prefix.c_str());
+        first = true;
+        for (const auto &s : symbols) {
+            if (s.is_label) {
+                // output trailing comma if necessary
+                if (!first) {
+                    fprintf(out, ",\n");
+                } else {
+                    first = false;
+                }
+                fprintf(out, "%s\t\"%s\": %d", prefix.c_str(), s.name.c_str(), s.value);
+            }
+        }
+        if (!first)
+            fprintf(out, "\n");
+        fprintf(out, "%s},\n", prefix.c_str());
+    }
+
+    int output(std::string destination, std::vector<std::string> output_options,
+               const compiled_source &source) override {
+
+        for (const auto &program : source.programs) {
+            for(const auto &p : program.lang_opts) {
+                if (p.first.size() >= name.size() && p.first.compare(0, name.size(), name) == 0) {
+                    std::cerr << "warning: " << name << " does not support output options; " << p.first << " lang_opt ignored.\n";
+                }
+            }
+        }
+        FILE *out = open_single_output(destination);
+        if (!out) return 1;
+
+        fprintf(out, "{\n");
+        bool first = true;
+
+        output_symbols(out, false, "\t", source.global_symbols);
+
+        const char* tabs = "\t\t\t";
+        fprintf(out, "\t\"programs\": [\n");
+
+        for (const auto &program : source.programs) {
+            // output trailing comma if necessary
+            if (!first) {
+                fprintf(out, ",\n");
+            } else {
+                first = false;
+            }
+            fprintf(out, "\t\t{\n");
+
+            fprintf(out, "%s\"name\": \"%s\",\n", tabs, program.name.c_str());
+            fprintf(out, "%s\"wrapTarget\": %d,\n", tabs, program.wrap_target);
+            fprintf(out, "%s\"wrap\": %d,\n", tabs, program.wrap);
+            fprintf(out, "%s\"origin\": %d,\n", tabs, program.origin.get());
+
+            if (program.sideset_bits_including_opt.is_specified()) {
+                fprintf(out, "%s\"sideset\": {\"size\": %d, \"optional\": %s, \"pindirs\": %s},\n", tabs, program.sideset_bits_including_opt.get(),
+                        program.sideset_opt ? "true" : "false",
+                        program.sideset_pindirs ? "true" : "false");
+            } else {
+                fprintf(out, "%s\"sideset\": {\"size\": 0, \"optional\": false, \"pindirs\": false},\n", tabs, program.origin.get());
+            }
+
+            output_symbols(out, true, tabs, program.symbols);
+
+            fprintf(out, "%s\"instructions\": [\n", tabs);
+            bool first_inst = true;
+            for (int i = 0; i < (int)program.instructions.size(); i++) {
+                const auto &inst = program.instructions[i];
+                // output trailing comma if necessary
+                if (!first_inst) {
+                    fprintf(out, ",\n");
+                } else {
+                    first_inst = false;
+                }
+                // TODO: find a nice, supportable, output format for instruction disassembly.
+                // Note that may require tearing apart pio_disassembler to return to us something
+                // that we could output as {"instr":"mov", args: ["x", "~y"], side: 3, delay: 1}
+                // but that will likely wait for now
+                fprintf(out, "%s\t{\"hex\": \"%04X\"}",// \"disassembly\": \"%s\"}",
+                        tabs, inst
+                        //, disassemble(inst, program.sideset_bits_including_opt.get(), program.sideset_opt).c_str()
+                        );
+            }
+            fprintf(out, "\n");
+            fprintf(out, "%s]\n", tabs);
+            fprintf(out, "\t\t}");
+        }
+        fprintf(out, "\n\t]\n}\n");
+        if (out != stdout) { fclose(out); }
+        return 0;
+    }
+};
+
+static json_output::factory creator;


### PR DESCRIPTION
During 'lightsleep' user may want to keep some clocks running (for example PIOs),
but at present microPython calls 'clock-init()' causing the SYS_CLK to be reinitialised.

This patch allows microPython to provide the previously used 'sleep_en0 & sleep_en1' 
signifying which clocks stayed on. As most are dependant of SYS_CLK it can be 
inferred that this does NOT need to (/should NOT) be re-initilised.
