### PR TITLE
Add build-essential to README command line install

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ You can install the [Raspberry Pi Pico Visual Studio Code extension](https://mar
 These instructions are extremely terse, and Linux-based only. For detailed steps,
 instructions for other platforms, and just in general, we recommend you see [Raspberry Pi Pico-Series C/C++ SDK](https://rptl.io/pico-c-sdk)
 
-1. Install CMake (at least version 3.13), and a GCC cross compiler
+1. Install CMake (at least version 3.13), a native compiler, and a GCC cross compiler
    ```
-   sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
+   sudo apt install cmake build-essential gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
    ```
 1. Set up your project to point to use the Raspberry Pi Pico SDK
 


### PR DESCRIPTION
In addition to a cross-compiler, a native compiler is required for compiling pioasm and picotool

I think this may fix #1782 as well - although I cannot reproduce that issue