### PR TITLE
Fix issue with conversion to uf2 using picotool

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -410,7 +410,7 @@ function(pico_add_uf2_output TARGET)
             ARGS uf2 convert
                 --quiet
                 ${uf2_package_args}
-                $<TARGET_FILE:${TARGET}>
+                $<TARGET_FILE:${TARGET}>.bin
                 ${output_path}$<IF:$<BOOL:$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>>,$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>,$<TARGET_PROPERTY:${TARGET},NAME>>.uf2
                 --family ${picotool_family}
                 ${extra_uf2_args}


### PR DESCRIPTION
There is a problem converting the binary file to uf2. The problem seems to be the lack of a file extension when generating the converting command in `tools/CMakeLists.txt`

Compilation output:
```
ERROR: filename '/workspaces/pico-2-template-project/build/sample' does not have a recognized file type (extension)
make[2]: *** [CMakeFiles/sample.dir/build.make:1205: sample] Error 157
make[2]: *** Deleting file 'sample'
make[1]: *** [CMakeFiles/Makefile2:1853: CMakeFiles/sample.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

and the snipet of makefile with wrong picotool command:
```
	/usr/local/bin/picotool uf2 convert --quiet /workspaces/pico-2-template-project/build/sample sample.uf2 --family rp2350-riscv --abs-block
```

The fix creates a correct uf2 file that can be uploaded to the microcontroller and run.