### PR TITLE
.gitignore: Add .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 cmake-*
 .DS_Store
+.cache
 build
 build-*
 


### PR DESCRIPTION
This is where clangd puts a bunch of junk,
so it's nice to have it ignored for folks who
use clangd.

Fixes #1823