### PR TITLE
Add PICOTOOL_OVERRIDE_DIR

### DIFF
--- a/tools/Findpicotool.cmake
+++ b/tools/Findpicotool.cmake
@@ -6,6 +6,23 @@
 #
 cmake_minimum_required(VERSION 3.17)
 
+# if PICOTOOL_OVERRIDE_DIR system environment variable is set,
+# then use that as the folder for the picotool executable
+if (DEFINED ENV{PICOTOOL_OVERRIDE_DIR})
+    message("PICOTOOL_OVERRIDE_DIR env var is set to '$ENV{PICOTOOL_OVERRIDE_DIR}'")
+    add_executable(picotool IMPORTED GLOBAL)
+    set_property(TARGET picotool PROPERTY IMPORTED_LOCATION $ENV{PICOTOOL_OVERRIDE_DIR}/picotool)
+    # check the picotool version:
+    execute_process(COMMAND $ENV{PICOTOOL_OVERRIDE_DIR}/picotool version
+                    OUTPUT_VARIABLE PICOTOOL_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX MATCH "^picotool v${picotool_VERSION_REQUIRED}" PICOTOOL_VERSION_MATCH ${PICOTOOL_VERSION})
+    if (NOT PICOTOOL_VERSION_MATCH)
+        message("picotool version response was: ${PICOTOOL_VERSION}")
+        message(FATAL_ERROR "PICOTOOL_OVERRIDE_DIR is set to '$ENV{PICOTOOL_OVERRIDE_DIR}', but the version of picotool found is not ${picotool_VERSION_REQUIRED}")
+    endif()
+endif ()
+
 if (NOT TARGET picotool)
     include(ExternalProject)
 


### PR DESCRIPTION
Submitting against 'develop'
Fixes #1818

When using Windows 11 and SDK 2.0.0, when trying to do a **cmake -G "NMake Makefiles" ..** or **cmake -G "Ninja" ..**  then picotool executable is not found, and it gets built within the project. The Findpicotool.cmake file does not seem to find the picotool executable at least with Windows, I have not checked Linux/Mac.

I have a solution which should be benign, since it only kicks in if the user creates a system environment variable in Windows, called PICOTOOL_OVERRIDE_DIR. If that is set, then the picotool.exe file there is used (and the version command is executed to confirm it is the correct version).

The submitted change is in a single file (Findpicotool.cmake), placed near the top of the file, after the cmake_minimum_required(VERSION 3.17) line.

I have tested by performing a build, and I can see that the picotool executable was used, and that the .uf2 file was successfully created.

The attached files evidence that, and at the end there is a dir listing that shows that the .uf2 file was created.

[nmake_output.txt](https://github.com/user-attachments/files/16616889/nmake_output.txt)
[cmake_g_nmake_makefile_output.txt](https://github.com/user-attachments/files/16616890/cmake_g_nmake_makefile_output.txt)


