### PR TITLE
Fix Bazel build breakages

### DIFF
--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -72,6 +72,12 @@ bool_flag(
     build_setting_default = True,
 )
 
+# PICO_BAZEL_CONFIG: PICO_DEFAULT_UART_BAUD_RATE, Define the default UART baudrate, type=int, max=921600, default=115200, group=hardware_uart
+int_flag(
+    name = "PICO_DEFAULT_UART_BAUD_RATE",
+    build_setting_default = 115200,
+)
+
 # PICO_BAZEL_CONFIG: PICO_STDIO_USB, Option to globally enable stdio USB for all targets by default, type=bool, default=0, group=pico_stdlib
 bool_flag(
     name = "PICO_STDIO_USB",
@@ -151,7 +157,7 @@ bool_flag(
     build_setting_default = True,
 )
 
-# PICO_BAZEL_CONFIG: PICO_CMSIS_PATH, Label of a cc_ibrary providing CMSIS core, default="included stub CORE only impl", group=build
+# PICO_BAZEL_CONFIG: PICO_CMSIS_PATH, Label of a cc_ibrary providing CMSIS core,  type=string, default="included stub CORE only impl", group=build
 label_flag(
     name = "PICO_CMSIS_PATH",
     build_setting_default = "//src/rp2_common/cmsis:cmsis_core",

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -14,6 +14,10 @@ alias(
         "//src/common/hardware_claim:__pkg__",
         "//src/common/pico_base_headers:__pkg__",
         "//src/common/pico_binary_info:__pkg__",
+        # These libraries sometimes need the host version even though they live
+        # in rp2_common.
+        "//src/rp2_common/boot_bootrom_headers:__pkg__",
+        "//src/rp2_common/pico_flash:__pkg__",
     ],
 )
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -17,6 +17,7 @@ alias(
         # These libraries sometimes need the host version even though they live
         # in rp2_common.
         "//src/rp2_common/boot_bootrom_headers:__pkg__",
+        "//src/rp2_common/hardware_boot_lock:__pkg__",
         "//src/rp2_common/pico_flash:__pkg__",
     ],
 )

