### PR TITLE
bump picotool to the develop branch

### DIFF
--- a/tools/Findpicotool.cmake
+++ b/tools/Findpicotool.cmake
@@ -35,7 +35,7 @@ if (NOT TARGET picotool)
         FetchContent_Declare(
                 picotool
                 GIT_REPOSITORY https://github.com/raspberrypi/picotool.git
-                GIT_TAG 2.0.0
+                GIT_TAG develop
                 GIT_PROGRESS true
         )
 


### PR DESCRIPTION
We were picking up 2.0.0 which is incompatible (for building) with SDK develop
