### PR TITLE
Fix dependency on files used by picotool

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -427,6 +427,7 @@ function(picotool_postprocess_binary TARGET)
     if (picotool_sign_output)
         list(APPEND picotool_args "--sign")
         get_target_property(picotool_sigfile ${TARGET} PICOTOOL_SIGFILE)
+        pico_add_link_depend(${TARGET} ${picotool_sigfile})
     endif()
 
     get_target_property(picotool_hash_output ${TARGET} PICOTOOL_HASH_OUTPUT)
@@ -442,10 +443,19 @@ function(picotool_postprocess_binary TARGET)
 
     # Embed PT properties
     get_target_property(picotool_embed_pt ${TARGET} PICOTOOL_EMBED_PT)
+    if (picotool_embed_pt)
+        pico_add_link_depend(${TARGET} ${picotool_embed_pt})
+    endif()
 
     # Encryption properties
     get_target_property(picotool_aesfile ${TARGET} PICOTOOL_AESFILE)
+    if (picotool_aesfile)
+        pico_add_link_depend(${TARGET} ${picotool_aesfile})
+    endif()
     get_target_property(picotool_enc_sigfile ${TARGET} PICOTOOL_ENC_SIGFILE)
+    if (picotool_enc_sigfile)
+        pico_add_link_depend(${TARGET} ${picotool_enc_sigfile})
+    endif()
 
     # Extra args
     get_target_property(extra_process_args ${TARGET} PICOTOOL_EXTRA_PROCESS_ARGS)


### PR DESCRIPTION
Add the key files and partition table JSON to the link dependencies, to ensure the postprocessing is run when any of them are updated. Link dependencies seem to be the simplest way, as the elf file needs re-linking anyway given it has been post-processed, so this shouldn't add any unnecessary extra processing.

Without this fix, if you modify a Partition Table JSON file or a private key, the ouptut binary will not be updated. With this fix it is updated correctly when those files are modified.