### PR TITLE
Add some missing pio functions

### DIFF
--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -205,13 +205,22 @@ void pio_clear_instruction_memory(PIO pio) {
     hw_claim_unlock(save);
 }
 
+void pio_sm_set_pins(PIO pio, uint sm, uint32_t pins) {
+    pio_sm_set_pins64(pio, sm, pins);
+}
+
 // Set the value of all PIO pins. This is done by forcibly executing
 // instructions on a "victim" state machine, sm. Ideally you should choose one
 // which is not currently running a program. This is intended for one-time
 // setup of initial pin states.
-void pio_sm_set_pins(PIO pio, uint sm, uint32_t pins) {
+void pio_sm_set_pins64(PIO pio, uint sm, uint64_t pins) {
     check_pio_param(pio);
     check_sm_param(sm);
+    check_pio_pin_mask64(pio, pins);
+
+#if PICO_PIO_USE_GPIO_BASE
+    pins >>= pio_get_gpio_base(pio);
+#endif
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
     uint32_t execctrl_saved = pio->sm[sm].execctrl;
     hw_clear_bits(&pio->sm[sm].execctrl, 1u << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
@@ -232,8 +241,17 @@ void pio_sm_set_pins(PIO pio, uint sm, uint32_t pins) {
 }
 
 void pio_sm_set_pins_with_mask(PIO pio, uint sm, uint32_t pinvals, uint32_t pin_mask) {
+    pio_sm_set_pins_with_mask64(pio, sm, pinvals, pin_mask);
+}
+
+void pio_sm_set_pins_with_mask64(PIO pio, uint sm, uint64_t pinvals, uint64_t pin_mask) {
     check_pio_param(pio);
     check_sm_param(sm);
+    check_pio_pin_mask64(pio, pin_mask);
+#if PICO_PIO_USE_GPIO_BASE
+    pinvals >>= pio_get_gpio_base(pio);
+    pin_mask >>= pio_get_gpio_base(pio);
+#endif
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
     uint32_t execctrl_saved = pio->sm[sm].execctrl;
     hw_clear_bits(&pio->sm[sm].execctrl, 1u << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);
@@ -250,8 +268,17 @@ void pio_sm_set_pins_with_mask(PIO pio, uint sm, uint32_t pinvals, uint32_t pin_
 }
 
 void pio_sm_set_pindirs_with_mask(PIO pio, uint sm, uint32_t pindirs, uint32_t pin_mask) {
+    pio_sm_set_pindirs_with_mask64(pio, sm, pindirs, pin_mask);
+}
+
+void pio_sm_set_pindirs_with_mask64(PIO pio, uint sm, uint64_t pindirs, uint64_t pin_mask) {
     check_pio_param(pio);
     check_sm_param(sm);
+    check_pio_pin_mask64(pio, pin_mask);
+#if PICO_PIO_USE_GPIO_BASE
+    pindirs >>= pio_get_gpio_base(pio);
+    pin_mask >>= pio_get_gpio_base(pio);
+#endif
     uint32_t pinctrl_saved = pio->sm[sm].pinctrl;
     uint32_t execctrl_saved = pio->sm[sm].execctrl;
     hw_clear_bits(&pio->sm[sm].execctrl, 1u << PIO_SM0_EXECCTRL_OUT_STICKY_LSB);

--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -250,9 +250,7 @@ int cyw43_spi_transfer(cyw43_int_t *self, const uint8_t *tx, size_t tx_length, u
         pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, false);
         pio_sm_set_wrap(bus_data->pio, bus_data->pio_sm, bus_data->pio_offset, bus_data->pio_offset + SPI_OFFSET_END - 1);
         pio_sm_clear_fifos(bus_data->pio, bus_data->pio_sm);
-        pio_sm_set_pindirs_with_mask(bus_data->pio, bus_data->pio_sm,
-            1u << (CYW43_PIN_WL_DATA_OUT - pio_get_gpio_base(bus_data->pio)),
-            1u << (CYW43_PIN_WL_DATA_OUT - pio_get_gpio_base(bus_data->pio)));
+        pio_sm_set_pindirs_with_mask64(bus_data->pio, bus_data->pio_sm, 1ull << CYW43_PIN_WL_DATA_OUT, 1ull << CYW43_PIN_WL_DATA_OUT);
         pio_sm_restart(bus_data->pio, bus_data->pio_sm);
         pio_sm_clkdiv_restart(bus_data->pio, bus_data->pio_sm);
         pio_sm_put(bus_data->pio, bus_data->pio_sm, tx_length * 8 - 1);
@@ -294,9 +292,7 @@ int cyw43_spi_transfer(cyw43_int_t *self, const uint8_t *tx, size_t tx_length, u
         pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, false);
         pio_sm_set_wrap(bus_data->pio, bus_data->pio_sm, bus_data->pio_offset, bus_data->pio_offset + SPI_OFFSET_LP1_END - 1);
         pio_sm_clear_fifos(bus_data->pio, bus_data->pio_sm);
-        pio_sm_set_pindirs_with_mask(bus_data->pio, bus_data->pio_sm,
-            1u << (CYW43_PIN_WL_DATA_OUT - pio_get_gpio_base(bus_data->pio)),
-            1u << (CYW43_PIN_WL_DATA_OUT - pio_get_gpio_base(bus_data->pio)));
+        pio_sm_set_pindirs_with_mask64(bus_data->pio, bus_data->pio_sm, 1ull << CYW43_PIN_WL_DATA_OUT, 1ull << CYW43_PIN_WL_DATA_OUT);
         pio_sm_restart(bus_data->pio, bus_data->pio_sm);
         pio_sm_clkdiv_restart(bus_data->pio, bus_data->pio_sm);
         pio_sm_put(bus_data->pio, bus_data->pio_sm, tx_length * 8 - 1);


### PR DESCRIPTION
Adds some 64 versions to work with rp2350b and more than 32 pins. Change cyw43 code to use the new function.

Fixes #1834

