### PR TITLE
Fix typo in hardware/pio.h to correct the comment for pio2

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -115,9 +115,9 @@ typedef pio_hw_t *PIO;
 #define pio1 pio1_hw
 
 #if NUM_PIOS > 2
-/** Identifier for the second (PIO 1) hardware PIO instance (for use in PIO functions).
+/** Identifier for the third (PIO 2) hardware PIO instance (for use in PIO functions).
  *
- * e.g. pio_gpio_init(pio1, 5)
+ * e.g. pio_gpio_init(pio2, 5)
  *
  *  \ingroup hardware_pio
  */


### PR DESCRIPTION
The comment above the `pio2 pio2_hw` define in `src\rp2_common\hardware_pio\include\hardware\pio.h` is copy and pasted from the pio1 define above leading to the following confusing hover info:
![img](https://github.com/user-attachments/assets/1c80d0e4-52c4-4d81-a800-3b2e2438877b)
