### PR TITLE
Fix Windows CI build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,8 +24,7 @@ jobs:
         run: choco install .github/workflows/choco_packages.config
 
       - name: Build Project
-        # bash required otherwise this mysteriously (no error) fails at "Generating cyw43_bus_pio_spi.pio.h"
-        shell: bash
+        shell: pwsh
         run: |
           mkdir build
           cd build

--- a/src/cmake/on_device.cmake
+++ b/src/cmake/on_device.cmake
@@ -40,7 +40,7 @@ function(pico_add_dis_output TARGET)
     add_custom_command(TARGET ${TARGET} POST_BUILD
             COMMAND ${CMAKE_OBJDUMP} -h $<TARGET_FILE:${TARGET}> > ${output_path}$<IF:$<BOOL:$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>>,$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>,$<TARGET_PROPERTY:${TARGET},NAME>>.dis
             COMMAND ${CMAKE_OBJDUMP} -d $<TARGET_FILE:${TARGET}> >> ${output_path}$<IF:$<BOOL:$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>>,$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>,$<TARGET_PROPERTY:${TARGET},NAME>>.dis
-            ${EXTRA_COMMAND} || ${CMAKE_COMMAND} -E echo "WARNING: Disassembly is not correct"
+            ${EXTRA_COMMAND}
             VERBATIM
             )
 endfunction()


### PR DESCRIPTION
Use powershell for the build, instead of bash - I can't test this works without this being merged, but running the CI commands locally in powershell works fine, so they should run correctly in GitHub actions. There seem to be some path escaping issues or something in bash on Windows, so using powershell instead as that's a more standard option on Windows generally

Also remove the unnecessary warning - it isn't necessary, as picotool no longer throws an error with garbage coprocessor instructions

Fixes #1843