### PR TITLE
Update dma.h (Fixes #1677) (Inline docs only)

### DIFF
--- a/src/rp2_common/hardware_dma/include/hardware/dma.h
+++ b/src/rp2_common/hardware_dma/include/hardware/dma.h
@@ -863,7 +863,7 @@ int dma_claim_unused_timer(bool required);
  */
 bool dma_timer_is_claimed(uint timer);
 
-/*! \brief Set the divider for the given DMA timer
+/*! \brief Set the multiplier for the given DMA timer
  *  \ingroup hardware_dma
  *
  * The timer will run at the system_clock_freq * numerator / denominator, so this is the speed


### PR DESCRIPTION
I think It's important to be clear that how DMA timers are scaled on RP2040 is the opposite of how PWM clocks are scaled. 

Specifically, pwm_config_set_clkdiv_int_frac() lets the user specifiy a fractional divider, but dma_timer_set_fraction() lets the user specify a fractional multiplier. So for instance the PWM divider is only effective if it's more than 1, while the DMA multiplier is only effective if it's less than 1.

This patch updates the inline doc of dma_timer_set_fraction() to reflect that it specifies a multiplier, not a divider, of clk_sys.