### PR TITLE
Remove CMake from choco_packages.config

### DIFF
--- a/.github/workflows/choco_packages.config
+++ b/.github/workflows/choco_packages.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="gcc-arm-embedded" version="10.2.1" />
-  <package id="cmake" version="3.25.2" installArguments="ADD_CMAKE_TO_PATH=System" />
   <package id="mingw" version="12.2.0" />
   <package id="ninja" version="1.11.1" />
 </packages>


### PR DESCRIPTION
This will hopefully fix the Windows GitHub CI as https://github.com/actions/runner-images/blob/win22/20241113.3/images/windows/Windows2022-Readme.md#tools says that CMake is already installed by default.

GitHub CI for pico-sdk was failing on Windows with:
```
A newer version of cmake.install (v3.31.0) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
Failed to install cmake because a previous dependency failed.
```