### PR TITLE
Remove ARM assembly from RISC-V CYW43 SPI PIO

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -80,7 +80,15 @@ static uint32_t counter = 0;
 
 //#define SWAP32(A) ((((A) & 0xff000000U) >> 8) | (((A) & 0xff0000U) << 8) | (((A) & 0xff00U) >> 8) | (((A) & 0xffU) << 8))
 __force_inline static uint32_t __swap16x2(uint32_t a) {
+#ifndef __riscv
     pico_default_asm ("rev16 %0, %0" : "+l" (a) : : );
+#else
+    uint32_t tmp;
+    pico_default_asm (
+        "rev8 %1, %0\n"
+        "rori %0, %1, 16\n"
+        : "+l" (a), "=l" (tmp));
+#endif
     return a;
 }
 #define SWAP32(a) __swap16x2(a)


### PR DESCRIPTION
Replace the ARM assembly for dual 16b swap with generic GCC builtin macros to allow building CYW43 SPI PIO driver for RISC-V

Fixes #2044