### PR TITLE
Add missing semicolon

### DIFF
--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -206,7 +206,7 @@ static inline int8_t get_slot_index(struct irq_handler_chain_slot *slot) {
 void irq_add_shared_handler(uint num, irq_handler_t handler, uint8_t order_priority) {
     check_irq_param(num);
 #if PICO_NO_RAM_VECTOR_TABLE
-    panic_unsupported()
+    panic_unsupported();
 #elif PICO_DISABLE_SHARED_IRQ_HANDLERS
     irq_set_exclusive_handler(num, handler);
 #else


### PR DESCRIPTION
Building `hardware_irq` currently fails with `PICO_NO_RAM_VECTOR_TABLE=1` due to a missing semicolon. This PR adds the missing semicolon.