### PR TITLE
pico_flash stops including certain unneeded headers

### DIFF
--- a/src/rp2_common/pico_flash/flash.c
+++ b/src/rp2_common/pico_flash/flash.c
@@ -5,7 +5,6 @@
  */
 
 #include "pico/flash.h"
-#include "hardware/exception.h"
 #include "hardware/sync.h"
 #if PICO_FLASH_SAFE_EXECUTE_PICO_SUPPORT_MULTICORE_LOCKOUT
 #include "pico/multicore.h"

--- a/src/rp2_common/pico_flash/include/pico/flash.h
+++ b/src/rp2_common/pico_flash/include/pico/flash.h
@@ -9,9 +9,6 @@
 
 #include "pico.h"
 
-#include "hardware/flash.h"
-#include "pico/time.h"
-
 /** \file pico/flash.h
  *  \defgroup pico_flash pico_flash
  *


### PR DESCRIPTION
Fixes #1698