### PR TITLE
bazel build: Fix compilation bugs for Pico-W support

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_driver/BUILD.bazel
@@ -16,16 +16,10 @@ cc_library(
 cc_library(
     name = "pico_cyw43_driver",
     srcs = [
-        "btstack_chipset_cyw43.c",
-        "btstack_cyw43.c",
-        "btstack_hci_transport_cyw43.c",
         "cyw43_bus_pio_spi.c",
         "cyw43_driver.c",
     ],
     hdrs = [
-        "include/pico/btstack_chipset_cyw43.h",
-        "include/pico/btstack_cyw43.h",
-        "include/pico/btstack_hci_transport_cyw43.h",
         "include/pico/cyw43_driver.h",
     ],
     includes = ["include"],
@@ -33,7 +27,6 @@ cc_library(
     deps = [
         ":cyw43_bus_pio",
         ":cyw43_configport",
-        "//bazel/config:PICO_BTSTACK_CONFIG",
         "//src/rp2_common:pico_platform",
         "//src/rp2_common/hardware_clocks",
         "//src/rp2_common/hardware_dma",
@@ -41,10 +34,38 @@ cc_library(
         "//src/rp2_common/hardware_pio",
         "//src/rp2_common/hardware_sync",
         "//src/rp2_common/pico_async_context",
+        "//src/rp2_common/pico_unique_id",
+        "@cyw43-driver//:cyw43_driver",
+    ] +
+    # Only depend on the btstack if its configuration is set up.
+    select({
+        "//bazel/constraint:pico_btstack_config_unset": [],
+        "//conditions:default": [":pico_cyw43_btstack"],
+    }),
+)
+
+cc_library(
+    name = "pico_cyw43_btstack",
+    srcs = [
+        "btstack_chipset_cyw43.c",
+        "btstack_cyw43.c",
+        "btstack_hci_transport_cyw43.c",
+    ],
+    hdrs = [
+        "include/pico/btstack_chipset_cyw43.h",
+        "include/pico/btstack_cyw43.h",
+        "include/pico/btstack_hci_transport_cyw43.h",
+    ],
+    defines = ["CYW43_ENABLE_BLUETOOTH=1"],
+    includes = ["include"],
+    deps = [
+        ":cyw43_bus_pio",
+        ":cyw43_configport",
+        "//bazel/config:PICO_BTSTACK_CONFIG",
         "//src/rp2_common/pico_btstack:btstack_run_loop_async_context",
         "//src/rp2_common/pico_btstack:pico_btstack_base",
         "//src/rp2_common/pico_btstack:pico_btstack_flash_bank",
-        "//src/rp2_common/pico_unique_id",
+        "//src/rp2_common/pico_cyw43_driver/cybt_shared_bus:cybt_shared_bus_driver",
         "@cyw43-driver//:cyw43_driver",
     ],
 )

--- a/src/rp2_common/pico_cyw43_driver/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_driver/BUILD.bazel
@@ -56,7 +56,6 @@ cc_library(
         "include/pico/btstack_cyw43.h",
         "include/pico/btstack_hci_transport_cyw43.h",
     ],
-    defines = ["CYW43_ENABLE_BLUETOOTH=1"],
     includes = ["include"],
     deps = [
         ":cyw43_bus_pio",

--- a/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD
+++ b/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD
@@ -11,7 +11,14 @@ cc_library(
         "src/cyw43_stats.c",
     ],
     hdrs = glob(["**/*.h"]),
-    defines = ["CYW43_ENABLE_BLUETOOTH=1"],
+    defines = select({
+        "@pico-sdk//bazel/constraint:pico_btstack_config_unset": [
+            "CYW43_ENABLE_BLUETOOTH=0",
+        ],
+        "//conditions:default": [
+            "CYW43_ENABLE_BLUETOOTH=1",
+        ],
+    }),
     includes = [
         "firmware",
         "src",

--- a/src/rp2_common/pico_lwip/lwip.BUILD
+++ b/src/rp2_common/pico_lwip/lwip.BUILD
@@ -15,6 +15,7 @@ cc_library(
         "@pico-sdk//bazel/config:PICO_LWIP_CONFIG",
         "@pico-sdk//src/rp2_common/pico_lwip:pico_lwip_config",
     ],
+    visibility = ["//visibility:private"],
 )
 
 cc_library(
@@ -26,8 +27,7 @@ cc_library(
     deps = [
         ":pico_lwip_headers",
     ] + select({
-        "@pico-sdk//bazel/constraint:pico_freertos_unset": [
-        ],
+        "@pico-sdk//bazel/constraint:pico_freertos_unset": [],
         "//conditions:default": [
             ":pico_lwip_contrib_freertos",
         ],

--- a/src/rp2_common/pico_lwip/lwip.BUILD
+++ b/src/rp2_common/pico_lwip/lwip.BUILD
@@ -158,6 +158,6 @@ cc_library(
     ),
     deps = [
         ":pico_lwip_core",
-        "//bazel/config:PICO_FREERTOS_LIB",
+        "@pico-sdk//bazel/config:PICO_FREERTOS_LIB",
     ],
 )

--- a/src/rp2_common/pico_lwip/lwip.BUILD
+++ b/src/rp2_common/pico_lwip/lwip.BUILD
@@ -2,18 +2,36 @@ load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])
 
+# Some of the LWIP sys_arch.h and the lwip headers depend circularly on one
+# another. Include them all in the same target.
 cc_library(
-    name = "pico_lwip_core",
-    srcs = glob(["src/core/*.c"]),
+    name = "pico_lwip_headers",
     hdrs = glob(["**/*.h"]),
-    includes = ["src/include"],
-    target_compatible_with = incompatible_with_config(
-        "@pico-sdk//bazel/constraint:pico_lwip_config_unset",
-    ),
+    includes = [
+        "contrib/ports/freertos/include/arch",
+        "src/include",
+    ],
     deps = [
         "@pico-sdk//bazel/config:PICO_LWIP_CONFIG",
         "@pico-sdk//src/rp2_common/pico_lwip:pico_lwip_config",
     ],
+)
+
+cc_library(
+    name = "pico_lwip_core",
+    srcs = glob(["src/core/*.c"]),
+    target_compatible_with = incompatible_with_config(
+        "@pico-sdk//bazel/constraint:pico_lwip_config_unset",
+    ),
+    deps = [
+        ":pico_lwip_headers",
+    ] + select({
+        "@pico-sdk//bazel/constraint:pico_freertos_unset": [
+        ],
+        "//conditions:default": [
+            ":pico_lwip_contrib_freertos",
+        ],
+    }),
 )
 
 cc_library(
@@ -151,13 +169,13 @@ cc_library(
 
 cc_library(
     name = "pico_lwip_contrib_freertos",
-    srcs = ["ports/freertos/sys_arch.c"],
-    includes = ["ports/freertos/include"],
+    srcs = ["contrib/ports/freertos/sys_arch.c"],
+    includes = ["contrib/ports/freertos/include"],
     target_compatible_with = incompatible_with_config(
         "@pico-sdk//bazel/constraint:pico_freertos_unset",
     ),
     deps = [
-        ":pico_lwip_core",
+        ":pico_lwip_headers",
         "@pico-sdk//bazel/config:PICO_FREERTOS_LIB",
     ],
 )


### PR DESCRIPTION
Fixes various minor errors with the bazel build files in the pico_lwip and pico_cyw43_driver directories that were causing compilation errors.

Fixes #1796 
Fixes #1798 