### PR TITLE
Restore the "API Documentation" link in sidebar when building with Doxygen >= 1.9.8

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -55,11 +55,21 @@ if(PICO_BUILD_DOCS)
     set(doxyfile_in ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
     set(doxyfile ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
+    if(DOXYGEN_VERSION VERSION_GREATER_EQUAL "1.9.8")
+        # see https://github.com/doxygen/doxygen/issues/10562
+        set(DOXY_API_DOCS_TAB_TYPE "topics")
+    else()
+        set(DOXY_API_DOCS_TAB_TYPE "modules")
+    endif()
+    set(doxylayout_in ${CMAKE_CURRENT_SOURCE_DIR}/DoxygenLayout.xml.in)
+    set(doxylayout ${CMAKE_CURRENT_BINARY_DIR}/DoxygenLayout.xml)
+
     if (PICO_PLATFORM STREQUAL "rp2040")
         set(PICO_DOXYGEN_TAG "(RP2040)")
     elseif (PICO_PLATFORM STREQUAL "rp2350-arm-s" OR PICO_PLATFORM STREQUAL "rp2350-riscv")
         set(PICO_DOXYGEN_TAG "(RP2350)")
     endif()
+    configure_file(${doxylayout_in} ${doxylayout} @ONLY)
     configure_file(${doxyfile_in} ${doxyfile} @ONLY)
 
     add_custom_target(docs

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -17,7 +17,7 @@ FILE_PATTERNS          = *.h \
                          *.md
 
 USE_MDFILE_AS_MAINPAGE = @PROJECT_SOURCE_DIR@/docs/mainpage.md
-LAYOUT_FILE = @PROJECT_SOURCE_DIR@/docs/DoxygenLayout.xml
+LAYOUT_FILE = @PROJECT_BINARY_DIR@/docs/DoxygenLayout.xml
 HTML_FOOTER = @PROJECT_SOURCE_DIR@/docs/footer.html
 HTML_HEADER = @PROJECT_SOURCE_DIR@/docs/header.html
 

--- a/docs/DoxygenLayout.xml.in
+++ b/docs/DoxygenLayout.xml.in
@@ -3,7 +3,7 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title="Introduction"></tab>
-    <tab type="modules" visible="yes" title="API Documentation" intro="These are the libraries supplied in the Raspberry Pi Pico SDK"/>
+    <tab type="@DOXY_API_DOCS_TAB_TYPE@" visible="yes" title="API Documentation" intro="These are the libraries supplied in the Raspberry Pi Pico SDK"/>
     <tab type="user" url="@ref examples_page" visible="yes" title="Examples" intro="Links to SDK examples"/>
     <tab type="usergroup" url="@ref weblinks_page" visible="yes" title="Additional Documentation" intro="Links to datasheets and documentation">
       <tab type="user" url="https://rptl.io/pico-datasheet" visible="yes" title="Raspberry Pi Pico Datasheet" intro=""/>


### PR DESCRIPTION
I noticed yesterday that when building the local HTML Doxygen docs (as described in Appendix B of https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf ), if you use Doxygen 1.9.8 (as used by Ubuntu 24.04) or Doxygen 1.10.0 (as used by https://github.com/raspberrypi/documentation/blob/develop/.github/workflows/build.yml ) the main "API Documentation" link in the sidebar suddenly disappears! (which unfortunately makes the local HTML Doxygen pretty useless)
![Screenshot from 2024-12-11 14-34-16](https://github.com/user-attachments/assets/106509fe-4b81-45a6-babd-49fc633229b6)

After much trial and error I eventually discovered that this was due to https://github.com/doxygen/doxygen/issues/10562 (which seems like a big change to make in a patch-level version bump from 1.9.7 to 1.9.8).

My initial approach was to just edit `docs/DoxygenLayout.xml` directly to change `<tab type="modules" ...` to `<tab type="topics" ...` and then edit `docs/CMakeLists.txt` to throw a fatal error if building with doxygen < 1.9.8 (which worked); but then I realised that we _do_ still need to keep supporting older versions of Doxygen, because Raspberry Pi OS still includes doxygen 1.9.4 in its APT repositories.
So that's why I came up with the slightly more "nuanced" approach seen here :wink: 

With this fix, the "API Documentation" link appears correctly, regardless of which version of Doxygen you use to build the local HTML Doxygen docs.
![Screenshot from 2024-12-11 14-45-26](https://github.com/user-attachments/assets/7a8cf050-cbfe-46d0-99a8-b135077c73ed)
