### PR TITLE
add GCC triplet for xPack RISC-V Embedded GCC

### DIFF
--- a/cmake/preload/toolchains/pico_riscv_gcc.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc.cmake
@@ -1,6 +1,6 @@
 set(CMAKE_SYSTEM_PROCESSOR hazard3)
 
-set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf)
+set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
 
 set(PICO_COMMON_LANG_FLAGS " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32")
 

--- a/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
@@ -3,7 +3,7 @@
 
 set(CMAKE_SYSTEM_PROCESSOR hazard3)
 
-set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf)
+set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
 
 set(PICO_COMMON_LANG_FLAGS " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32")
 


### PR DESCRIPTION
The [xPack RISC-V Embedded GCC](https://xpack-dev-tools.github.io/riscv-none-elf-gcc-xpack/) toolchain uses the `riscv-none-elf` triplet.

This patch adds it to the `PICO_DEFAULT_GCC_TRIPLE` list in the CMake files, thus adding support for the xPack RISC-V Embedded GCC toolchain.

This PR fixes https://github.com/raspberrypi/pico-sdk/issues/1887.