### PR TITLE
Add missing time.h include

### DIFF
--- a/src/rp2_common/pico_runtime/runtime.c
+++ b/src/rp2_common/pico_runtime/runtime.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include <time.h>
 #include <sys/time.h>
 #include <sys/times.h>
 #include <unistd.h>


### PR DESCRIPTION
 Fix #1780 Can not find marco CLOCKS_PER_SEC in runtime.c