### PR TITLE
Fix #1861 - incorrect assertion on MAX_EXCEPTION_NUM

### DIFF
--- a/src/rp2_common/hardware_exception/exception.c
+++ b/src/rp2_common/hardware_exception/exception.c
@@ -39,7 +39,7 @@ static void set_raw_exception_handler_and_restore_interrupts(enum exception_numb
 }
 
 static inline void check_exception_param(__unused enum exception_number num) {
-    invalid_params_if(HARDWARE_EXCEPTION, num < MIN_EXCEPTION_NUM || num >= MAX_EXCEPTION_NUM);
+    invalid_params_if(HARDWARE_EXCEPTION, num < MIN_EXCEPTION_NUM || num > MAX_EXCEPTION_NUM);
 }
 
 exception_handler_t exception_get_vtable_handler(enum exception_number num) {


### PR DESCRIPTION
MAX_EXCEPTION_NUM is the highest exception number, so when checking for an invalid exception the check should be for `>` rather than `>=`

The `>=` is leftover from when exception numbers were all negative, so the check for `>= 0` was correct then, but should now be `>`