### PR TITLE
boot_stage2: improve reproducibility

### DIFF
--- a/src/rp2040/boot_stage2/CMakeLists.txt
+++ b/src/rp2040/boot_stage2/CMakeLists.txt
@@ -66,15 +66,12 @@ function(pico_define_boot_stage2 NAME SOURCES)
     add_custom_command(OUTPUT ${ORIGINAL_BIN} DEPENDS ${NAME} COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${NAME}> ${ORIGINAL_BIN}
         VERBATIM)
 
-    add_custom_target(${NAME}_padded_checksummed_asm DEPENDS ${PADDED_CHECKSUMMED_ASM})
     add_custom_command(OUTPUT ${PADDED_CHECKSUMMED_ASM} DEPENDS ${ORIGINAL_BIN}
             COMMAND ${Python3_EXECUTABLE} ${PICO_BOOT_STAGE2_DIR}/pad_checksum -s 0xffffffff ${ORIGINAL_BIN} ${PADDED_CHECKSUMMED_ASM}
             VERBATIM)
 
-    add_library(${NAME}_library INTERFACE)
-    add_dependencies(${NAME}_library ${NAME}_padded_checksummed_asm)
-    # not strictly (or indeed actually) a link library, but this avoids dependency cycle
-    target_link_libraries(${NAME}_library INTERFACE ${PADDED_CHECKSUMMED_ASM})
+    add_library(${NAME}_library OBJECT ${PADDED_CHECKSUMMED_ASM})
+    target_link_libraries(${NAME}_library INTERFACE "$<TARGET_OBJECTS:${NAME}_library>")
     target_link_libraries(${NAME}_library INTERFACE boot_stage2_headers)
 
     list(GET SOURCES 0 FIRST_SOURCE)

--- a/src/rp2350/boot_stage2/CMakeLists.txt
+++ b/src/rp2350/boot_stage2/CMakeLists.txt
@@ -65,15 +65,12 @@ function(pico_define_boot_stage2 NAME SOURCES)
     add_custom_target(${NAME}_bin DEPENDS ${ORIGINAL_BIN})
     add_custom_command(OUTPUT ${ORIGINAL_BIN} DEPENDS ${NAME} COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${NAME}> ${ORIGINAL_BIN})
 
-    add_custom_target(${NAME}_padded_checksummed_asm DEPENDS ${PADDED_CHECKSUMMED_ASM})
     add_custom_command(OUTPUT ${PADDED_CHECKSUMMED_ASM} DEPENDS ${ORIGINAL_BIN}
             COMMAND ${Python3_EXECUTABLE} ${PICO_BOOT_STAGE2_DIR}/pad_checksum -s 0xffffffff -a $<IF:${PICO_RISCV},riscv,arm> ${ORIGINAL_BIN} ${PADDED_CHECKSUMMED_ASM}
             )
 
-    add_library(${NAME}_library INTERFACE)
-    add_dependencies(${NAME}_library ${NAME}_padded_checksummed_asm)
-    # not strictly (or indeed actually) a link library, but this avoids dependency cycle
-    target_link_libraries(${NAME}_library INTERFACE ${PADDED_CHECKSUMMED_ASM})
+    add_library(${NAME}_library OBJECT ${PADDED_CHECKSUMMED_ASM})
+    target_link_libraries(${NAME}_library INTERFACE "$<TARGET_OBJECTS:${NAME}_library>")
     target_link_libraries(${NAME}_library INTERFACE boot_stage2_headers)
 
     list(GET SOURCES 0 FIRST_SOURCE)


### PR DESCRIPTION
Specifying the final boot2 source file as a link library here causes the final `.elf` to be linked directly with that `.S`, which causes it to be compiled into an object file with a name like `/tmp/<random chars>.o`. This temporary object name is embedded in the final `.elf`, so the `.elf`'s contents change after each link even if none of the input files change, breaking reproducibility.

Fix the issue by specifying the source file as the source for an object-only library, then specifying the library's object files as the target link libraries, so the source is compiled in a separate step and only the object is passed to the linker.

Fixes #1906

This makes everything fully reproducible for me and my setup though I have not tested exhaustively and reproducibility is of course something that can't be absolutely proved. Also please keep in mind I'm not knowledgeable with CMake and bumbled into this solution.