### PR TITLE
Doc fix for aon_timer on RP2350

### DIFF
--- a/src/rp2_common/pico_aon_timer/include/pico/aon_timer.h
+++ b/src/rp2_common/pico_aon_timer/include/pico/aon_timer.h
@@ -21,7 +21,7 @@
  * This library uses the RTC on RP2040.
  * \endif
  * \if rp2350_specific
- * This library uses the RTC on RP2350.
+ * This library uses the Powman Timer on RP2350.
  * \endif
  */
 


### PR DESCRIPTION
Fixes #1959.

https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#group_pico_aon_timer says,

```
This library uses the RTC on RP2040. This library uses the RTC on RP2350.
```

![Screenshot_2024-09-28_17-23-06](https://github.com/user-attachments/assets/20da8d30-717c-4495-aa06-d143b98713fc)

This looks a bit off.

...

Whereas https://github.com/raspberrypi/pico-sdk/releases says,

- On RP2040 this uses the RTC.
- On RP2350 this uses the Powman Timer.
