### PR TITLE
RP2350 RISC-V invalid inline asm machine constraint fix in platform.h

### DIFF
--- a/src/rp2350/pico_platform/include/pico/platform.h
+++ b/src/rp2350/pico_platform/include/pico/platform.h
@@ -252,7 +252,7 @@ static inline uint8_t rp2040_rom_version(void) {
  */
 __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
 #ifdef __riscv
-    __asm ("mul %0, %0, %1" : "+l" (a) : "l" (b) : );
+    __asm ("mul %0, %0, %1" : "+r" (a) : "r" (b) : );
 #else
     pico_default_asm ("muls %0, %1"     : "+l" (a) : "l" (b) : "cc");
 #endif


### PR DESCRIPTION
Fixes #1922. 

I already described the issue and this proposed fix in the issue above, but I'll also describe it here for reference.

Currently, [`/src/rp2350/pico_platform/include/pico/platform.h`](https://github.com/raspberrypi/pico-sdk/blob/efe2103f9b28458a1615ff096054479743ade236/src/rp2350/pico_platform/include/pico/platform.h#L249) has the following `__mul_instruction` function:
```h
247 | __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
248 | #ifdef __riscv
249 |     __asm ("mul %0, %0, %1" : "+l" (a) : "l" (b) : );
250 | #else
251 |     pico_default_asm ("muls %0, %1"     : "+l" (a) : "l" (b) : "cc");
```

When trying to compile the Pico SDK headers for RISC-V using LLVM, an error is trown at line 249, indicating that `l` is an invalid inline asm machine constraint. And, checking the GNU docs for [arch-specific constraints](https://gcc.gnu.org/onlinedocs/gcc/Machine-Constraints.html) and [general constraints](https://gcc.gnu.org/onlinedocs/gcc/Simple-Constraints.html), it seems that `l` is an invalid constraint for RISC-V. 

Thus, this PR addresses this by replacing the `+l` and `l` constraints with the general constraints `+r` and `r`.