### PR TITLE
Fix btstack compilation

### DIFF
--- a/src/rp2_common/pico_btstack/btstack_flash_bank.c
+++ b/src/rp2_common/pico_btstack/btstack_flash_bank.c
@@ -7,6 +7,7 @@
 #include "pico/btstack_flash_bank.h"
 #include "pico/flash.h"
 #include "hardware/sync.h"
+#include "hardware/flash.h"
 #include <string.h>
 
 // Check sizes


### PR DESCRIPTION
hardware/flash.h has been removed from pico/flash.h in the fix for #1699. This breaks btstack compilation. Let's fix it.
