### PR TITLE
dont include glibc header sys/cdefs.h on musl

### DIFF
--- a/src/host/pico_platform/include/pico/platform.h
+++ b/src/host/pico_platform/include/pico/platform.h
@@ -11,7 +11,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#ifdef __unix__
+#if defined __unix__ && defined __GLIBC__
 
 #include <sys/cdefs.h>
 


### PR DESCRIPTION
remove the include of `sys/cdefs.h` in platform. I'm not sure if it needs replacement, 
bit it closes #2028