### PR TITLE
Fixes #1891 Update pico_configure_ip4_address comments

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -93,11 +93,11 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
     # target name, target type, compile definition name to set then address in a string
     # This can be used to set the following compile definitions
     # CYW43_DEFAULT_IP_STA_ADDRESS
-    # CYW43_DEFAULT_IP_MASK
     # CYW43_DEFAULT_IP_STA_GATEWAY
-    # CYW43_DEFAULT_IP_DNS
     # CYW43_DEFAULT_IP_AP_ADDRESS
     # CYW43_DEFAULT_IP_AP_GATEWAY
+    # CYW43_DEFAULT_IP_MASK
+    # CYW43_DEFAULT_IP_DNS
     # e.g. pico_configure_ip4_address(picow_tcpip_server_background PRIVATE CYW43_DEFAULT_IP_STA_ADDRESS "10.3.15.204")
     function(pico_configure_ip4_address TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
             string(REGEX MATCHALL "[0-9]+" IP_ADDRESS_LIST ${IP_ADDRESS_STR})

--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -92,12 +92,13 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
     # Set an ip address in a compile definition
     # target name, target type, compile definition name to set then address in a string
     # This can be used to set the following compile definitions
-    # CYW43_DEFAULT_IP_ADDRESS
+    # CYW43_DEFAULT_IP_STA_ADDRESS
     # CYW43_DEFAULT_IP_MASK
-    # CYW43_DEFAULT_IP_GATEWAY
+    # CYW43_DEFAULT_IP_STA_GATEWAY
     # CYW43_DEFAULT_IP_DNS
-    # CYW43_DEFAULT_AP_IP_ADDRESS
-    # e.g. pico_configure_ip4_address(picow_tcpip_server_background PRIVATE CYW43_DEFAULT_IP_ADDRESS "10.3.15.204")
+    # CYW43_DEFAULT_IP_AP_ADDRESS
+    # CYW43_DEFAULT_IP_AP_GATEWAY
+    # e.g. pico_configure_ip4_address(picow_tcpip_server_background PRIVATE CYW43_DEFAULT_IP_STA_ADDRESS "10.3.15.204")
     function(pico_configure_ip4_address TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
             string(REGEX MATCHALL "[0-9]+" IP_ADDRESS_LIST ${IP_ADDRESS_STR})
             list(LENGTH IP_ADDRESS_LIST IP_ADDRESS_COMPONENT_COUNT)


### PR DESCRIPTION
Update `pico_configure_ip4_address` CMakeLists.txt function comments to correct compile definition names, and avoid user confusion.
