### PR TITLE
More CYW43 config tweaks

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -56,28 +56,32 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
             hardware_exception
             )
 
+    if (CYW43_PIN_WL_DYNAMIC)
+        # PICO_CMAKE_CONFIG: CYW43_PIN_WL_DYNAMIC, flag to indicate if cyw43 SPI pins can be changed at runtime, type=bool, group=pico_cyw43_driver
+        target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_PIN_WL_DYNAMIC=${CYW43_PIN_WL_DYNAMIC})
+    endif()
     if (CYW43_DEFAULT_PIN_WL_REG_ON)
-        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_REG_ON, gpio pin to power up the cyw43 chip, type=int, default=23, group=pico_cyw43_driver
+        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_REG_ON, gpio pin to power up the cyw43 chip, type=int, group=pico_cyw43_driver
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_DEFAULT_PIN_WL_REG_ON=${CYW43_DEFAULT_PIN_WL_REG_ON})
     endif()
     if (CYW43_DEFAULT_PIN_WL_DATA_OUT)
-        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_DATA_OUT, gpio pin for spi data out to the cyw43 chip, type=int, default=24, group=pico_cyw43_driver
+        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_DATA_OUT, gpio pin for spi data out to the cyw43 chip, type=int, group=pico_cyw43_driver
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_DEFAULT_PIN_WL_DATA_OUT=${CYW43_DEFAULT_PIN_WL_DATA_OUT})
     endif()
     if (CYW43_DEFAULT_PIN_WL_DATA_IN)
-        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_DATA_IN, gpio pin for spi data in from the cyw43 chip, type=int, default=24, group=pico_cyw43_driver
+        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_DATA_IN, gpio pin for spi data in from the cyw43 chip, type=int, group=pico_cyw43_driver
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_DEFAULT_PIN_WL_DATA_IN=${CYW43_DEFAULT_PIN_WL_DATA_IN})
     endif()
     if (CYW43_DEFAULT_PIN_WL_HOST_WAKE)
-        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_HOST_WAKE, gpio (irq) pin for the irq line from the cyw43 chip, type=int, default=24, group=pico_cyw43_driver
+        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_HOST_WAKE, gpio (irq) pin for the irq line from the cyw43 chip, type=int, group=pico_cyw43_driver
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_DEFAULT_PIN_WL_HOST_WAKE=${CYW43_DEFAULT_PIN_WL_HOST_WAKE})
     endif()
     if (CYW43_DEFAULT_PIN_WL_CLOCK)
-        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_HOST_WAKE, gpio pin for the spi clock line to the cyw43 chip, type=int, default=29, group=pico_cyw43_driver
+        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_CLOCK, gpio pin for the spi clock line to the cyw43 chip, type=int, group=pico_cyw43_driver
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_DEFAULT_PIN_WL_CLOCK=${CYW43_DEFAULT_PIN_WL_CLOCK})
     endif()
     if (CYW43_DEFAULT_PIN_WL_CS)
-        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_CS, gpio pin for the spi chip select to the cyw43 chip, type=int, default=25, group=pico_cyw43_driver
+        # PICO_CMAKE_CONFIG: CYW43_DEFAULT_PIN_WL_CS, gpio pin for the spi chip select to the cyw43 chip, type=int, group=pico_cyw43_driver
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_DEFAULT_PIN_WL_CS=${CYW43_DEFAULT_PIN_WL_CS})
     endif()
     if (CYW43_PIO_CLOCK_DIV_INT)
@@ -89,7 +93,7 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_PIO_CLOCK_DIV_FRAC8=${CYW43_PIO_CLOCK_DIV_FRAC8})
     endif()
     if (CYW43_PIO_CLOCK_DIV_DYNAMIC)
