### PR TITLE
Clear i2c abort reason less often.

### DIFF
--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -298,7 +298,10 @@ static int i2c_read_blocking_internal(i2c_inst_t *i2c, uint8_t addr, uint8_t *ds
 
         do {
             abort_reason = i2c->hw->tx_abrt_source;
-            abort = (bool) i2c->hw->clr_tx_abrt;
+            if (i2c->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
+                abort = true;
+                i2c->hw->clr_tx_abrt;
+            }
             if (timeout_check) {
                 timeout = timeout_check(ts, false);
                 abort |= timeout;


### PR DESCRIPTION
It seems to be possible to get stuck in the loop which is checking for abort. It can take 100s of iterations before an abort happens and on each iteration we're clearing the abort interrupt even when it's not required. If we only clear the abort when needed the lockup doesn't seem to be reproducible.

Fixes #2025
