### PR TITLE
boards/pimoroni_plasma2350.h: correct flash size.

### DIFF
--- a/src/boards/include/boards/pimoroni_plasma2350.h
+++ b/src/boards/include/boards/pimoroni_plasma2350.h
@@ -104,9 +104,9 @@
 #define PICO_FLASH_SPI_CLKDIV 2
 #endif
 
-// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (8 * 1024 * 1024)
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (4 * 1024 * 1024)
 #ifndef PICO_FLASH_SIZE_BYTES
-#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
 #endif
 
 #ifndef PICO_RP2350_A2_SUPPORTED


### PR DESCRIPTION
Correct flash size from 8MB to 4MB to avoid wrapped addresses causing firmware to be overwritten by the user filesystem in MicroPython.

I, uh, skipped the associated issue since this is my own silly mistake and doesn't bear any discussion 🤦 