### PR TITLE
Assert ordering of pins in bi_pins_with_names is correct

### DIFF
--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -207,9 +207,10 @@ static const struct _binary_info_named_group __bi_lineno_var_name = { \
 #define bi_6pins_with_func(p0, p1, p2, p3, p4, p5, func)    __bi_encoded_pins_64_with_func(BI_PINS_ENCODING_MULTI | ((func << 3)) | ((p0) << 8) | ((p1) << 16) | ((p2) << 24) | ((uint64_t)(p3) << 32) | ((uint64_t)(p4) << 40) | ((uint64_t)(p5) << 48) | ((uint64_t)(p5) << 56))
 #define bi_7pins_with_func(p0, p1, p2, p3, p4, p5, p6,func) __bi_encoded_pins_64_with_func(BI_PINS_ENCODING_MULTI | ((func << 3)) | ((p0) << 8) | ((p1) << 16) | ((p2) << 24) | ((uint64_t)(p3) << 32) | ((uint64_t)(p4) << 40) | ((uint64_t)(p5) << 48) | ((uint64_t)(p6) << 56))
 
+#define order_assert(ps) static_assert(ps, "bi_pins_with_names numbers must be in order")
 #define bi_1pin_with_name(p0, name)                   bi_pin_mask_with_name(1ull << (p0), name)
-#define bi_2pins_with_names(p0, name0, p1, name1)     bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)), name0 "|" name1)
-#define bi_3pins_with_names(p0, name0, p1, name1, p2, name2)  bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)), name0 "|" name1 "|" name2)
-#define bi_4pins_with_names(p0, name0, p1, name1, p2, name2, p3, name3)  bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)) | (1ull << (p3)), name0 "|" name1 "|" name2 "|" name3)
+#define bi_2pins_with_names(p0, name0, p1, name1)     order_assert(p0 < p1); bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)), name0 "|" name1)
+#define bi_3pins_with_names(p0, name0, p1, name1, p2, name2)  order_assert(p0 < p1 && p1 < p2); bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)), name0 "|" name1 "|" name2)
+#define bi_4pins_with_names(p0, name0, p1, name1, p2, name2, p3, name3)  order_assert(p0 < p1 && p1 < p2 && p2 < p3); bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)) | (1ull << (p3)), name0 "|" name1 "|" name2 "|" name3)
 
 #endif


### PR DESCRIPTION
Fixes #878 by adding an assertion that the ordering of pins in bi_pins_with_names is correct

The pins are passed as a pin mask, so there is no ordering, and therefore the pins must be given in ascending order else the names will be associated with the wrong pins

This breaks compilation of the pio/spi/spi_flash example, as the pins there are not in order - given the default pins could be in any order depending on the board, that example should probably be modified to have 4 separate `bi_1pin_with_name` lines instead of a single `bi_4pins_with_names`