### PR TITLE
Workaround gcc/newlib issue on Ubuntu 24

### DIFF
--- a/test/pico_float_test/pico_double_test.c
+++ b/test/pico_float_test/pico_double_test.c
@@ -17,6 +17,9 @@
 #include <math.h>
 #include <pico/double.h>
 #include "pico/stdlib.h"
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIx64
+#include <sys/types.h>
 #include "inttypes.h"
 
 #define test_assert(x) ({ if (!(x)) { printf("Assertion failed: ");puts(#x);printf("  at " __FILE__ ":%d\n", __LINE__); exit(-1); } })

--- a/test/pico_float_test/pico_float_test.c
+++ b/test/pico_float_test/pico_float_test.c
@@ -17,6 +17,9 @@
 #include <math.h>
 #include <pico/float.h>
 #include "pico/stdlib.h"
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIx64
+#include <sys/types.h>
 #include "inttypes.h"
 
 #define test_assert(x) ({ if (!(x)) { printf("Assertion failed: ");puts(#x);printf("  at " __FILE__ ":%d\n", __LINE__); exit(-1); } })

--- a/test/pico_sha256_test/pico_sha256_test.c
+++ b/test/pico_sha256_test/pico_sha256_test.c
@@ -6,6 +6,9 @@
 
 #include <stdio.h>
 #include <string.h>
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIu64
+#include <sys/types.h>
 #include <inttypes.h>
 #include <stdlib.h>
 

--- a/test/pico_stdlib_test/pico_stdlib_test.c
+++ b/test/pico_stdlib_test/pico_stdlib_test.c
@@ -5,6 +5,9 @@
  */
 
 #include <stdio.h>
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIu64
+#include <sys/types.h>
 #include <inttypes.h>
 #include "pico/stdlib.h"
 #include "pico/bit_ops.h"

--- a/test/pico_time_test/pico_time_test.c
+++ b/test/pico_time_test/pico_time_test.c
@@ -10,6 +10,9 @@
 #include <hardware/sync.h>
 #include "pico/stdlib.h"
 #include "pico/test.h"
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIi64
+#include <sys/types.h>
 #include <inttypes.h>
 PICOTEST_MODULE_NAME("pico_time_test", "pico_time test harness");
 


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-examples/issues/520 and https://github.com/raspberrypi/pico-examples/commit/8953e1b75a5b4f3d28533e3e04f6767a465625f9

(and also https://github.com/raspberrypi/pico-examples/pull/526 )

EDIT: Ahhh, and see the debian-bugs I mentioned here too https://github.com/raspberrypi/pico-sdk/issues/1690#issuecomment-2068291315