### PR TITLE
Fix: solve the problem that micropython could not be used

### DIFF
--- a/src/boards/include/boards/seeed_xiao_rp2350.h
+++ b/src/boards/include/boards/seeed_xiao_rp2350.h
@@ -134,7 +134,7 @@
 #define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
 
 #ifndef PICO_FLASH_SPI_CLKDIV
-#define PICO_FLASH_SPI_CLKDIV 2
+#define PICO_FLASH_SPI_CLKDIV 4
 #endif
 
 // pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (4 * 1024 * 1024)


### PR DESCRIPTION
Solved the problem that micropython could not be used normally in XIAO RP2350