### PR TITLE
Fix missing headers leading to #include failing when pulling in hardware_irq and pico_bootrom

### DIFF
--- a/src/rp2_common/hardware_irq/CMakeLists.txt
+++ b/src/rp2_common/hardware_irq/CMakeLists.txt
@@ -4,7 +4,7 @@ pico_simple_hardware_target(irq)
 
 target_sources(hardware_irq INTERFACE ${CMAKE_CURRENT_LIST_DIR}/irq_handler_chain.S)
 
-target_link_libraries(hardware_irq INTERFACE pico_sync pico_runtime_init pico_runtime) # not mirrored as only implementation requires it
+target_link_libraries(hardware_irq INTERFACE pico_sync pico_runtime_init_headers pico_runtime) # not mirrored as only implementation requires it
 if (PICO_RISCV)
     pico_mirrored_target_link_libraries(hardware_irq INTERFACE hardware_hazard3)
 endif()

--- a/src/rp2_common/hardware_irq/CMakeLists.txt
+++ b/src/rp2_common/hardware_irq/CMakeLists.txt
@@ -4,7 +4,7 @@ pico_simple_hardware_target(irq)
 
 target_sources(hardware_irq INTERFACE ${CMAKE_CURRENT_LIST_DIR}/irq_handler_chain.S)
 
-target_link_libraries(hardware_irq INTERFACE pico_sync) # not mirrored as only implementation requires it
+target_link_libraries(hardware_irq INTERFACE pico_sync pico_runtime_init pico_runtime) # not mirrored as only implementation requires it
 if (PICO_RISCV)
     pico_mirrored_target_link_libraries(hardware_irq INTERFACE hardware_hazard3)
 endif()

--- a/src/rp2_common/pico_bootrom/CMakeLists.txt
+++ b/src/rp2_common/pico_bootrom/CMakeLists.txt
@@ -8,5 +8,5 @@ target_sources(pico_bootrom INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/bootrom_lock.c
         )
 
-target_link_libraries(pico_bootrom_headers INTERFACE boot_picoboot_headers boot_bootrom_headers boot_picobin_headers pico_runtime_init)
+target_link_libraries(pico_bootrom_headers INTERFACE boot_picoboot_headers boot_bootrom_headers boot_picobin_headers pico_runtime_init_headers)
 pico_mirrored_target_link_libraries(pico_bootrom INTERFACE pico_base hardware_boot_lock pico_flash)

--- a/src/rp2_common/pico_bootrom/CMakeLists.txt
+++ b/src/rp2_common/pico_bootrom/CMakeLists.txt
@@ -8,5 +8,5 @@ target_sources(pico_bootrom INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/bootrom_lock.c
         )
 
-target_link_libraries(pico_bootrom_headers INTERFACE boot_picoboot_headers boot_bootrom_headers)
+target_link_libraries(pico_bootrom_headers INTERFACE boot_picoboot_headers boot_bootrom_headers boot_picobin_headers pico_runtime_init)
 pico_mirrored_target_link_libraries(pico_bootrom INTERFACE pico_base hardware_boot_lock pico_flash)


### PR DESCRIPTION
As suggested by @kilograham (in https://github.com/raspberrypi/pico-sdk/issues/1929#issuecomment-2364746391), add `pico_runtime_init` as well as `pico_runtime` and `boot_picobin_headers` to the `CMakeLists.txt`s defining `hardware_irq` and `pico_bootrom_headers`.

While the issue initially was reported only for `hardware_irq` missing `pico_runtime_init`, the same issue affect the other mentionned.

Fixes #1929 