### PR TITLE
.gitignore: Add .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .vscode
 cmake-*
+.cache
 .DS_Store
 build
 build-*


### PR DESCRIPTION
This is where clangd puts a bunch of junk,
so it's nice to have it ignored for folks who
use clangd.

Fixes #1823