### PR TITLE
Fix minor unused/uninitialized warnings from G++

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -647,7 +647,7 @@ static inline void sm_config_set_mov_status(pio_sm_config *c, enum pio_mov_statu
  * \return the default state machine configuration which can then be modified.
  */
 static inline pio_sm_config pio_get_default_sm_config(void) {
-    pio_sm_config c = {0};
+    pio_sm_config c = {};
 #if PICO_PIO_USE_GPIO_BASE
     c.pinhi = -1;
 #endif


### PR DESCRIPTION
Decorate an unused parameter in the timer API and fill in all structure elements in a PIO API call that generate warnings under GCC 12.

Fixes #1785