### PR TITLE
Initialise stack in async_context_execute_sync call

### DIFF
--- a/src/rp2_common/pico_async_context/async_context_freertos.c
+++ b/src/rp2_common/pico_async_context/async_context_freertos.c
@@ -193,7 +193,7 @@ static void handle_sync_func_call(async_context_t *context, async_when_pending_w
 uint32_t async_context_freertos_execute_sync(async_context_t *self_base, uint32_t (*func)(void *param), void *param) {
     async_context_freertos_t *self = (async_context_freertos_t*)self_base;
     hard_assert(xSemaphoreGetMutexHolder(self->lock_mutex) != xTaskGetCurrentTaskHandle());
-    sync_func_call_t call;
+    sync_func_call_t call = {0};
     call.worker.do_work = handle_sync_func_call;
     call.func = func;
     call.param = param;

--- a/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
+++ b/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
@@ -140,7 +140,7 @@ uint32_t async_context_threadsafe_background_execute_sync(async_context_t *self_
 #if ASYNC_CONTEXT_THREADSAFE_BACKGROUND_MULTI_CORE
     if (self_base->core_num != get_core_num()) {
         hard_assert(!recursive_mutex_enter_count(&self->lock_mutex));
-        sync_func_call_t call;
+        sync_func_call_t call = {0};
         call.worker.do_work = handle_sync_func_call;
         call.func = func;
         call.param = param;


### PR DESCRIPTION
We need to do this to avoid work_pending being set twice.

Fixes #2101
