### PR TITLE
typo in documentation of __time_critical_func

### DIFF
--- a/src/rp2_common/pico_platform_sections/include/pico/platform/sections.h
+++ b/src/rp2_common/pico_platform_sections/include/pico/platform/sections.h
@@ -143,7 +143,7 @@
  *
  * For example a function called my_func taking an int parameter:
  *
- *     void __time_critical(my_func)(int some_arg) {
+ *     void __time_critical_func(my_func)(int some_arg) {
  *
  * The function is placed in the `.time_critical.<func_name>` linker section
  *


### PR DESCRIPTION
I was reading through my PDF copy of the SDK docs, and I think that there's a typo in this example. The macro is `__time_critical_func` but the example spells it `__time_critical`.

If this warrants a github issue, please let me know and I will create one.
