### PR TITLE
Fix CMake build for hardware_watchdog

### DIFF
--- a/src/rp2_common/hardware_watchdog/CMakeLists.txt
+++ b/src/rp2_common/hardware_watchdog/CMakeLists.txt
@@ -1,3 +1,3 @@
 pico_simple_hardware_target(watchdog)
 
-pico_mirrored_target_link_libraries(hardware_watchdog INTERFACE hardware_ticks)
+pico_mirrored_target_link_libraries(hardware_watchdog INTERFACE hardware_ticks pico_bootrom)


### PR DESCRIPTION
hardware_watchdog depends from pico_bootrom due to header "pico/bootrom.h".

BUILD.bazel also has this dependency.
