### PR TITLE
Ensure makefsdata.py generates valid variable names

### DIFF
--- a/src/rp2_common/pico_lwip/tools/makefsdata.py
+++ b/src/rp2_common/pico_lwip/tools/makefsdata.py
@@ -1,31 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+import mimetypes
 from pathlib import Path
 import re
-
-file_types = {
-    "html": "text/html",
-    "htm":  "text/html",
-    "shtml": "text/html",
-    "shtm": "text/html",
-    "ssi":  "text/html",
-    "gif":  "image/gif",
-    "png":  "image/png",
-    "jpg":  "image/jpeg",
-    "bmp":  "image/bmp",
-    "ico":  "image/x-icon",
-    "class": "application/octet-stream",
-    "cls":  "application/octet-stream",
-    "js":   "application/javascript",
-    "ram":  "application/javascript",
-    "css":  "text/css",
-    "swf":  "application/x-shockwave-flash",
-    "xml":  "text/xml",
-    "xsl":  "application/pdf",
-    "pdf":  "text/xml",
-    "json": "application/json",
-    "svg":  "image/svg+xml"
-}
 
 response_types = {
   200: "HTTP/1.0 200 OK",
@@ -42,9 +19,9 @@ def process_file(input_dir, file):
     results = []
 
     # Check content type
-    content_type = file_types.get(file.suffix[1:].lower())
+    content_type, _ = mimetypes.guess_type(file)
     if content_type is None:
-        raise RuntimeError(f"Unsupported file type {file.suffix}")
+        content_type = "application/octet-stream"
 
     # file name
     data = f"/{file.relative_to(input_dir)}\x00"
@@ -165,6 +142,11 @@ def run_tool():
     )
     args = parser.parse_args()
     print(args.input)
+
+    mimetypes.init()
+    for ext in [".shtml", ".shtm", ".ssi"]:
+        mimetypes.add_type("text/html", ext)
+
     with open(args.output, "w") as fd:
         process_file_list(fd, args.input)
 

--- a/src/rp2_common/pico_lwip/tools/makefsdata.py
+++ b/src/rp2_common/pico_lwip/tools/makefsdata.py
@@ -82,6 +82,11 @@ def process_file_list(fd, input):
         # make a variable name
         var_name = str(file.relative_to(input_dir))
         var_name = re.sub(r"\W+", "_", var_name, flags=re.ASCII)
+
+        # Add a suffix if the variable name is used already
+        if any(d["data_var"] == f"data_{var_name}" for d in data):
+            var_name += f"_{len(data)}"
+
         data_var = f"data_{var_name}"
         file_var = f"file_{var_name}"
 

--- a/src/rp2_common/pico_lwip/tools/makefsdata.py
+++ b/src/rp2_common/pico_lwip/tools/makefsdata.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 from pathlib import Path
+import re
 
 file_types = {
     "html": "text/html",
@@ -41,7 +42,7 @@ def process_file(input_dir, file):
     results = []
 
     # Check content type
-    content_type = file_types[file.suffix[1:].lower()]
+    content_type = file_types.get(file.suffix[1:].lower())
     if content_type is None:
         raise RuntimeError(f"Unsupported file type {file.suffix}")
 
@@ -103,8 +104,7 @@ def process_file_list(fd, input):
 
         # make a variable name
         var_name = str(file.relative_to(input_dir))
-        var_name = var_name.replace(".", "_")
-        var_name = var_name.replace("/", "_")
+        var_name = re.sub(r"\W+", "_", var_name, flags=re.ASCII)
         data_var = f"data_{var_name}"
         file_var = f"file_{var_name}"
 
@@ -121,7 +121,7 @@ def process_file_list(fd, input):
                 if byte_count % 16 == 0:
                     fd.write("\n")
             if byte_count % 16 != 0:
-                 fd.write("\n")
+                fd.write("\n")
         fd.write(f"}};\n\n")
 
         # set the flags


### PR DESCRIPTION
This PR:
- Updates makefsdata.py to strip out all characters that would be invalid in a C variable name.
- Adds a minor fix when getting the MIME type from the map to throw the exception we intend to, instead of `KeyError`.
- Fixes a minor indentation inconsistency which would bug me forever if not fixed.

There are a couple more issues in the script which can potentially be fixed, please let me know if you think it's worthwhile to do so and I will add these changes too:
- We could end up with duplicate variable names in some cases, if two or more file names differ only in special characters.
- It might be a good idea to use Python's built-in [mimetypes](https://docs.python.org/3/library/mimetypes.html) module to figure out the MIME type rather than our own map.

Fixes #1793.