### PR TITLE
use configured uart_instance rather than default instance for flushing STDIO uart

### DIFF
--- a/src/rp2_common/pico_stdio_uart/stdio_uart.c
+++ b/src/rp2_common/pico_stdio_uart/stdio_uart.c
@@ -188,7 +188,7 @@ static void stdio_uart_set_chars_available_callback(void (*fn)(void*), void *par
 #endif
 
 static void stdio_uart_out_flush(void) {
-    uart_default_tx_wait_blocking();
+    uart_tx_wait_blocking(uart_instance);
 }
 
 stdio_driver_t stdio_uart = {


### PR DESCRIPTION
fixes #1936 