### PR TITLE
Add PICO_PANIC_NO_STRINGS_ON_TARGET config

### DIFF
--- a/src/rp2_common/pico_platform/include/pico/platform.h
+++ b/src/rp2_common/pico_platform/include/pico/platform.h
@@ -388,7 +388,11 @@ void __attribute__((noreturn)) panic_unsupported(void);
  * @param fmt format string (printf-like)
  * @param ...  printf-like arguments
  */
+#ifdef PICO_PANIC_NO_STRINGS_ON_TARGET
+#define panic(fmt, ...) do{__breakpoint();while(1){};}while(0)
+#else
 void __attribute__((noreturn)) panic(const char *fmt, ...);
+#endif
 
 #ifdef NDEBUG
 #define panic_compact(...) panic(__VA_ARGS__)

--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -276,6 +276,7 @@ void __attribute__((noreturn)) panic_unsupported(void) {
     panic("not supported");
 }
 
+#ifndef PICO_PANIC_NO_STRINGS_ON_TARGET
 // PICO_CONFIG: PICO_PANIC_FUNCTION, Name of a function to use in place of the stock panic function or empty string to simply breakpoint on panic, group=pico_runtime
 // note the default is not "panic" it is undefined
 #ifdef PICO_PANIC_FUNCTION
@@ -324,6 +325,7 @@ void __attribute__((noreturn)) __printflike(1, 0) panic(const char *fmt, ...) {
 
     _exit(1);
 }
+#endif
 #endif
 
 void hard_assertion_failure(void) {


### PR DESCRIPTION
Removes rodata not always needed strings
Fixes: #1770