-        # PICO_CMAKE_CONFIG: CYW43_PIO_CLOCK_DIV_DYNAMIC, flag used to enable dynamic pio clock divider API, type=bool, default=false, group=pico_cyw43_driver
+        # PICO_CMAKE_CONFIG: CYW43_PIO_CLOCK_DIV_DYNAMIC, flag used to enable dynamic pio clock divider API, type=bool, default=0, group=pico_cyw43_driver
         target_compile_definitions(cyw43_driver_picow INTERFACE CYW43_PIO_CLOCK_DIV_DYNAMIC=${CYW43_PIO_CLOCK_DIV_DYNAMIC})
     endif()
 

--- a/src/rp2_common/pico_cyw43_driver/include/pico/cyw43_driver.h
+++ b/src/rp2_common/pico_cyw43_driver/include/pico/cyw43_driver.h
@@ -79,7 +79,7 @@ void cyw43_driver_deinit(struct async_context *context);
 
 // PICO_CONFIG: CYW43_DEFAULT_PIN_WL_CLOCK, gpio pin for the spi clock line to the cyw43 chip, type=int, advanced=true, group=pico_cyw43_driver
 
-// PICO_CONFIG: CYW43_DEFAULT_PIN_WL_CS, gpio pin for the spi chip select to the cyw43 chip, type=int, dvanced=true, group=pico_cyw43_driver
+// PICO_CONFIG: CYW43_DEFAULT_PIN_WL_CS, gpio pin for the spi chip select to the cyw43 chip, type=int, advanced=true, group=pico_cyw43_driver
 
 #if CYW43_PIO_CLOCK_DIV_DYNAMIC
 /*! \brief Set the clock divisor for the cyw43 pio clock

--- a/tools/extract_build_defines.py
+++ b/tools/extract_build_defines.py
@@ -39,6 +39,8 @@ BASE_BUILD_DEFINE_RE = re.compile(r'\b{}\b'.format(BASE_BUILD_DEFINE_NAME))
 
 BUILD_DEFINE_RE = re.compile(r'#\s+{}:\s+(\w+),\s+([^,]+)(?:,\s+(.*))?$'.format(BASE_BUILD_DEFINE_NAME))
 
+ALLOWED_CONFIG_PROPERTIES = set(['type', 'default', 'min', 'max', 'group'])
+
 CHIP_NAMES = ["rp2040", "rp2350"]
 
 chips_all_configs = defaultdict(dict)
@@ -47,10 +49,14 @@ chips_all_descriptions = defaultdict(dict)
 
 
 
-def ValidateAttrs(config_attrs, file_path, linenum):
+def ValidateAttrs(config_name, config_attrs, file_path, linenum):
     _type = config_attrs.get('type')
 
     # Validate attrs
+    for key in config_attrs.keys():
+        if key not in ALLOWED_CONFIG_PROPERTIES:
+            raise Exception('{} at {}:{} has unexpected property "{}"'.format(config_name, file_path, linenum, key))
+
     if _type == 'int':
         _min = _max = _default = None
         if config_attrs.get('min', None) is not None:
@@ -184,7 +190,7 @@ for applicable, all_configs in chips_all_configs.items():
         file_path = os.path.join(scandir, config_obj['filename'])
         linenum = config_obj['line_number']
 
-        ValidateAttrs(config_obj['attrs'], file_path, linenum)
+        ValidateAttrs(config_name, config_obj['attrs'], file_path, linenum)
 
 # All settings in "host" should also be in "all"
 for config_name, config_obj in chips_all_configs["host"].items():

--- a/tools/extract_cmake_configs.py
+++ b/tools/extract_cmake_configs.py
@@ -39,6 +39,8 @@ BASE_BUILD_DEFINE_RE = re.compile(r'\b{}\b'.format(BASE_BUILD_DEFINE_NAME))
 
 CMAKE_CONFIG_RE = re.compile(r'#\s+{}:\s+(\w+),\s+([^,]+)(?:,\s+(.*))?$'.format(BASE_CMAKE_CONFIG_NAME))
 
+ALLOWED_CONFIG_PROPERTIES = set(['type', 'default', 'min', 'max', 'group', 'advanced', 'docref'])
+
 CHIP_NAMES = ["rp2040", "rp2350"]
 
 chips_all_configs = defaultdict(dict)
@@ -47,10 +49,14 @@ chips_all_descriptions = defaultdict(dict)
 
 
 
-def ValidateAttrs(config_attrs, file_path, linenum):
+def ValidateAttrs(config_name, config_attrs, file_path, linenum):
     _type = config_attrs.get('type')
 
     # Validate attrs
+    for key in config_attrs.keys():
+        if key not in ALLOWED_CONFIG_PROPERTIES:
+            raise Exception('{} at {}:{} has unexpected property "{}"'.format(config_name, file_path, linenum, key))
+
     if _type == 'int':
         _min = _max = _default = None
         if config_attrs.get('min', None) is not None:
@@ -93,7 +99,7 @@ def ValidateAttrs(config_attrs, file_path, linenum):
         _default = config_attrs.get('default', None)
         if _default is not None:
             if '/' not in _default:
-                if (_default.lower() != '0') and (config_attrs['default'].lower() != '1') and ( _default not in all_configs):
+                if (_default.lower() != '0') and (config_attrs['default'].lower() != '1') and (_default not in all_configs):
                     logger.info('{} at {}:{} has non-integer default value "{}"'.format(config_name, file_path, linenum, config_attrs['default']))
 
     elif _type == 'string':
@@ -184,7 +190,7 @@ for applicable, all_configs in chips_all_configs.items():
         file_path = os.path.join(scandir, config_obj['filename'])
         linenum = config_obj['line_number']
 
-        ValidateAttrs(config_obj['attrs'], file_path, linenum)
+        ValidateAttrs(config_name, config_obj['attrs'], file_path, linenum)
 
 # All settings in "host" should also be in "all"
 for config_name, config_obj in chips_all_configs["host"].items():

--- a/tools/extract_configs.py
+++ b/tools/extract_configs.py
@@ -40,6 +40,8 @@ BASE_BUILD_DEFINE_RE = re.compile(r'\b{}\b'.format(BASE_BUILD_DEFINE_NAME))
 CONFIG_RE = re.compile(r'//\s+{}:\s+(\w+),\s+([^,]+)(?:,\s+(.*))?$'.format(BASE_CONFIG_NAME))
 DEFINE_RE = re.compile(r'#define\s+(\w+)\s+(.+?)(\s*///.*)?$')
 
