### PR TITLE
Use CYW43_PRINTF macro in cyw43-support code.

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -498,7 +498,7 @@ int cyw43_read_bytes(cyw43_int_t *self, uint32_t fn, uint32_t addr, size_t len, 
         logic_debug_set(pin_WIFI_RX, 0);
     }
     if (ret != 0) {
-        printf("cyw43_read_bytes error %d", ret);
+        CYW43_PRINTF("cyw43_read_bytes error %d", ret);
         return ret;
     }
     if (buf != self->spid_buf) { // avoid a copy in the usual case just to add the header
@@ -527,7 +527,7 @@ int cyw43_write_bytes(cyw43_int_t *self, uint32_t fn, uint32_t addr, size_t len,
             }
         }
         if (f2_ready_attempts <= 0) {
-            printf("F2 not ready\n");
+            CYW43_PRINTF("F2 not ready\n");
             return CYW43_FAIL_FAST_CHECK(-CYW43_EIO);
         }
     }


### PR DESCRIPTION
Fixes #1744.

Without this change, using cyw43 has a dependency on printf code for printing error message. Everywhere else in cyw43-code this dependency is masked with the CYW43_PRINTF-macro. This PR extends the usage of the CYW43-PRINTF macro to the SPI-support code.

