### PR TITLE
[Bazel] Update version string to 2.0.1-develop

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "pico-sdk",
-    version = "2.0.0",
+    version = "2.0.1-develop",
 )
 
 bazel_dep(name = "platforms", version = "0.0.9")


### PR DESCRIPTION
Updates the Bazel module version string to match the current CMake version string for the develop branch.