### PR TITLE
Add RP2350 specific values to the exception_number enum

### DIFF
--- a/src/rp2_common/hardware_exception/include/hardware/exception.h
+++ b/src/rp2_common/hardware_exception/include/hardware/exception.h
@@ -43,6 +43,11 @@ extern "C" {
  * ---------------------|-------|-----------------------
  * NMI_EXCEPTION        | 2     | Non Maskable Interrupt
  * HARDFAULT_EXCEPTION  | 3     | HardFault
+ * \if rp2350_specific
+ * MEMFAULT_EXCEPTION   | 4     | MemFault
+ * BUSFAULT_EXCEPTION   | 5     | BusFault
+ * USGFAULT_EXCEPTION   | 6     | UsageFault
+ * \endif
  * SVCALL_EXCEPTION     | 11    | SV Call
  * PENDSV_EXCEPTION     | 14    | Pend SV
  * SYSTICK_EXCEPTION    | 15    | System Tick
@@ -90,6 +95,11 @@ enum exception_number {
     MIN_EXCEPTION_NUM = 2,
     NMI_EXCEPTION = 2,        ///< Non Maskable Interrupt
     HARDFAULT_EXCEPTION = 3,  ///< HardFault Interrupt
+#if PICO_RP2350
+    MEMFAULT_EXCEPTION = 4,  ///< MemFault Interrupt
+    BUSFAULT_EXCEPTION = 5,  ///< BusFault Interrupt
+    USGFAULT_EXCEPTION = 6,  ///< UsageFault Interrupt
+#endif
     SVCALL_EXCEPTION = 11,    ///< SV Call Interrupt
     PENDSV_EXCEPTION = 14,    ///< Pend SV Interrupt
     SYSTICK_EXCEPTION = 15,   ///< System Tick Interrupt

--- a/src/rp2_common/hardware_exception/include/hardware/exception.h
+++ b/src/rp2_common/hardware_exception/include/hardware/exception.h
@@ -47,7 +47,6 @@ extern "C" {
  * MEMMANAGE_EXCEPTION   | 4     | MemManage
  * BUSFAULT_EXCEPTION    | 5     | BusFault
  * USAGEFAULT_EXCEPTION  | 6     | UsageFault
- * SECUREFAULT_EXCEPTION | 7     | SecureFault
  * \endif
  * SVCALL_EXCEPTION      | 11    | SV Call
  * PENDSV_EXCEPTION      | 14    | Pend SV
@@ -100,7 +99,6 @@ enum exception_number {
     MEMMANAGE_EXCEPTION = 4,   ///< MemManage Interrupt
     BUSFAULT_EXCEPTION = 5,    ///< BusFault Interrupt
     USAGEFAULT_EXCEPTION = 6,  ///< UsageFault Interrupt
-    SECUREFAULT_EXCEPTION = 7, ///< SecureFault Interrupt
 #endif
     SVCALL_EXCEPTION = 11,     ///< SV Call Interrupt
     PENDSV_EXCEPTION = 14,     ///< Pend SV Interrupt

--- a/src/rp2_common/hardware_exception/include/hardware/exception.h
+++ b/src/rp2_common/hardware_exception/include/hardware/exception.h
@@ -39,18 +39,18 @@ extern "C" {
  *
  * On Arm these are vector table indices:
  *
- * Name                 | Value | Exception
- * ---------------------|-------|-----------------------
- * NMI_EXCEPTION        | 2     | Non Maskable Interrupt
- * HARDFAULT_EXCEPTION  | 3     | HardFault
+ * Name                  | Value | Exception
+ * ----------------------|-------|-----------------------
+ * NMI_EXCEPTION         | 2     | Non Maskable Interrupt
+ * HARDFAULT_EXCEPTION   | 3     | HardFault
  * \if rp2350_specific
- * MEMMANAGE_EXCEPTION  | 4     | MemManage
- * BUSFAULT_EXCEPTION   | 5     | BusFault
- * USAGEFAULT_EXCEPTION | 6     | UsageFault
+ * MEMMANAGE_EXCEPTION   | 4     | MemManage
+ * BUSFAULT_EXCEPTION    | 5     | BusFault
+ * USAGEFAULT_EXCEPTION  | 6     | UsageFault
  * \endif
- * SVCALL_EXCEPTION     | 11    | SV Call
- * PENDSV_EXCEPTION     | 14    | Pend SV
- * SYSTICK_EXCEPTION    | 15    | System Tick
+ * SVCALL_EXCEPTION      | 11    | SV Call
+ * PENDSV_EXCEPTION      | 14    | Pend SV
+ * SYSTICK_EXCEPTION     | 15    | System Tick
  *
  * \if rp2350_specific
  * On RISC-V these are exception cause numbers:
@@ -93,16 +93,16 @@ enum exception_number {
 enum exception_number {
     // Assigned to VTOR indices
     MIN_EXCEPTION_NUM = 2,
-    NMI_EXCEPTION = 2,        ///< Non Maskable Interrupt
-    HARDFAULT_EXCEPTION = 3,  ///< HardFault Interrupt
+    NMI_EXCEPTION = 2,         ///< Non Maskable Interrupt
+    HARDFAULT_EXCEPTION = 3,   ///< HardFault Interrupt
 #if PICO_RP2350
-    MEMMANAGE_EXCEPTION = 4,  ///< MemManage Interrupt
-    BUSFAULT_EXCEPTION = 5,   ///< BusFault Interrupt
-    USAGEFAULT_EXCEPTION = 6, ///< UsageFault Interrupt
+    MEMMANAGE_EXCEPTION = 4,   ///< MemManage Interrupt
+    BUSFAULT_EXCEPTION = 5,    ///< BusFault Interrupt
+    USAGEFAULT_EXCEPTION = 6,  ///< UsageFault Interrupt
 #endif
-    SVCALL_EXCEPTION = 11,    ///< SV Call Interrupt
-    PENDSV_EXCEPTION = 14,    ///< Pend SV Interrupt
-    SYSTICK_EXCEPTION = 15,   ///< System Tick Interrupt
+    SVCALL_EXCEPTION = 11,     ///< SV Call Interrupt
+    PENDSV_EXCEPTION = 14,     ///< Pend SV Interrupt
+    SYSTICK_EXCEPTION = 15,    ///< System Tick Interrupt
     MAX_EXCEPTION_NUM = 15
 };
 #endif

--- a/src/rp2_common/hardware_exception/include/hardware/exception.h
+++ b/src/rp2_common/hardware_exception/include/hardware/exception.h
@@ -39,18 +39,19 @@ extern "C" {
  *
  * On Arm these are vector table indices:
  *
- * Name                 | Value | Exception
- * ---------------------|-------|-----------------------
- * NMI_EXCEPTION        | 2     | Non Maskable Interrupt
- * HARDFAULT_EXCEPTION  | 3     | HardFault
+ * Name                  | Value | Exception
+ * ----------------------|-------|-----------------------
+ * NMI_EXCEPTION         | 2     | Non Maskable Interrupt
+ * HARDFAULT_EXCEPTION   | 3     | HardFault
  * \if rp2350_specific
- * MEMFAULT_EXCEPTION   | 4     | MemFault
- * BUSFAULT_EXCEPTION   | 5     | BusFault
- * USGFAULT_EXCEPTION   | 6     | UsageFault
+ * MEMMANAGE_EXCEPTION   | 4     | MemManage
+ * BUSFAULT_EXCEPTION    | 5     | BusFault
+ * USAGEFAULT_EXCEPTION  | 6     | UsageFault
+ * SECUREFAULT_EXCEPTION | 7     | SecureFault
  * \endif
- * SVCALL_EXCEPTION     | 11    | SV Call
- * PENDSV_EXCEPTION     | 14    | Pend SV
- * SYSTICK_EXCEPTION    | 15    | System Tick
+ * SVCALL_EXCEPTION      | 11    | SV Call
+ * PENDSV_EXCEPTION      | 14    | Pend SV
+ * SYSTICK_EXCEPTION     | 15    | System Tick
  *
  * \if rp2350_specific
  * On RISC-V these are exception cause numbers:
@@ -93,16 +94,17 @@ enum exception_number {
 enum exception_number {
     // Assigned to VTOR indices
     MIN_EXCEPTION_NUM = 2,
-    NMI_EXCEPTION = 2,        ///< Non Maskable Interrupt
-    HARDFAULT_EXCEPTION = 3,  ///< HardFault Interrupt
+    NMI_EXCEPTION = 2,         ///< Non Maskable Interrupt
+    HARDFAULT_EXCEPTION = 3,   ///< HardFault Interrupt
 #if PICO_RP2350
-    MEMFAULT_EXCEPTION = 4,  ///< MemFault Interrupt
-    BUSFAULT_EXCEPTION = 5,  ///< BusFault Interrupt
-    USGFAULT_EXCEPTION = 6,  ///< UsageFault Interrupt
+    MEMMANAGE_EXCEPTION = 4,   ///< MemManage Interrupt
+    BUSFAULT_EXCEPTION = 5,    ///< BusFault Interrupt
+    USAGEFAULT_EXCEPTION = 6,  ///< UsageFault Interrupt
+    SECUREFAULT_EXCEPTION = 7, ///< SecureFault Interrupt
 #endif
-    SVCALL_EXCEPTION = 11,    ///< SV Call Interrupt
-    PENDSV_EXCEPTION = 14,    ///< Pend SV Interrupt
-    SYSTICK_EXCEPTION = 15,   ///< System Tick Interrupt
+    SVCALL_EXCEPTION = 11,     ///< SV Call Interrupt
+    PENDSV_EXCEPTION = 14,     ///< Pend SV Interrupt
+    SYSTICK_EXCEPTION = 15,    ///< System Tick Interrupt
     MAX_EXCEPTION_NUM = 15
 };
 #endif

--- a/src/rp2_common/hardware_exception/include/hardware/exception.h
+++ b/src/rp2_common/hardware_exception/include/hardware/exception.h
@@ -47,6 +47,7 @@ extern "C" {
  * MEMMANAGE_EXCEPTION   | 4     | MemManage
  * BUSFAULT_EXCEPTION    | 5     | BusFault
  * USAGEFAULT_EXCEPTION  | 6     | UsageFault
+ * SECUREFAULT_EXCEPTION | 7     | SecureFault
  * \endif
  * SVCALL_EXCEPTION      | 11    | SV Call
  * PENDSV_EXCEPTION      | 14    | Pend SV
@@ -99,6 +100,7 @@ enum exception_number {
     MEMMANAGE_EXCEPTION = 4,   ///< MemManage Interrupt
     BUSFAULT_EXCEPTION = 5,    ///< BusFault Interrupt
     USAGEFAULT_EXCEPTION = 6,  ///< UsageFault Interrupt
+    SECUREFAULT_EXCEPTION = 7, ///< SecureFault Interrupt
 #endif
     SVCALL_EXCEPTION = 11,     ///< SV Call Interrupt
     PENDSV_EXCEPTION = 14,     ///< Pend SV Interrupt

--- a/src/rp2_common/hardware_exception/include/hardware/exception.h
+++ b/src/rp2_common/hardware_exception/include/hardware/exception.h
@@ -39,18 +39,18 @@ extern "C" {
  *
  * On Arm these are vector table indices:
  *
- * Name                  | Value | Exception
- * ----------------------|-------|-----------------------
- * NMI_EXCEPTION         | 2     | Non Maskable Interrupt
- * HARDFAULT_EXCEPTION   | 3     | HardFault
+ * Name                 | Value | Exception
+ * ---------------------|-------|-----------------------
+ * NMI_EXCEPTION        | 2     | Non Maskable Interrupt
+ * HARDFAULT_EXCEPTION  | 3     | HardFault
  * \if rp2350_specific
- * MEMMANAGE_EXCEPTION   | 4     | MemManage
- * BUSFAULT_EXCEPTION    | 5     | BusFault
- * USAGEFAULT_EXCEPTION  | 6     | UsageFault
+ * MEMMANAGE_EXCEPTION  | 4     | MemManage
+ * BUSFAULT_EXCEPTION   | 5     | BusFault
+ * USAGEFAULT_EXCEPTION | 6     | UsageFault
  * \endif
- * SVCALL_EXCEPTION      | 11    | SV Call
- * PENDSV_EXCEPTION      | 14    | Pend SV
- * SYSTICK_EXCEPTION     | 15    | System Tick
+ * SVCALL_EXCEPTION     | 11    | SV Call
+ * PENDSV_EXCEPTION     | 14    | Pend SV
+ * SYSTICK_EXCEPTION    | 15    | System Tick
  *
  * \if rp2350_specific
  * On RISC-V these are exception cause numbers:
@@ -93,16 +93,16 @@ enum exception_number {
 enum exception_number {
     // Assigned to VTOR indices
     MIN_EXCEPTION_NUM = 2,
-    NMI_EXCEPTION = 2,         ///< Non Maskable Interrupt
-    HARDFAULT_EXCEPTION = 3,   ///< HardFault Interrupt
+    NMI_EXCEPTION = 2,        ///< Non Maskable Interrupt
+    HARDFAULT_EXCEPTION = 3,  ///< HardFault Interrupt
 #if PICO_RP2350
-    MEMMANAGE_EXCEPTION = 4,   ///< MemManage Interrupt
-    BUSFAULT_EXCEPTION = 5,    ///< BusFault Interrupt
-    USAGEFAULT_EXCEPTION = 6,  ///< UsageFault Interrupt
+    MEMMANAGE_EXCEPTION = 4,  ///< MemManage Interrupt
+    BUSFAULT_EXCEPTION = 5,   ///< BusFault Interrupt
+    USAGEFAULT_EXCEPTION = 6, ///< UsageFault Interrupt
 #endif
-    SVCALL_EXCEPTION = 11,     ///< SV Call Interrupt
-    PENDSV_EXCEPTION = 14,     ///< Pend SV Interrupt
-    SYSTICK_EXCEPTION = 15,    ///< System Tick Interrupt
+    SVCALL_EXCEPTION = 11,    ///< SV Call Interrupt
+    PENDSV_EXCEPTION = 14,    ///< Pend SV Interrupt
+    SYSTICK_EXCEPTION = 15,   ///< System Tick Interrupt
     MAX_EXCEPTION_NUM = 15
 };
 #endif


### PR DESCRIPTION
Adds vector table values for MemManage, BusFault and UsageFault which are supported on the Cortex-M33 but not the Cortex-M0+.

Fixes #1987 