+ALLOWED_CONFIG_PROPERTIES = set(['type', 'default', 'min', 'max', 'enumvalues', 'group', 'advanced', 'depends'])
+
 CHIP_NAMES = ["rp2040", "rp2350"]
 
 chips_all_configs = defaultdict(dict)
@@ -49,10 +51,14 @@ chips_all_defines = defaultdict(dict)
 
 
 
-def ValidateAttrs(config_attrs, file_path, linenum):
+def ValidateAttrs(config_name, config_attrs, file_path, linenum):
     _type = config_attrs.get('type', 'int')
 
     # Validate attrs
+    for key in config_attrs.keys():
+        if key not in ALLOWED_CONFIG_PROPERTIES:
+            raise Exception('{} at {}:{} has unexpected property "{}"'.format(config_name, file_path, linenum, key))
+
     if _type == 'int':
         assert 'enumvalues' not in config_attrs
         _min = _max = _default = None
@@ -229,7 +235,7 @@ for applicable, all_configs in chips_all_configs.items():
         file_path = os.path.join(scandir, config_obj['filename'])
         linenum = config_obj['line_number']
 
-        ValidateAttrs(config_obj['attrs'], file_path, linenum)
+        ValidateAttrs(config_name, config_obj['attrs'], file_path, linenum)
 
         # Check that default values match up
         if 'default' in config_obj['attrs']:


### PR DESCRIPTION
 - Re-synchronise the PICO_CMAKE_CONFIG: entries with the corresponding PICO_CONFIG: entries
 - Fix a silly typo I made in #2002
 - Enhance config-extraction scripts to catch similar typos in future

This is a follow-up to the previous #2002 (I spotted the typo, and ended up "fixing" a few other things in the process of fixing that!).