### PR TITLE
Fix inclusion of picobin.h from assembly with NO_PICO_PLATFORM defined

### DIFF
--- a/src/common/boot_picobin_headers/include/boot/picobin.h
+++ b/src/common/boot_picobin_headers/include/boot/picobin.h
@@ -11,7 +11,11 @@
 #include "pico/platform.h"
 #else
 #ifndef _u
+#ifdef __ASSEMBLER__
+#define _u(x) x
+#else
 #define _u(x) x ## u
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Copies the _u(x) definition from platform_defs.h into picobin.h

This fixes inclusion of picobin.h in assembly files when NO_PICO_PLATFORM is defined - this is not used in the SDK, but is necessary for users who want to create their own embedded blocks in assembly with NO_PICO_PLATFORM defined.