### PR TITLE
Disable interrupts while doing flash_op, explicit_buy, and chain_image

### DIFF
--- a/src/rp2_common/pico_bootrom/CMakeLists.txt
+++ b/src/rp2_common/pico_bootrom/CMakeLists.txt
@@ -9,4 +9,4 @@ target_sources(pico_bootrom INTERFACE
         )
 
 target_link_libraries(pico_bootrom_headers INTERFACE boot_picoboot_headers)
-pico_mirrored_target_link_libraries(pico_bootrom INTERFACE pico_base hardware_boot_lock)
+pico_mirrored_target_link_libraries(pico_bootrom INTERFACE pico_base hardware_boot_lock pico_flash)

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -549,10 +549,10 @@ typedef struct {
     uint32_t size_bytes;
     uint8_t *buf;
     int *res;
-} flash_op_params_t;
+} rom_helper_flash_op_params_t;
 
-static void flash_op_helper(void *param) {
-    const flash_op_params_t *op = (const flash_op_params_t *)param;
+static inline void rom_helper_flash_op(void *param) {
+    const rom_helper_flash_op_params_t *op = (const rom_helper_flash_op_params_t *)param;
     rom_flash_op_fn func = (rom_flash_op_fn) rom_func_lookup_inline(ROM_FUNC_FLASH_OP);
     *(op->res) = func(op->flags, op->addr, op->size_bytes, op->buf);
 }
@@ -600,14 +600,14 @@ static inline int rom_flash_op(cflash_flags_t flags, uintptr_t addr, uint32_t si
     if (!bootrom_try_acquire_lock(BOOTROM_LOCK_FLASH_OP))
         return BOOTROM_ERROR_LOCK_REQUIRED;
     int rc = 0;
-    flash_op_params_t params = {
+    rom_helper_flash_op_params_t params = {
         .flags = flags,
         .addr = addr,
         .size_bytes = size_bytes,
         .buf = buf,
         .res = &rc
     };
-    int flash_rc = flash_safe_execute(flash_op_helper, &params, UINT32_MAX);
+    int flash_rc = flash_safe_execute(rom_helper_flash_op, &params, UINT32_MAX);
     bootrom_release_lock(BOOTROM_LOCK_FLASH_OP);
     if (flash_rc != PICO_OK) {
         return flash_rc;
@@ -846,10 +846,10 @@ typedef struct {
     uint8_t *buffer;
     uint32_t buffer_size;
     int *res;
-} buy_params_t;
+} rom_helper_explicit_buy_params_t;
 
-static void buy_helper(void *param) {
-    const buy_params_t *op = (const buy_params_t *)param;
+static inline void rom_helper_explicit_buy(void *param) {
+    const rom_helper_explicit_buy_params_t *op = (const rom_helper_explicit_buy_params_t *)param;
     rom_explicit_buy_fn func = (rom_explicit_buy_fn) rom_func_lookup_inline(ROM_FUNC_EXPLICIT_BUY);
     *(op->res) = func(op->buffer, op->buffer_size);
 }
@@ -882,12 +882,12 @@ static void buy_helper(void *param) {
  */
 static inline int rom_explicit_buy(uint8_t *buffer, uint32_t buffer_size) {
     int rc = 0;
-    buy_params_t params = {
+    rom_helper_explicit_buy_params_t params = {
         .buffer = buffer,
         .buffer_size = buffer_size,
         .res = &rc
     };
-    int flash_rc = flash_safe_execute(buy_helper, &params, UINT32_MAX);
+    int flash_rc = flash_safe_execute(rom_helper_explicit_buy, &params, UINT32_MAX);
     if (flash_rc != PICO_OK) {
         return flash_rc;
     } else {

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -20,6 +20,7 @@
 #ifndef __ASSEMBLER__
 #include <string.h>
 #include "pico/bootrom/lock.h"
+#include "pico/flash.h"
 // ROM FUNCTION SIGNATURES
 
 #if PICO_RP2040
@@ -542,6 +543,20 @@ static inline void rom_flash_select_xip_read_mode(bootrom_xip_mode_t mode, uint8
     func(mode, clkdiv);
 }
 
+typedef struct {
+    cflash_flags_t flags;
+    uintptr_t addr;
+    uint32_t size_bytes;
+    uint8_t *buf;
+    int *res;
+} flash_op_params_t;
+
+static void flash_op_helper(void *param) {
+    const flash_op_params_t *op = (const flash_op_params_t *)param;
+    rom_flash_op_fn func = (rom_flash_op_fn) rom_func_lookup_inline(ROM_FUNC_FLASH_OP);
+    *(op->res) = func(op->flags, op->addr, op->size_bytes, op->buf);
+}
+
 /*!
  * \brief Perform a flash read, erase, or program operation
  * \ingroup pico_bootrom
@@ -582,19 +597,23 @@ static inline void rom_flash_select_xip_read_mode(bootrom_xip_mode_t mode, uint8
  * \param buf contains data to be written to flash, for program operations, and data read back from flash, for read operations
  */
 static inline int rom_flash_op(cflash_flags_t flags, uintptr_t addr, uint32_t size_bytes, uint8_t *buf) {
-    rom_flash_op_fn func = (rom_flash_op_fn) rom_func_lookup_inline(ROM_FUNC_FLASH_OP);
     if (!bootrom_try_acquire_lock(BOOTROM_LOCK_FLASH_OP))
         return BOOTROM_ERROR_LOCK_REQUIRED;
-#if !PICO_NO_FLASH
-    // Flash binary must disable interrupts before accessing flash
-    uint32_t interrupt_flags = save_and_disable_interrupts();
-#endif
-    int rc = func(flags, addr, size_bytes, buf);
-#if !PICO_NO_FLASH
-    restore_interrupts_from_disabled(interrupt_flags);
-#endif
+    int rc = 0;
+    flash_op_params_t params = {
+        .flags = flags,
+        .addr = addr,
+        .size_bytes = size_bytes,
+        .buf = buf,
+        .res = &rc
+    };
+    int flash_rc = flash_safe_execute(flash_op_helper, &params, UINT32_MAX);
     bootrom_release_lock(BOOTROM_LOCK_FLASH_OP);
-    return rc;
+    if (flash_rc != PICO_OK) {
+        return flash_rc;
+    } else {
+        return rc;
+    }
 }
 
 /*!
@@ -823,6 +842,18 @@ static inline int rom_chain_image(uint8_t *workarea_base, uint32_t workarea_size
     return rc;
 }
 
+typedef struct {
+    uint8_t *buffer;
+    uint32_t buffer_size;
+    int *res;
+} buy_params_t;
+
+static void buy_helper(void *param) {
+    const buy_params_t *op = (const buy_params_t *)param;
+    rom_explicit_buy_fn func = (rom_explicit_buy_fn) rom_func_lookup_inline(ROM_FUNC_EXPLICIT_BUY);
+    *(op->res) = func(op->buffer, op->buffer_size);
+}
+
 // todo SECURE only
 /*!
  * \brief Buy an image
@@ -850,16 +881,18 @@ static inline int rom_chain_image(uint8_t *workarea_base, uint32_t workarea_size
  * \param buffer_size size of scratch space
  */
 static inline int rom_explicit_buy(uint8_t *buffer, uint32_t buffer_size) {
-    rom_explicit_buy_fn func = (rom_explicit_buy_fn) rom_func_lookup_inline(ROM_FUNC_EXPLICIT_BUY);
-#if !PICO_NO_FLASH
-    // Flash binary must disable interrupts, in case a flash erase is required
-    uint32_t interrupt_flags = save_and_disable_interrupts();
-#endif
-    int rc = func(buffer, buffer_size);
-#if !PICO_NO_FLASH
-    restore_interrupts_from_disabled(interrupt_flags);
-#endif
-    return rc;
+    int rc = 0;
+    buy_params_t params = {
+        .buffer = buffer,
+        .buffer_size = buffer_size,
+        .res = &rc
+    };
+    int flash_rc = flash_safe_execute(buy_helper, &params, UINT32_MAX);
+    if (flash_rc != PICO_OK) {
+        return flash_rc;
+    } else {
+        return rc;
+    }
 }
 
 #ifndef __riscv


### PR DESCRIPTION
For `flash_op` and `explicit_buy`, disable interrupts if running a flash binary. This prevents calling interrupt routines in flash while the flash is being accessed directly (eg when `explicit_buy` does a flash erase), which would cause a bus fault. I haven't added the same to the other flash functions, because those are generally lower-level, whereas `flash_op` is a higher-level function so it's nice to be able to call it without additional configuration.

For `chain_image`, always disable interrupts before chaining, to prevent interrupt routines interrupting the chaining.