### PR TITLE
Fix GCC14.1 compile error in w25x10cls.S

### DIFF
--- a/src/rp2040/boot_stage2/boot2_w25x10cl.S
+++ b/src/rp2040/boot_stage2/boot2_w25x10cl.S
@@ -144,10 +144,10 @@ regular_func _stage2_boot
 // status register and checking for the "RX FIFO Not Empty" flag to assert.
 
     movs r1, #SSI_SR_RFNE_BITS
-00:
+1:
     ldr r0, [r3, #SSI_SR_OFFSET]    // Read status register
     tst r0, r1                      // RFNE status flag set?
-    beq 00b                         // If not then wait
+    beq 1b                         // If not then wait
 
 // At this point CN# will be deasserted and the SPI clock will not be running.
 // The Winbond WX25X10CL device will be in continuous read, dual I/O mode and


### PR DESCRIPTION
GCC14 doesn't like the 2-character temporary label "00" and throws an error
````
.../pico-sdk/src/rp2040/boot_stage2/boot2_w25x10cl.S: Assembler messages:
.../pico-sdk/src/rp2040/boot_stage2/boot2_w25x10cl.S:147: Error: junk at end of line, first unrecognized character is `0'
.../pico/rp2040/pico-sdk/src/rp2040/boot_stage2/boot2_w25x10cl.S:150: Error: garbage following instruction -- `beq 00b'
````

Convert it to a single number, "1", like in other boot2xxx.S files

Fixes #1999

(--edit-- formatting)