### PR TITLE
#1909 fix system_RP2350 typos

### DIFF
--- a/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/system_RP2350.h
+++ b/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/system_RP2350.h
@@ -1,9 +1,9 @@
 /*************************************************************************//**
- * @file     system_RP2040.h
+ * @file     system_RP2350.h
  * @brief    CMSIS-Core(M) Device Peripheral Access Layer Header File for
- *           Device RP2040
- * @version  V1.0.0
- * @date     5. May 2021
+ *           Device RP2350
+ * @version  V1.0.1
+ * @date     6. Sep 2024
  *****************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.
@@ -26,8 +26,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef _CMSIS_SYSTEM_RP2040_H
-#define _CMSIS_SYSTEM_RP2040_H
+#ifndef _CMSIS_SYSTEM_RP2350_H
+#define _CMSIS_SYSTEM_RP2350_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,4 +62,4 @@ extern void SystemCoreClockUpdate (void);
 }
 #endif
 
-#endif /* _CMSIS_SYSTEM_RP2040_H */
+#endif /* _CMSIS_SYSTEM_RP2350_H */

--- a/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Source/system_RP2350.c
+++ b/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Source/system_RP2350.c
@@ -1,9 +1,9 @@
 /*************************************************************************//**
- * @file     system_RP2040.c
+ * @file     system_RP2350.c
  * @brief    CMSIS-Core(M) Device Peripheral Access Layer Header File for
- *           Device RP2040
- * @version  V1.0.0
- * @date     5. May 2021
+ *           Device RP2350
+ * @version  V1.0.1
+ * @date     6. Sep 2024
  *****************************************************************************/
 /*
  * Copyright (c) 2009-2021 Arm Limited. All rights reserved.


### PR DESCRIPTION
Fixes #1909 

"RP2040" changed to "RP2350" in the header and macro definitions in system_RP2350.h and .c.