### PR TITLE
PICO_MALLOC_TRACK_PEAK, peak allocation tracking for malloc

### DIFF
--- a/src/rp2_common/pico_malloc/include/pico/malloc.h
+++ b/src/rp2_common/pico_malloc/include/pico/malloc.h
@@ -35,4 +35,15 @@
 #define PICO_DEBUG_MALLOC_LOW_WATER 0
 #endif
 
+// PICO_CONFIG: PICO_MALLOC_TRACK_PEAK, Enable/disable tracking the peak allocated bytes by malloc, type=bool, default=0, group=pico_malloc
+#ifndef PICO_MALLOC_TRACK_PEAK
+#define PICO_MALLOC_TRACK_PEAK 0
+#endif
+
+#if PICO_MALLOC_TRACK_PEAK
+#include <stdlib.h>
+extern size_t malloc_peak_bytes;
+void malloc_reset_peak();
+#endif
+
 #endif


### PR DESCRIPTION
This PR implements a peak allocated bytes tracking option for malloc.

To enable:

```
target_compile_definitions(my_project PRIVATE PICO_MALLOC_TRACK_PEAK=1)
```

Usage: determining the peak allocated bytes during a block of code / call-stack:

```c
malloc_reset_peak();
unsigned char* m1 = malloc(1000);
unsigned char* m2 = malloc(2000);
unsigned char* m3= malloc(3000);
// this simply prevents the compiler from optimizing out the malloc calls:
if (m1 == NULL || m2 == NULL || m3 == NULL) {
    printf("malloc failed");
}
free(m1);
free(m2);
free(m3);
printf("malloc peak: %u bytes", malloc_peak_bytes);
```

which will print:

```
malloc peak: 6024 bytes
```
