### PR TITLE
remove dead code in __aeabi_dcmpun

### DIFF
--- a/src/rp2_common/pico_double/double_aeabi.S
+++ b/src/rp2_common/pico_double/double_aeabi.S
@@ -416,9 +416,6 @@ wrapper_func __aeabi_dcmpun
    movs r0, #1
    bx lr
 
-    movs r0, #0
-    bx lr
-
 // double FUNC_NAME(__aeabi_ui2d)(unsigned)             unsigned to double (double precision) conversion
 double_wrapper_section __aeabi_ui2d
     shimmable_table_tail_call SF_TABLE_UINT2FLOAT uint2double_shim


### PR DESCRIPTION
Two tail instructions are unreachable.

Fixes #1702 .