### PR TITLE
Export linker scripts in the bazel build.

### DIFF
--- a/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
@@ -1,5 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(
+    [
+        "memmap_blocked_ram.ld",
+        "memmap_copy_to_ram.ld",
+        "memmap_default.ld",
+        "memmap_no_flash.ld",
+    ]
+)
+
 # It's possible to set linker scripts globally or on a per-binary basis.
 #
 # Setting globally:
@@ -56,13 +65,4 @@ cc_library(
         "memmap_no_flash.ld",
         "//src/rp2_common/pico_crt0:no_warn_rwx_flag",
     ],
-)
-
-exports_files(
-    [
-        "memmap_blocked_ram.ld",
-        "memmap_copy_to_ram.ld",
-        "memmap_default.ld",
-        "memmap_no_flash.ld",
-    ]
 )

--- a/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
@@ -57,3 +57,12 @@ cc_library(
         "//src/rp2_common/pico_crt0:no_warn_rwx_flag",
     ],
 )
+
+exports_files(
+    [
+        "memmap_blocked_ram.ld",
+        "memmap_copy_to_ram.ld",
+        "memmap_default.ld",
+        "memmap_no_flash.ld",
+    ]
+)

--- a/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
@@ -1,5 +1,13 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(
+    [
+        "memmap_copy_to_ram.ld",
+        "memmap_default.ld",
+        "memmap_no_flash.ld",
+    ]
+)
+
 # It's possible to set linker scripts globally or on a per-binary basis.
 #
 # Setting globally:
@@ -43,12 +51,4 @@ cc_library(
         "memmap_no_flash.ld",
         "//src/rp2_common/pico_crt0:no_warn_rwx_flag",
     ],
-)
-
-exports_files(
-    [
-        "memmap_copy_to_ram.ld",
-        "memmap_default.ld",
-        "memmap_no_flash.ld",
-    ]
 )

--- a/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
@@ -44,3 +44,11 @@ cc_library(
         "//src/rp2_common/pico_crt0:no_warn_rwx_flag",
     ],
 )
+
+exports_files(
+    [
+        "memmap_copy_to_ram.ld",
+        "memmap_default.ld",
+        "memmap_no_flash.ld",
+    ]
+)


### PR DESCRIPTION
Export linker scripts in the bazel build.

Make the rp2040 and rp2350 linker scripts available in downstream projects bazel builds.