### PR TITLE
Small tweak to extract_configs.py

### DIFF
--- a/tools/extract_configs.py
+++ b/tools/extract_configs.py
@@ -219,4 +219,4 @@ with open(outfile, 'w', newline='') as csvfile:
 
     writer.writeheader()
     for config_name, config_obj in sorted(all_configs.items()):
-        writer.writerow({'name': config_name, 'location': '{}:{}'.format(config_obj['filename'], config_obj['line_number']), 'description': config_obj['description'], **config_obj['attrs']})
+        writer.writerow({'name': config_name, 'location': '/{}:{}'.format(config_obj['filename'], config_obj['line_number']), 'description': config_obj['description'], **config_obj['attrs']})


### PR DESCRIPTION
Always write the path as "absolute" (relative to the root of pico-sdk) as that makes searching for it (when building the RP2040 datasheet) much faster. This matches the behaviour of extract_build_defines.py and extract_cmake_configs.py