### PR TITLE
Fix mis-matched backticks in doxygen

### DIFF
--- a/src/common/README.md
+++ b/src/common/README.md
@@ -1,3 +1,3 @@
 This directory code that is common to all builds regardless of `PICO_PLATFORM`. It is a mix
 of common header files, or high level functionality built entirely using `hardware_` or `pico_` libraries provided
-by the actual target `PICO_PLATFORM`` 
+by the actual target `PICO_PLATFORM`

--- a/src/rp2_common/pico_standard_binary_info/doc.h
+++ b/src/rp2_common/pico_standard_binary_info/doc.h
@@ -9,11 +9,11 @@
  * * The program name if defined (unless `PICO_NO_BINARY_SIZE=1`). The value is `PICO_PROGRAM_NAME` or `PICO_TARGET_NAME` if the former isn't defined
  * * The value of PICO_BOARD (unless `PICO_NO_BI_PICO_BOARD=1`)
  * * The SDK version (unless `PICO_NO_BI_SDK_VERSION=1`)
- * * The program version string if defined (unless `PICO_NO_BI_PROGRAM_VERSION_STRING=1`). The value is `PICO_PROGRAM_VERSION_STRING``
+ * * The program version string if defined (unless `PICO_NO_BI_PROGRAM_VERSION_STRING=1`). The value is `PICO_PROGRAM_VERSION_STRING`
  * * The program description if defined (unless `PICO_NO_BI_PROGRAM_DESCRIPTION=1`). The value is `PICO_PROGRAM_DESCRIPTION`
  * * The program url if defined (unless `PICO_NO_BI_PROGRAM_URL=1`). The value is `PICO_PROGRAM_URL`
  * * The boot stage 2 used if any (unless `PICO_NO_BI_BOOT_STAGE2_NAME=1`). The value is `PICO_BOOT_STAGE2_NAME`
- * * The program build date (unless `PICO_NO_BI_PROGRAM_BUILD_DATE=1). The value defaults to the C preprocessor value `__DATE__`, but can be overridden with `PICO_PROGRAM_BUILD_DATE`. Note you should do a clean build if you want to be sure this value is up to date.
+ * * The program build date (unless `PICO_NO_BI_PROGRAM_BUILD_DATE=1`). The value defaults to the C preprocessor value `__DATE__`, but can be overridden with `PICO_PROGRAM_BUILD_DATE`. Note you should do a clean build if you want to be sure this value is up to date.
  * * The program build type (unless `PICO_NO_BI_BUILD_TYPE=1`). The value is `PICO_CMAKE_BUILD_TYPE` which comes from the CMake build - e.g. Release, Debug, RelMinSize
  * * The binary size (unless `PICO_NO_BI_BINARY_SIZE=1`)
  */


### PR DESCRIPTION
This fixes formatting errors in the [C SDK PDF](https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf):
![Screenshot from 2024-11-27 10-50-31](https://github.com/user-attachments/assets/01066a49-320c-4246-8414-2732e877ce93)

and the [HTML-formatted docs](https://www.raspberrypi.com/documentation/pico-sdk/runtime.html#pico_standard_binary_info):
![Screenshot from 2024-11-27 10-52-18](https://github.com/user-attachments/assets/90ce10bf-cbfd-4730-9946-f16f9962375a)

@nathan-contino I'll leave it up to you to decide if you want to cherry-pick this commit onto the `doxyfix` branch or not.