### PR TITLE
Remove repeated source file from pico_btstack

### DIFF
--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -157,7 +157,6 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
 
     pico_add_library(pico_btstack_mesh)
     target_sources(pico_btstack_mesh INTERFACE
-        ${PICO_BTSTACK_PATH}/src/mesh/mesh.c
         ${PICO_BTSTACK_PATH}/src/mesh/adv_bearer.c
         ${PICO_BTSTACK_PATH}/src/mesh/beacon.c
         ${PICO_BTSTACK_PATH}/src/mesh/gatt_bearer.c


### PR DESCRIPTION
Removes a duplicate reference to btstack's `src/mesh/mesh.c` file in the CMake build.