### PR TITLE
convert windows path delimiter to posix (#2149)

### DIFF
--- a/src/rp2_common/pico_lwip/tools/makefsdata.py
+++ b/src/rp2_common/pico_lwip/tools/makefsdata.py
@@ -23,9 +23,10 @@ def process_file(input_dir, file):
     if content_type is None:
         content_type = "application/octet-stream"
 
-    # file name
-    data = f"/{file.relative_to(input_dir).as_posix()}\x00"
-    comment = f"\"/{file.relative_to(input_dir).as_posix()}\" ({len(data)} chars)"
+    # file name with posix directory separators 
+    file_path_posix = file.relative_to(input_dir).as_posix()
+    data = f"/{file_path_posix}\x00"
+    comment = f"\"/{file_path_posix}\" ({len(data)} chars)"
     while(len(data) % PAYLOAD_ALIGNMENT != 0):
         data += "\x00"
     results.append({'data': bytes(data, "utf-8"), 'comment': comment});

--- a/src/rp2_common/pico_lwip/tools/makefsdata.py
+++ b/src/rp2_common/pico_lwip/tools/makefsdata.py
@@ -24,8 +24,8 @@ def process_file(input_dir, file):
         content_type = "application/octet-stream"
 
     # file name
-    data = f"/{file.relative_to(input_dir)}\x00"
-    comment = f"\"/{file.relative_to(input_dir)}\" ({len(data)} chars)"
+    data = f"/{file.relative_to(input_dir).as_posix()}\x00"
+    comment = f"\"/{file.relative_to(input_dir).as_posix()}\" ({len(data)} chars)"
     while(len(data) % PAYLOAD_ALIGNMENT != 0):
         data += "\x00"
     results.append({'data': bytes(data, "utf-8"), 'comment': comment});


### PR DESCRIPTION
Fixes #2149 
When generating lwip file system data convert windows directory separators by posix separators.
This is an issue when native directory during resource generation separator is "\\" as on windows. Running toolchain from mingw64 python3 would also preserve "\\" in resource name which would cause mismatch on resource lookup.
Fix should be portable with python 3.4 and up.