### PR TITLE
Include Platform Paths files for the host

### DIFF
--- a/cmake/Platform/PICO.cmake
+++ b/cmake/Platform/PICO.cmake
@@ -2,3 +2,10 @@
 
 set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
 set(CMAKE_EXECUTABLE_SUFFIX .elf)
+
+# include paths to find installed tools
+if(CMAKE_HOST_WIN32)
+    include(Platform/WindowsPaths)
+else()
+    include(Platform/UnixPaths)
+endif()


### PR DESCRIPTION
This fixes searching for installed picotool/pioasm on Windows, and generally improves default find_package behaviour on Unix platforms too.

Without this some of the paths searched by find_package, such as `CMAKE_SYSTEM_PREFIX_PATH`, will not be populated. See the [find_package documentation](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure) for more details on how the `CMAKE_SYSTEM_PREFIX_PATH` is used when searching for installed packages (eg picotool/pioasm).