### PR TITLE
Specify minimum cmake version for generic_board.cmake

### DIFF
--- a/cmake/generic_board.cmake
+++ b/cmake/generic_board.cmake
@@ -1,4 +1,5 @@
 # For boards without their own cmake file, we look for a header file
+cmake_minimum_required(VERSION 3.15)
 
 # PICO_CMAKE_CONFIG: PICO_BOARD_HEADER_DIRS, List of directories to look for <PICO_BOARD>.h in. This may be specified the user environment, type=list, group=build
 if (DEFINED ENV{PICO_BOARD_HEADER_DIRS})


### PR DESCRIPTION
`cmake/generic_board.cmake` uses `POP_FRONT`, which https://cmake.org/cmake/help/latest/command/list.html#pop-front says was added in CMake version 3.15.
(this change means that people still using an ancient version of cmake will get a nicer error-message)