### PR TITLE
Fix a compile error by using clang-x86_64-pc-windows-msvc

### DIFF
--- a/src/host/pico_platform/include/pico/platform.h
+++ b/src/host/pico_platform/include/pico/platform.h
@@ -47,7 +47,7 @@ extern void tight_loop_contents();
 #define __STRING(x) #x
 #endif
 
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || defined(__clang__)
 #ifndef __noreturn
 #define __noreturn __attribute((noreturn))
 #endif


### PR DESCRIPTION
Fix compile errors when using clang-x86_64-pc-windows-msvc

Please see also https://github.com/raspberrypi/picotool/pull/129

- Environment

```console
$ clang --version
clang version 18.1.8
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin
Error messages
```

- An error message

```console
C:/hoge/pico-sdk/src/host/pico_platform/include\pico/platform.h:99:24: error: definition of builtin function '__builtin_unreachable'
   99 | static __noreturn void __builtin_unreachable() {
      |                        ^
1 error generated.
```
