### PR TITLE
Add `PRESERVE8` directive

### DIFF
--- a/src/rp2_common/hardware_irq/irq_handler_chain.S
+++ b/src/rp2_common/hardware_irq/irq_handler_chain.S
@@ -62,6 +62,7 @@ irq_handler_chain_slots:
     .set next_slot_number, next_slot_number + 1
 .endr
 
+.eabi_attribute Tag_ABI_align_preserved, 1
 irq_handler_chain_first_slot:
 #ifndef __riscv
     push {r0, lr}     // Save EXC_RETURN token, so `pop {r0, pc}` will return from interrupt


### PR DESCRIPTION
Add this directive to inform the linker that codes in this file preserve 8-byte alignment of the stack, thus eliminating `Warning: L6306W: '~PRES8' section irq_handler_chain.o(.data) should not use the address of 'REQ8' function irq_add_tail_to_free_list.`.

Reference: [Miscellaneous directives](https://developer.arm.com/documentation/100068/0620/Migrating-from-armasm-to-the-armclang-Integrated-Assembler/Miscellaneous-directives)
