### PR TITLE
Fixed string trimming issue at line 48

### DIFF
--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -45,7 +45,7 @@ void pico_get_unique_board_id_string(char *id_out, uint len) {
     assert(len > 0);
     size_t i;
     // Generate hex one nibble at a time
-    for (i = 0; (i < len - 1) && (i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2); i++) {
+    for (i = 0; (i < len) && (i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2); i++) {
         int nibble = (retrieved_id.id[i/2] >> (4 - 4 * (i&1))) & 0xf;
         id_out[i] = (char)(nibble < 10 ? nibble + '0' : nibble + 'A' - 10);
     }


### PR DESCRIPTION
Fixed an issue where in pico_get_unique_board_id_string, the limit for the for loop was set too low, so I incremented it and now it should work for strings with length 16.

Fixes #1912 