--- a/src/boards/BUILD.bazel
+++ b/src/boards/BUILD.bazel
@@ -8,6 +8,7 @@ BOARD_CHOICES = [
     "0xcb_helios",
     "adafruit_feather_rp2040_usb_host",
     "adafruit_feather_rp2040",
+    "adafruit_feather_rp2350",
     "adafruit_itsybitsy_rp2040",
     "adafruit_kb2040",
     "adafruit_macropad_rp2040",

--- a/src/common/boot_picoboot_headers/BUILD.bazel
+++ b/src/common/boot_picoboot_headers/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+# This needs to remain compatible with the host build since it's used by
+# Picotool.
 cc_library(
     name = "boot_picoboot_headers",
     hdrs = [

--- a/src/rp2040/boot_stage2/BUILD.bazel
+++ b/src/rp2040/boot_stage2/BUILD.bazel
@@ -76,17 +76,17 @@ cc_binary(
     copts = ["-fPIC"],
     # Incompatible with section garbage collection.
     features = ["-gc_sections"],
+    # Platforms will commonly depend on bootloader components in every
+    # binary via `link_extra_libs`, so we must drop these deps when
+    # building the bootloader binaries themselves in order to avoid a
+    # circular dependency.
+    link_extra_lib = "//bazel:empty_cc_lib",
     linkopts = [
         "-Wl,--no-gc-sections",
         "-nostartfiles",
         "-Wl,--entry=_stage2_boot",
         "-T$(location boot_stage2.ld)",
     ],
-    # Platforms will commonly depend on bootloader components in every
-    # binary via `link_extra_libs`, so we must drop these deps when
-    # building the bootloader binaries themselves in order to avoid a
-    # circular dependency.
-    link_extra_lib = "//bazel:empty_cc_lib",
     # this does nothing if someone passes --custom_malloc, so the
     # rp2040_bootloader_binary transition forcibly clobbers --custom_malloc.
     malloc = "//bazel:empty_cc_lib",

--- a/src/rp2_common/hardware_boot_lock/BUILD.bazel
+++ b/src/rp2_common/hardware_boot_lock/BUILD.bazel
@@ -8,6 +8,7 @@ cc_library(
     hdrs = ["include/hardware/boot_lock.h"],
     includes = ["include"],
     tags = ["manual"],
+    # deps = ["//src:pico_platform_internal"],
     visibility = ["//src/rp2_common/pico_bootrom:__pkg__"],
 )
 

--- a/src/rp2_common/hardware_boot_lock/BUILD.bazel
+++ b/src/rp2_common/hardware_boot_lock/BUILD.bazel
@@ -8,7 +8,7 @@ cc_library(
     hdrs = ["include/hardware/boot_lock.h"],
     includes = ["include"],
     tags = ["manual"],
-    # deps = ["//src:pico_platform_internal"],
+    deps = ["//src:pico_platform_internal"],
     visibility = ["//src/rp2_common/pico_bootrom:__pkg__"],
 )
 

--- a/src/rp2_common/hardware_hazard3/BUILD.bazel
+++ b/src/rp2_common/hardware_hazard3/BUILD.bazel
@@ -4,7 +4,11 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "hardware_hazard3",
-    hdrs = ["include/hardware/hazard3.h"],
+    hdrs = [
+        "include/hardware/hazard3.h",
+        "include/hardware/hazard3/features.h",
+        "include/hardware/hazard3/instructions.h",
+    ],
     includes = ["include"],
     target_compatible_with = compatible_with_rp2() + ["@platforms//cpu:riscv32"],
     deps = [

--- a/src/rp2_common/hardware_uart/BUILD.bazel
+++ b/src/rp2_common/hardware_uart/BUILD.bazel
@@ -1,6 +1,13 @@
 load("//bazel:defs.bzl", "compatible_with_rp2")
+load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 
 package(default_visibility = ["//visibility:public"])
+
+pico_sdk_define(
+    name = "PICO_DEFAULT_UART_BAUD_RATE",
+    define_name = "PICO_DEFAULT_UART_BAUD_RATE",
+    from_flag = "//bazel/config:PICO_DEFAULT_UART_BAUD_RATE",
+)
 
 cc_library(
     name = "hardware_uart",
@@ -9,6 +16,7 @@ cc_library(
     includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
     deps = [
+        ":PICO_DEFAULT_UART_BAUD_RATE",
         "//src/rp2_common:hardware_regs",
         "//src/rp2_common:hardware_structs",
         "//src/rp2_common:pico_platform",

--- a/src/rp2_common/pico_bit_ops/BUILD.bazel
+++ b/src/rp2_common/pico_bit_ops/BUILD.bazel
@@ -25,6 +25,7 @@ cc_library(
         "//src/common/pico_bit_ops_headers:pico_bit_ops_interface",
         "//src/rp2_common:pico_platform_internal",
         "//src/rp2_common/pico_bootrom",
+        "//src/rp2_common/pico_runtime_init",
     ],
     alwayslink = True,  # Ensures the wrapped symbols are linked in.
 )

--- a/src/rp2_common/pico_bootrom/BUILD.bazel
+++ b/src/rp2_common/pico_bootrom/BUILD.bazel
@@ -2,7 +2,7 @@ load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
 
-# Picotool needs this, so we can't strictly constrain compatibility.
+# Picotool needs this, so we can't strictly constrain platform compatibility.
 cc_library(
     name = "pico_bootrom_headers",
     hdrs = [
@@ -15,8 +15,13 @@ cc_library(
     tags = ["manual"],
     visibility = ["@picotool//:__subpackages__"],
     deps = [
+        "//src/rp2_common/boot_bootrom_headers",
         "//src/rp2_common/hardware_boot_lock:hardware_boot_lock_headers",
-    ],
+        "//src/rp2_common/pico_flash:pico_flash_headers",
+    ] + select({
+        "//bazel/constraint:host": ["//src/host/hardware_sync"],
+        "//conditions:default": ["//src/rp2_common/hardware_sync"],
+    }),
 )
 
 cc_library(
@@ -25,22 +30,15 @@ cc_library(
         "bootrom.c",
         "bootrom_lock.c",
     ],
-    hdrs = [
-        "include/pico/bootrom.h",
-        "include/pico/bootrom/lock.h",
-        "include/pico/bootrom/sf_table.h",
-        "include/pico/bootrom_constants.h",
-    ],
     implementation_deps = [
         "//src/common/boot_picobin_headers",
         "//src/common/boot_picoboot_headers",
         "//src/rp2_common/hardware_sync",
         "//src/rp2_common/pico_runtime_init",
     ],
-    includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
     deps = [
-        "//src/rp2_common/hardware_boot_lock",
+        ":pico_bootrom_headers",
     ] + select({
         "//bazel/constraint:host": [
         ],

--- a/src/rp2_common/pico_flash/BUILD.bazel
+++ b/src/rp2_common/pico_flash/BUILD.bazel
@@ -2,17 +2,29 @@ load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
 
+# Picotool needs this (transitively through
+# //src/rp2_common/pico_bootrom:pico_bootrom_headers), so we can't strictly
+# constrain compatibility.
+cc_library(
+    name = "pico_flash_headers",
+    hdrs = ["include/pico/flash.h"],
+    includes = ["include"],
+    visibility = ["//src/rp2_common/pico_bootrom:__pkg__"],
+    deps = [
+        "//src:pico_platform_internal",
+    ],
+)
+
 cc_library(
     name = "pico_flash",
     srcs = ["flash.c"],
-    hdrs = ["include/pico/flash.h"],
     defines = select({
         "//bazel/constraint:pico_freertos_unset": ["PICO_FREERTOS_LIB=0"],
         "//conditions:default": ["PICO_FREERTOS_LIB=1"],
     }),
-    includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
     deps = [
+        ":pico_flash_headers",
         "//src/common/pico_time",
         "//src/rp2_common:pico_platform",
         "//src/rp2_common/hardware_exception",

--- a/src/rp2_common/pico_float/BUILD.bazel
+++ b/src/rp2_common/pico_float/BUILD.bazel
@@ -86,6 +86,7 @@ alias(
     actual = select({
         "//bazel/constraint:rp2040": ":pico_float_pico",
         "@platforms//cpu:armv8-m": ":pico_float_vfp",
+        "@platforms//cpu:riscv32": ":pico_float_single_hazard3",
         "//conditions:default": ":pico_float_compiler",
     }),
     visibility = ["//visibility:private"],
@@ -138,12 +139,22 @@ _PICO_FLOAT_IMPLS = [
         "extra_deps": ["//src/rp2_common/hardware_dcp"],
         "linkopts": _WRAP_FLOAT_SCI_FLAGS,
     },
+    {
+        "name": "single_hazard3",
+        "srcs": [
+            "float_single_hazard3.S",
+        ],
+        "compatibility": compatible_with_rp2() + ["@platforms//cpu:riscv32"],
+        "extra_deps": ["//src/rp2_common/hardware_hazard3"],
+        "linkopts": _WRAP_FLOAT_SCI_FLAGS,
+    },
 ]
 
 # Creates:
 #   * pico_float_pico
 #   * pico_float_dcp
 #   * pico_float_vfp
+#   * pico_float_single_hazard3
 [
     cc_library(
         name = "pico_float_{}".format(impl["name"]),

--- a/src/rp2_common/pico_lwip/lwip.BUILD
+++ b/src/rp2_common/pico_lwip/lwip.BUILD
@@ -11,11 +11,11 @@ cc_library(
         "contrib/ports/freertos/include/arch",
         "src/include",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         "@pico-sdk//bazel/config:PICO_LWIP_CONFIG",
         "@pico-sdk//src/rp2_common/pico_lwip:pico_lwip_config",
     ],
-    visibility = ["//visibility:private"],
 )
 
 cc_library(

--- a/src/rp2_common/pico_mem_ops/BUILD.bazel
+++ b/src/rp2_common/pico_mem_ops/BUILD.bazel
@@ -44,6 +44,7 @@ cc_library(
     deps = [
         "//src/rp2_common:pico_platform_internal",
         "//src/rp2_common/pico_bootrom",
+        "//src/rp2_common/pico_runtime_init",
     ],
     alwayslink = True,  # Ensures the wrapped symbols are linked in.
 )

--- a/test/pico_float_test/BUILD.bazel
+++ b/test/pico_float_test/BUILD.bazel
@@ -3,6 +3,23 @@ load("//bazel/util:transition.bzl", "pico_float_test_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+# TODO: Set up a transition to build this under RISC-V.
+cc_binary(
+    name = "pico_float_test_hazard3",
+    testonly = True,
+    srcs = ["pico_float_test_hazard3.c"],
+    hdrs = [
+        "vectors/hazard3_addsf.inc",
+        "vectors/hazard3_mulsf.inc",
+    ],
+    includes = ["."],
+    target_compatible_with = compatible_with_rp2() + ["@platforms//cpu:riscv32"],
+    deps = [
+        "//src/rp2_common/pico_float",
+        "//src/rp2_common/pico_stdlib",
+    ],
+)
+
 cc_binary(
     name = "pico_float_test",
     testonly = True,

--- a/test/pico_float_test/BUILD.bazel
+++ b/test/pico_float_test/BUILD.bazel
@@ -3,12 +3,18 @@ load("//bazel/util:transition.bzl", "pico_float_test_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+cc_binary(
+    name = "hazard3_test_gen",
+    srcs = ["hazard3_test_gen.c"],
+    target_compatible_with = ["//bazel/constraint:host"],
+)
+
 # TODO: Set up a transition to build this under RISC-V.
 cc_binary(
     name = "pico_float_test_hazard3",
     testonly = True,
-    srcs = ["pico_float_test_hazard3.c"],
-    hdrs = [
+    srcs = [
+        "pico_float_test_hazard3.c",
         "vectors/hazard3_addsf.inc",
         "vectors/hazard3_mulsf.inc",
     ],

--- a/tools/bazel_build.py
+++ b/tools/bazel_build.py
@@ -42,6 +42,7 @@ BUILD_CONFIGURATIONS = (
                 "//test/pico_divider_test:pico_divider_nesting_test",
                 "//test/pico_float_test:pico_double_test",
                 "//test/pico_float_test:pico_float_test",
+                "//test/pico_float_test:pico_float_test_hazard3",
                 "//test/pico_sha256_test:pico_sha256_test",
                 "//test/pico_stdio_test:pico_stdio_test",
                 "//test/pico_time_test:pico_time_test",
@@ -63,6 +64,10 @@ BUILD_CONFIGURATIONS = (
             (
                 "//test/kitchen_sink:kitchen_sink_lwip_poll",
                 "//test/kitchen_sink:kitchen_sink_lwip_background",
+                # Host only.
+                "//test/pico_float_test:hazard3_test_gen",
+                # No RISC-V on RP2040.
+                "//test/pico_float_test:pico_float_test_hazard3",
                 # hardware_sha256 doesn't appear to work on RP2040.
                 "//test/pico_sha256_test:pico_sha256_test",
             )
@@ -76,6 +81,10 @@ BUILD_CONFIGURATIONS = (
             (
                 "//test/kitchen_sink:kitchen_sink_lwip_poll",
                 "//test/kitchen_sink:kitchen_sink_lwip_background",
+                # Host only.
+                "//test/pico_float_test:hazard3_test_gen",
+                # TODO: RISC-V support.
+                "//test/pico_float_test:pico_float_test_hazard3",
             )
         ),
     },
@@ -90,6 +99,10 @@ BUILD_CONFIGURATIONS = (
             (
                 "//test/kitchen_sink:kitchen_sink_lwip_poll",
                 "//test/kitchen_sink:kitchen_sink_lwip_background",
+                # Host only.
+                "//test/pico_float_test:hazard3_test_gen",
+                # No RISC-V on RP2040.
+                "//test/pico_float_test:pico_float_test_hazard3",
                 # hardware_sha256 doesn't appear to work on RP2040.
                 "//test/pico_sha256_test:pico_sha256_test",
             )
@@ -106,6 +119,10 @@ BUILD_CONFIGURATIONS = (
             (
                 "//test/kitchen_sink:kitchen_sink_lwip_poll",
                 "//test/kitchen_sink:kitchen_sink_lwip_background",
+                # Host only.
+                "//test/pico_float_test:hazard3_test_gen",
+                # TODO: RISC-V support.
+                "//test/pico_float_test:pico_float_test_hazard3",
             )
         ),
     },
@@ -118,6 +135,10 @@ BUILD_CONFIGURATIONS = (
         "extra_targets": (),
         "exclusions": frozenset(
             (
+                # Host only.
+                "//test/pico_float_test:hazard3_test_gen",
+                # No RISC-V on RP2040.
+                "//test/pico_float_test:pico_float_test_hazard3",
                 # hardware_sha256 doesn't appear to work on RP2040.
                 "//test/pico_sha256_test:pico_sha256_test",
             )


### PR DESCRIPTION
* Adds support for new PICO_DEFAULT_UART_BAUD_RATE option.
* Fixes issues related to Picotool and boot_picoboot_headers.
* Adds pico_float RISC-V pieces to the Bazel build (not yet fully tested).
* Adds the missing adafruit board header to the Bazel build.