### PR TITLE
Add the required `SYS_CLK_HZ` definition to the suggested cmake output

### DIFF
--- a/src/rp2_common/hardware_clocks/scripts/vcocalc.py
+++ b/src/rp2_common/hardware_clocks/scripts/vcocalc.py
@@ -62,6 +62,7 @@ f"""target_compile_definitions({args.cmake_executable_name} PRIVATE
 	PLL_SYS_VCO_FREQ_HZ={int((args.input * 1_000_000) / best_refdiv * best_fbdiv)}
 	PLL_SYS_POSTDIV1={best_pd1}
 	PLL_SYS_POSTDIV2={best_pd2}
+	SYS_CLK_HZ={int((args.input * 1_000_000) / (best_refdiv * best_pd1 * best_pd2) * best_fbdiv)}
 )
 """
 	if not args.cmake_only:


### PR DESCRIPTION
Fixes #2014
