### PR TITLE
Bazel: disable link_extra_lib when building bootloader

### DIFF
--- a/bazel/util/transition.bzl
+++ b/bazel/util/transition.bzl
@@ -87,11 +87,18 @@ rp2040_bootloader_binary = declare_transtion(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
+	"_link_extra_libs": attr.label(default = "//bazel:empty_cc_lib"),
     },
     flag_overrides = {
         # We don't want --custom_malloc to ever apply to the bootloader, so
         # always explicitly override it here.
         "//command_line_option:custom_malloc": "_malloc",
+
+        # Platforms will commonly depend on bootloader components in every
+        # binary via `link_extra_libs`, so we must drop these deps when
+        # building the bootloader binaries themselves in order to avoid a
+        # circular dependency.
+	"@bazel_tools//tools/cpp:link_extra_libs": "_link_extra_libs",
     },
 )
 

--- a/src/rp2040/boot_stage2/BUILD.bazel
+++ b/src/rp2040/boot_stage2/BUILD.bazel
@@ -82,6 +82,11 @@ cc_binary(
         "-Wl,--entry=_stage2_boot",
         "-T$(location boot_stage2.ld)",
     ],
+    # Platforms will commonly depend on bootloader components in every
+    # binary via `link_extra_libs`, so we must drop these deps when
+    # building the bootloader binaries themselves in order to avoid a
+    # circular dependency.
+    link_extra_lib = "//bazel:empty_cc_lib",
     # this does nothing if someone passes --custom_malloc, so the
     # rp2040_bootloader_binary transition forcibly clobbers --custom_malloc.
     malloc = "//bazel:empty_cc_lib",

--- a/src/rp2350/boot_stage2/BUILD.bazel
+++ b/src/rp2350/boot_stage2/BUILD.bazel
@@ -76,6 +76,11 @@ cc_binary(
     copts = ["-fPIC"],
     # Incompatible with section garbage collection.
     features = ["-gc_sections"],
+    # Platforms will commonly depend on bootloader components in every
+    # binary via `link_extra_libs`, so we must drop these deps when
+    # building the bootloader binaries themselves in order to avoid a
+    # circular dependency.
+    link_extra_lib = "//bazel:empty_cc_lib",
     linkopts = [
         "-Wl,--no-gc-sections",
         "-nostartfiles",


### PR DESCRIPTION
Fixes #1853

The bazel bootloader targets (e.g. @@pico-sdk~//src/rp2040/boot_stage2:boot_stage2_elf_actual) get built with link_extra_lib in their deps, so including them in the link_extra_lib list for other binaries causes a dependency cycle. This cycle should be broken by removing link_extra_lib dependencies when building bootloader targets.