### PR TITLE
Fix hardware_alarm_irq_handler when using Timer 1, Fixes #1948

### DIFF
--- a/src/rp2_common/hardware_timer/timer.c
+++ b/src/rp2_common/hardware_timer/timer.c
@@ -145,9 +145,10 @@ void busy_wait_until(absolute_time_t t) {
 
 static void hardware_alarm_irq_handler(void) {
     // Determine which timer this IRQ is for
-    uint alarm_num = TIMER_ALARM_NUM_FROM_IRQ(__get_current_exception() - VTABLE_FIRST_IRQ);
+    uint irq_num = __get_current_exception() - VTABLE_FIRST_IRQ;
+    uint alarm_num = TIMER_ALARM_NUM_FROM_IRQ(irq_num);
     check_hardware_alarm_num_param(alarm_num);
-    uint timer_num = TIMER_NUM_FROM_IRQ(alarm_num);
+    uint timer_num = TIMER_NUM_FROM_IRQ(irq_num);
     timer_hw_t *timer = timer_get_instance(timer_num);
     hardware_alarm_callback_t callback = NULL;
 


### PR DESCRIPTION
Correct the logic for determining `timer_num`. Previously this would always evaluate to 0 due to using `alarm_num` instead of `irq_num`.

Fixes #1948.
