### PR TITLE
provide slightly meaningless _start symbol for boot_stage2 to make LLVM ld happy

### DIFF
--- a/src/rp2040/boot_stage2/boot_stage2.ld
+++ b/src/rp2040/boot_stage2/boot_stage2.ld
@@ -7,6 +7,7 @@ MEMORY {
 SECTIONS {
     . = ORIGIN(SRAM);
     .text : {
+        _start = .; /* make LLVM happy */
         *(.entry)
         *(.text)
     } >SRAM

--- a/src/rp2350/boot_stage2/boot_stage2.ld
+++ b/src/rp2350/boot_stage2/boot_stage2.ld
@@ -7,6 +7,7 @@ MEMORY {
 SECTIONS {
     . = ORIGIN(SRAM);
     .text : {
+        _start = .; /* make LLVM happy */
         *(.entry)
         *(.text)
     } >SRAM


### PR DESCRIPTION
fixes #1813 