### PR TITLE
clear both the tx and rx fifos

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -1668,7 +1668,7 @@ static inline void pio_sm_clear_fifos(PIO pio, uint sm) {
     check_pio_param(pio);
     check_sm_param(sm);
     hw_xor_bits(&pio->sm[sm].shiftctrl, PIO_SM0_SHIFTCTRL_FJOIN_RX_BITS);
-    hw_xor_bits(&pio->sm[sm].shiftctrl, PIO_SM0_SHIFTCTRL_FJOIN_RX_BITS);
+    hw_xor_bits(&pio->sm[sm].shiftctrl, PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS);
 }
 
 /*! \brief Use a state machine to set a value on all pins for the PIO instance


### PR DESCRIPTION
_Instructions: (please delete)_
 - _please do not submit against `master`, use `develop` instead_
 - _please make sure there is an associated issue for your PR, and reference it via "Fixes #num" in the description_
 - _please enter a detailed description_

This PR is meant to fix #1855. As the issue says, we operate twice on the RX FIFO and I believe that we are supposed to clear both the RX and the TX FIFO.