### PR TITLE
Release the lock in mbedtls_sha256_free if it was not released already

### DIFF
--- a/src/rp2_common/pico_mbedtls/pico_mbedtls.c
+++ b/src/rp2_common/pico_mbedtls/pico_mbedtls.c
@@ -36,6 +36,9 @@ void mbedtls_sha256_init(__unused mbedtls_sha256_context *ctx) {
 }
 
 void mbedtls_sha256_free(__unused mbedtls_sha256_context *ctx) {
+    if (ctx->locked) {
+        pico_sha256_unlock(ctx);
+    }
 }
 
 int mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224) {

--- a/src/rp2_common/pico_mbedtls/pico_mbedtls.c
+++ b/src/rp2_common/pico_mbedtls/pico_mbedtls.c
@@ -36,9 +36,7 @@ void mbedtls_sha256_init(__unused mbedtls_sha256_context *ctx) {
 }
 
 void mbedtls_sha256_free(__unused mbedtls_sha256_context *ctx) {
-    if (ctx->locked) {
-        pico_sha256_unlock(ctx);
-    }
+    pico_sha256_cleanup(ctx);
 }
 
 int mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224) {

--- a/src/rp2_common/pico_sha256/include/pico/sha256.h
+++ b/src/rp2_common/pico_sha256/include/pico/sha256.h
@@ -58,15 +58,15 @@ typedef struct pico_sha256_state {
     size_t total_data_size;
 } pico_sha256_state_t;
 
-/*! \brief Release the internal lock on the SHA256 hardware
+/*! \brief Release the internal lock on the SHA-256 hardware
  *  \ingroup pico_sha256
  *
- * Release the internal lock on the hardware.
+ * Release the internal lock on the SHA-256 hardware.
  * Fails if the internal lock was not claimed.
  *
  * @param state A pointer to a pico_sha256_state_t instance
  */
-void __weak pico_sha256_unlock(pico_sha256_state_t *state);
+void pico_sha256_cleanup(pico_sha256_state_t *state);
 
 /*! \brief Start a SHA-256 calculation returning immediately with an error if the SHA-256 hardware is not available
  *  \ingroup pico_sha256

--- a/src/rp2_common/pico_sha256/include/pico/sha256.h
+++ b/src/rp2_common/pico_sha256/include/pico/sha256.h
@@ -58,6 +58,16 @@ typedef struct pico_sha256_state {
     size_t total_data_size;
 } pico_sha256_state_t;
 
+/*! \brief Release the internal lock on the SHA256 hardware
+ *  \ingroup pico_sha256
+ *
+ * Release the internal lock on the hardware.
+ * Fails if the internal lock was not claimed.
+ *
+ * @param state A pointer to a pico_sha256_state_t instance
+ */
+void __weak pico_sha256_unlock(pico_sha256_state_t *state);
+
 /*! \brief Start a SHA-256 calculation returning immediately with an error if the SHA-256 hardware is not available
  *  \ingroup pico_sha256
  *

--- a/src/rp2_common/pico_sha256/include/pico/sha256.h
+++ b/src/rp2_common/pico_sha256/include/pico/sha256.h
@@ -62,7 +62,7 @@ typedef struct pico_sha256_state {
  *  \ingroup pico_sha256
  *
  * Release the internal lock on the SHA-256 hardware.
- * Fails if the internal lock was not claimed.
+ * Does nothing if the internal lock was not claimed.
  *
  * @param state A pointer to a pico_sha256_state_t instance
  */

--- a/src/rp2_common/pico_sha256/sha256.c
+++ b/src/rp2_common/pico_sha256/sha256.c
@@ -30,6 +30,12 @@ void __weak pico_sha256_unlock(pico_sha256_state_t *state) {
     state->locked = false;
 }
 
+void pico_sha256_cleanup(pico_sha256_state_t *state) {
+    if (state->locked) {
+        pico_sha256_unlock(state);
+    }
+}
+
 int pico_sha256_try_start(pico_sha256_state_t *state, enum sha256_endianness endianness, bool use_dma) {
     memset(state, 0, sizeof(*state));
     if (!pico_sha256_lock(state)) return PICO_ERROR_RESOURCE_IN_USE;


### PR DESCRIPTION
Release the lock in `mbedtls_sha256_free` if it was not released already. Requires making `pico_sha256_unlock` include-able. Fixes #2103.