### PR TITLE
Remove deprecated uses of FetchContent_Populate

### DIFF
--- a/external/pico_sdk_import.cmake
+++ b/external/pico_sdk_import.cmake
@@ -40,25 +40,26 @@ if (NOT PICO_SDK_PATH)
         if (PICO_SDK_FETCH_FROM_GIT_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
-        # GIT_SUBMODULES_RECURSE was added in 3.17
-        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
-            FetchContent_Declare(
-                    pico_sdk
-                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
-                    GIT_SUBMODULES_RECURSE FALSE
-            )
-        else ()
-            FetchContent_Declare(
-                    pico_sdk
-                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
-            )
-        endif ()
+        FetchContent_Declare(
+                pico_sdk
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+        )
 
         if (NOT pico_sdk)
             message("Downloading Raspberry Pi Pico SDK")
-            FetchContent_Populate(pico_sdk)
+            FetchContent_Populate(
+                    pico_sdk
+                    QUIET
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+                    GIT_SUBMODULES_RECURSE FALSE
+
+                    SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                    BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                    SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+            )
+
             set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
         endif ()
         set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})

--- a/external/pico_sdk_import.cmake
+++ b/external/pico_sdk_import.cmake
@@ -48,17 +48,31 @@ if (NOT PICO_SDK_PATH)
 
         if (NOT pico_sdk)
             message("Downloading Raspberry Pi Pico SDK")
-            FetchContent_Populate(
-                    pico_sdk
-                    QUIET
-                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
-                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
-                    GIT_SUBMODULES_RECURSE FALSE
+            # GIT_SUBMODULES_RECURSE was added in 3.17
+            if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+                        GIT_SUBMODULES_RECURSE FALSE
 
-                    SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
-                    BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
-                    SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
-            )
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            else ()
+                FetchContent_Populate(
+                        pico_sdk
+                        QUIET
+                        GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                        GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+
+                        SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-src
+                        BINARY_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-build
+                        SUBBUILD_DIR ${FETCHCONTENT_BASE_DIR}/pico_sdk-subbuild
+                )
+            endif ()
 
             set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
         endif ()

--- a/tools/Findpicotool.cmake
+++ b/tools/Findpicotool.cmake
@@ -15,10 +15,12 @@ if (NOT TARGET picotool)
     endif ()
 
     include(FetchContent)
-    set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
     if (PICOTOOL_FETCH_FROM_GIT_PATH)
-        get_filename_component(FETCHCONTENT_BASE_DIR "${PICOTOOL_FETCH_FROM_GIT_PATH}" ABSOLUTE)
+        get_filename_component(picotool_INSTALL_DIR "${PICOTOOL_FETCH_FROM_GIT_PATH}" ABSOLUTE)
+    else ()
+        get_filename_component(picotool_INSTALL_DIR "${FETCHCONTENT_BASE_DIR}" ABSOLUTE)
     endif ()
+    set(picotool_INSTALL_DIR ${picotool_INSTALL_DIR} CACHE PATH "Directory where picotool has been installed" FORCE)
 
     set(picotool_BUILD_TARGET picotoolBuild)
     set(picotool_TARGET picotool)
@@ -32,20 +34,15 @@ if (NOT TARGET picotool)
             )
         endif()
 
-        FetchContent_Declare(
-                picotool
-                GIT_REPOSITORY https://github.com/raspberrypi/picotool.git
-                GIT_TAG develop
-                GIT_PROGRESS true
-        )
+        message("Downloading Picotool")
+        FetchContent_Populate(picotool QUIET
+            GIT_REPOSITORY https://github.com/raspberrypi/picotool.git
+            GIT_TAG develop
 
-        FetchContent_GetProperties(picotool)
-        set(picotool_INSTALL_DIR ${FETCHCONTENT_BASE_DIR} CACHE PATH "Directory where picotool has been installed" FORCE)
-        if (NOT picotool_POPULATED)
-            message("Downloading Picotool")
-            FetchContent_Populate(picotool)
-        endif ()
-        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+            SOURCE_DIR ${picotool_INSTALL_DIR}/picotool-src
+            BINARY_DIR ${picotool_INSTALL_DIR}/picotool-build
+            SUBBUILD_DIR ${picotool_INSTALL_DIR}/picotool-subbuild
+        )
 
         add_custom_target(picotoolForceReconfigure
             ${CMAKE_COMMAND} -E touch_nocreate "${CMAKE_SOURCE_DIR}/CMakeLists.txt"


### PR DESCRIPTION
This removes the deprecated uses of FetchContent_Populate (see #2124)

The SDK cannot just use MakeAvailable as the files shouldn't be added to the build, so instead this uses the full signature for FetchContent_Populate which has not been deprecated. The FetchContent_Declare call is kept in `pico_sdk_import.cmake` else it will re-clone the SDK for every new build directory when `PICO_SDK_FETCH_FROM_GIT_PATH` is set, rather than re-using the cloned SDK in `PICO_SDK_FETCH_FROM_GIT_PATH`.

Fixes #2124