### PR TITLE
add rom_reset_usb_boot_extra which supports >32 pins and ACTIVE_LOW

### DIFF
--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -238,6 +238,25 @@ static inline void __attribute__((noreturn)) reset_usb_boot(uint32_t usb_activit
 }
 
 /*!
+ * \brief Reboot the device into BOOTSEL mode
+ * \ingroup pico_bootrom
+ *
+ * This function reboots the device into the BOOTSEL mode ('usb boot").
+ *
+ * Facilities are provided to enable an "activity light" via GPIO attached LED for the USB Mass Storage Device,
+ * and to limit the USB interfaces exposed.
+ *
+ * \param usb_activity_gpio_pin  GPIO pin to be used as an activitiy pin, or -1 for none
+ *                               from the host.
+ * \param disable_interface_mask value to control exposed interfaces
+ *  - 0 To enable both interfaces (as per a cold boot)
+ *  - 1 To disable the USB Mass Storage Interface
+ *  - 2 To disable the USB PICOBOOT Interface
+ * \param usb_activity_gpio_pin_active_low Activity GPIO is active low (ignored on RP2040)
+ */
+void __attribute__((noreturn)) rom_reset_usb_boot_extra(int usb_activity_gpio_pin, uint32_t disable_interface_mask, bool usb_activity_gpio_pin_active_low);
+
+/*!
  * \brief Connect the SSI/QMI to the QSPI pads
  * \ingroup pico_bootrom
  * 

--- a/src/rp2_common/pico_bootsel_via_double_reset/pico_bootsel_via_double_reset.c
+++ b/src/rp2_common/pico_bootsel_via_double_reset/pico_bootsel_via_double_reset.c
@@ -24,6 +24,11 @@
 
 // PICO_CONFIG: PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via reset double tap, type=int, min=0, max=47 on RP2350B, 29 otherwise, group=pico_bootsel_via_double_reset
 
+// PICO_CONFIG: PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED_ACTIVE_LOW, Whether pin used as bootloader activity LED when BOOTSEL mode is entered via reset double tap is active low. Not supported on RP2040, type=bool, default=0, group=pico_bootsel_via_double_reset
+#ifndef PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED_ACTIVE_LOW
+#define PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED_ACTIVE_LOW 0
+#endif
+
 // PICO_CONFIG: PICO_BOOTSEL_VIA_DOUBLE_RESET_INTERFACE_DISABLE_MASK, Optionally disable either the mass storage interface (bit 0) or the PICOBOOT interface (bit 1) when entering BOOTSEL mode via double reset, type=int, min=0, max=3, default=0, group=pico_bootsel_via_double_reset
 #ifndef PICO_BOOTSEL_VIA_DOUBLE_RESET_INTERFACE_DISABLE_MASK
 #define PICO_BOOTSEL_VIA_DOUBLE_RESET_INTERFACE_DISABLE_MASK 0u
@@ -127,13 +132,14 @@ static void __attribute__((constructor)) boot_double_tap_check(void) {
     // Detected a double reset, so enter USB bootloader
     clear_double_tap_flag();
 #ifdef PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED
-    const uint32_t led_mask = 1u << PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED;
+    const int led = PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED;
 #else
-    const uint32_t led_mask = 0u;
+    const int led = -1;
 #endif
-    reset_usb_boot(
-        led_mask,
-        PICO_BOOTSEL_VIA_DOUBLE_RESET_INTERFACE_DISABLE_MASK
+    rom_reset_usb_boot_extra(
+        led,
+        PICO_BOOTSEL_VIA_DOUBLE_RESET_INTERFACE_DISABLE_MASK,
+        PICO_BOOTSEL_VIA_DOUBLE_RESET_ACTIVITY_LED_ACTIVE_LOW
     );
 }
 

--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
@@ -73,6 +73,11 @@
 
 // PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=47 on RP2350B, 29 otherwise, group=pico_stdio_usb
 
+// PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED_ACTIVE_LOW, Whether pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE) is active low, type=bool, default=0, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED_ACTIVE_LOW
+#define PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED_ACTIVE_LOW 0
+#endif
+
 // PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED, Whether the pin specified by PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED is fixed or can be modified by picotool over the VENDOR USB interface, type=bool, default=0, group=pico_stdio_usb
 #ifndef PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
 #define PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED 0


### PR DESCRIPTION
I noticed this in passing - this change also adds relevant PICO_CONFIG to specify the ACTIVE_LOW default (note if the ACTIVITY_LED is not specified, the OTP defaults will be used on RP2350)
