### PR TITLE
Avoid hang in stdio_set_chars_available_callback

### DIFF
--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -172,6 +172,8 @@ static void on_uart_rx(void) {
 static void stdio_uart_set_chars_available_callback(void (*fn)(void*), void *param) {
     uint irq_num = UART_IRQ_NUM(uart_instance);
     if (fn && !chars_available_callback) {
+        chars_available_callback = fn;
+        chars_available_param = param;
         irq_set_exclusive_handler(irq_num, on_uart_rx);
         irq_set_enabled(irq_num, true);
         uart_set_irqs_enabled(uart_instance, true, false);
@@ -179,9 +181,9 @@ static void stdio_uart_set_chars_available_callback(void (*fn)(void*), void *par
         uart_set_irqs_enabled(uart_instance, false, false);
         irq_set_enabled(irq_num, false);
         irq_remove_handler(irq_num, on_uart_rx);
+        chars_available_callback = NULL;
+        chars_available_param = NULL;
     }
-    chars_available_callback = fn;
-    chars_available_param = param;
 }
 #endif
 


### PR DESCRIPTION
The function is setting the callback after enabing interrupts which can cause a hang if a receive character is already pending. Smilarly we also have to clear the callback pointer only after the interrupt is disabled.

Fixes #2009
