### PR TITLE
Update mktime header declaration to match upstream LLVM libc.

### DIFF
--- a/src/rp2_common/pico_clib_interface/include/llvm_libc/time.h
+++ b/src/rp2_common/pico_clib_interface/include/llvm_libc/time.h
@@ -14,7 +14,7 @@
 
 __BEGIN_C_DECLS
 
-time_t mktime(struct tm* arg);
+time_t mktime(struct tm* arg) __NOEXCEPT;
 struct tm* localtime_r(const time_t* timer, struct tm* buf);
 
 __END_C_DECLS


### PR DESCRIPTION
Fixes:#1971