### PR TITLE
Use lib instead of CMAKE_INSTALL_LIBDIR for pioasm install

### DIFF
--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -58,7 +58,7 @@ if (PIOASM_FLAT_INSTALL)
     set(INSTALL_CONFIGDIR pioasm)
     set(INSTALL_BINDIR pioasm)
 else()
-    set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/pioasm)
+    set(INSTALL_CONFIGDIR lib/cmake/pioasm)
     set(INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})
 endif()
 


### PR DESCRIPTION
The CMake GNUInstallDirs module prior to CMake version 3.23.1 used an architecture-specific CMAKE_INSTALL_LIBDIR on debian, which is not searched by `find_package` calls from the SDK

Fix this in the same way as picotool https://github.com/raspberrypi/picotool/issues/117 by hard-coding the lib directory