### PR TITLE
Reorder pins in bi_pins_with_names to be correct

### DIFF
--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -208,8 +208,62 @@ static const struct _binary_info_named_group __bi_lineno_var_name = { \
 #define bi_7pins_with_func(p0, p1, p2, p3, p4, p5, p6,func) __bi_encoded_pins_64_with_func(BI_PINS_ENCODING_MULTI | ((func << 3)) | ((p0) << 8) | ((p1) << 16) | ((p2) << 24) | ((uint64_t)(p3) << 32) | ((uint64_t)(p4) << 40) | ((uint64_t)(p5) << 48) | ((uint64_t)(p6) << 56))
 
 #define bi_1pin_with_name(p0, name)                   bi_pin_mask_with_name(1ull << (p0), name)
-#define bi_2pins_with_names(p0, name0, p1, name1)     bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)), name0 "|" name1)
-#define bi_3pins_with_names(p0, name0, p1, name1, p2, name2)  bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)), name0 "|" name1 "|" name2)
-#define bi_4pins_with_names(p0, name0, p1, name1, p2, name2, p3, name3)  bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)) | (1ull << (p3)), name0 "|" name1 "|" name2 "|" name3)
+#define bi_2pins_with_names(p0, name0, p1, name1)     bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)), p0 < p1 ? name0 "|" name1 : name1 "|" name0)
+#define bi_3pins_with_names(p0, name0, p1, name1, p2, name2)  bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)),\
+    p0 < p1 ?\
+        (p1 < p2 ?\
+            name0 "|" name1 "|" name2:\
+            (p0 < p2 ? name0 "|" name2 "|" name1 : name2 "|" name0 "|" name1)):\
+        (p1 < p2 ?\
+            (p0 < p2 ? name1 "|" name0 "|" name2 : name1 "|" name2 "|" name0) :\
+            name2 "|" name1 "|" name0))
+#define bi_4pins_with_names(p0, name0, p1, name1, p2, name2, p3, name3)  bi_pin_mask_with_names((1ull << (p0)) | (1ull << (p1)) | (1ull << (p2)) | (1ull << (p3)),\
+    p0 < p1 ?\
+        (p1 < p2 ?\
+            (p2 < p3 ?\
+                name0 "|" name1 "|" name2 "|" name3:\
+                (p0 < p3 ?\
+                    (p1 < p3 ?\
+                        name0 "|" name1 "|" name3 "|" name2:\
+                        name0 "|" name3 "|" name1 "|" name2):\
+                    name3 "|" name0 "|" name1 "|" name2)):\
+            (p2 < p3 ?\
+                (p0 < p2 ?\
+                    (p1 < p3 ?\
+                        name0 "|" name2 "|" name1 "|" name3:\
+                        name0 "|" name2 "|" name3 "|" name1):\
+                    (p0 < p3 ?\
+                        (p1 < p3 ?\
+                            name2 "|" name0 "|" name1 "|" name3:\
+                            name2 "|" name0 "|" name3 "|" name1):\
+                        name2 "|" name3 "|" name0 "|" name1)):\
+                (p0 < p2 ?\
+                    (p0 < p3 ?\
+                        name0 "|" name3 "|" name2 "|" name1:\
+                        name3 "|" name0 "|" name2 "|" name1):\
+                    name3 "|" name2 "|" name0 "|" name1))):\
+        (p1 < p2 ?\
+            (p2 < p3 ?\
+                (p0 < p2 ?\
+                    name1 "|" name0 "|" name2 "|" name3:\
+                    (p0 < p3 ?\
+                        name1 "|" name2 "|" name0 "|" name3:\
+                        name1 "|" name2 "|" name3 "|" name0)):\
+                (p0 < p2 ?\
+                    (p0 < p3 ?\
+                        name1 "|" name0 "|" name3 "|" name2:\
+                        (p1 < p3 ?\
+                            name1 "|" name3 "|" name0 "|" name2:\
+                            name3 "|" name1 "|" name0 "|" name2)):\
+                    (p1 < p3 ?\
+                        name1 "|" name3 "|" name2 "|" name0:\
+                        name3 "|" name1 "|" name2 "|" name0))):\
+            (p2 < p3 ?\
+                (p0 < p3 ?\
+                    name2 "|" name1 "|" name0 "|" name3:\
+                    (p1 < p3 ?\
+                        name2 "|" name1 "|" name3 "|" name0:\
+                        name2 "|" name3 "|" name1 "|" name0)):\
+                name3 "|" name2 "|" name1 "|" name0)))
 
 #endif


### PR DESCRIPTION
Alternative to #1791 - instead of asserting when the order is incorrect, reorder the names so they are in the correct order for the pin mask

Requires more pre-processor stuff, but doesn't break existing code with the pins in the wrong order, so [pico-examples/524](https://github.com/raspberrypi/pico-examples/pull/524) would no longer be required

Has been tested using the following python code to generate all permutations of `bi_decls` which are then copied and compiled into a binary, and then checked with `picotool info` to ensure pins are all named correctly

```python
import itertools

pins = [
    'PICO_DEFAULT_SPI_RX_PIN, "SPI RX"',
    'PICO_DEFAULT_SPI_TX_PIN, "SPI TX"',
    'PICO_DEFAULT_SPI_SCK_PIN, "SPI SCK"',
    'PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"'
]

pinperms = itertools.permutations(pins, 2)
for p in pinperms:
    print(f"bi_decl(bi_2pins_with_names({p[0]}, {p[1]}));")

pinperms = itertools.permutations(pins, 3)
for p in pinperms:
    print(f"bi_decl(bi_3pins_with_names({p[0]}, {p[1]}, {p[2]}));")

pinperms = itertools.permutations(pins, 4)
for p in pinperms:
    print(f"bi_decl(bi_4pins_with_names({p[0]}, {p[1]}, {p[2]}, {p[3]}));")
```