### PR TITLE
Add rom_pick_ab_update_partition function

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -19,6 +19,7 @@ alias(
         "//src/rp2_common/boot_bootrom_headers:__pkg__",
         "//src/rp2_common/hardware_boot_lock:__pkg__",
         "//src/rp2_common/pico_flash:__pkg__",
+        "//src/rp2_common/hardware_rcp:__pkg__",
     ],
 )
 

--- a/src/rp2_common/hardware_rcp/BUILD.bazel
+++ b/src/rp2_common/hardware_rcp/BUILD.bazel
@@ -2,6 +2,19 @@ load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
 
+# Picotool needs this (transitively through
+# //src/rp2_common/pico_bootrom:pico_bootrom_headers), so we can't strictly
+# constrain compatibility.
+cc_library(
+    name = "hardware_rcp_headers",
+    hdrs = ["include/hardware/rcp.h"],
+    includes = ["include"],
+    visibility = ["//src/rp2_common/pico_bootrom:__pkg__"],
+    deps = [
+        "//src:pico_platform_internal",
+    ],
+)
+
 cc_library(
     name = "hardware_rcp",
     hdrs = ["include/hardware/rcp.h"],

--- a/src/rp2_common/hardware_rcp/include/hardware/rcp.h
+++ b/src/rp2_common/hardware_rcp/include/hardware/rcp.h
@@ -15,13 +15,15 @@
  */
 
 // ----------------------------------------------------------------------------
-// RCP instructions (this header is Arm-only)
-#if defined(PICO_RP2350) && !defined(__riscv)
+// RCP masks (this header is RP2350 only)
+#if defined(PICO_RP2350)
 
 #define RCP_MASK_TRUE   _u(0xa500a500)
 #define RCP_MASK_FALSE  _u(0x00c300c3)
 #define RCP_MASK_INTXOR _u(0x96009600)
 
+// RCP instructions (this header is Arm-only)
+#if !defined(__riscv)
 // ----------------------------------------------------------------------------
 // Macros and inline functions for use in C files
 #ifndef __ASSEMBLER__
@@ -995,6 +997,7 @@ rcp_switch_u8_to_ch_cl rcp_canary_check_nodelay_impl \tag, \x
 .endm
 
 #endif // !__riscv
+#endif // PICO_RP2350
 #endif // __ASSEMBLER__
 // ----------------------------------------------------------------------------
 

--- a/src/rp2_common/hardware_rcp/include/hardware/rcp.h
+++ b/src/rp2_common/hardware_rcp/include/hardware/rcp.h
@@ -16,14 +16,14 @@
 
 // ----------------------------------------------------------------------------
 // RCP masks (this header is RP2350 only)
-#if defined(PICO_RP2350)
+#if PICO_RP2350
 
 #define RCP_MASK_TRUE   _u(0xa500a500)
 #define RCP_MASK_FALSE  _u(0x00c300c3)
 #define RCP_MASK_INTXOR _u(0x96009600)
 
 // RCP instructions (this header is Arm-only)
-#if !defined(__riscv)
+#if HAS_REDUNDANCY_COPROCESSOR
 // ----------------------------------------------------------------------------
 // Macros and inline functions for use in C files
 #ifndef __ASSEMBLER__
@@ -996,7 +996,7 @@ rcp_switch_u8_to_ch_cl rcp_canary_check_nodelay_impl \tag, \x
     cdp p7, #0, c0, c0, c0, #1
 .endm
 
-#endif // !__riscv
+#endif // HAS_REDUNDANCY_COPROCESSOR
 #endif // PICO_RP2350
 #endif // __ASSEMBLER__
 // ----------------------------------------------------------------------------

--- a/src/rp2_common/hardware_rcp/include/hardware/rcp.h
+++ b/src/rp2_common/hardware_rcp/include/hardware/rcp.h
@@ -15,14 +15,14 @@
  */
 
 // ----------------------------------------------------------------------------
-// RCP masks (this header is RP2350 only)
-#if PICO_RP2350
+// RCP masks
+#if !PICO_RP2040
 
 #define RCP_MASK_TRUE   _u(0xa500a500)
 #define RCP_MASK_FALSE  _u(0x00c300c3)
 #define RCP_MASK_INTXOR _u(0x96009600)
 
-// RCP instructions (this header is Arm-only)
+// RCP instructions (these instructions are Arm-only)
 #if HAS_REDUNDANCY_COPROCESSOR
 // ----------------------------------------------------------------------------
 // Macros and inline functions for use in C files
@@ -997,7 +997,7 @@ rcp_switch_u8_to_ch_cl rcp_canary_check_nodelay_impl \tag, \x
 .endm
 
 #endif // HAS_REDUNDANCY_COPROCESSOR
-#endif // PICO_RP2350
+#endif // !PICO_RP2040
 #endif // __ASSEMBLER__
 // ----------------------------------------------------------------------------
 

--- a/src/rp2_common/pico_bootrom/BUILD.bazel
+++ b/src/rp2_common/pico_bootrom/BUILD.bazel
@@ -18,6 +18,7 @@ cc_library(
         "//src/rp2_common/boot_bootrom_headers",
         "//src/rp2_common/hardware_boot_lock:hardware_boot_lock_headers",
         "//src/rp2_common/pico_flash:pico_flash_headers",
+        "//src/rp2_common/hardware_rcp:hardware_rcp_headers",
     ] + select({
         "//bazel/constraint:host": ["//src/host/hardware_sync"],
         "//conditions:default": ["//src/rp2_common/hardware_sync"],

--- a/src/rp2_common/pico_bootrom/bootrom.c
+++ b/src/rp2_common/pico_bootrom/bootrom.c
@@ -71,23 +71,6 @@ void __attribute__((noreturn)) rom_reset_usb_boot_extra(int usb_activity_gpio_pi
 }
 
 #if !PICO_RP2040
-
-
-// Generated from adding the following code into the bootrom
-// scan_workarea_t* scan_workarea = (scan_workarea_t*)workarea;
-// printf("VERSION_DOWNGRADE_ERASE_ADDR %08x\n", &(always->zero_init.version_downgrade_erase_flash_addr));
-// printf("TBYB_FLAG_ADDR %08x\n", &(always->zero_init.tbyb_flag_flash_addr));
-// printf("IMAGE_DEF_VERIFIED %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.verified) - (uint32_t)scan_workarea);
-// printf("IMAGE_DEF_TBYB_FLAGGED %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.tbyb_flagged) - (uint32_t)scan_workarea);
-// printf("IMAGE_DEF_BASE %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.enclosing_window.base) - (uint32_t)scan_workarea);
-// printf("IMAGE_DEF_REL_BLOCK_OFFSET %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.window_rel_block_offset) - (uint32_t)scan_workarea);
-#define VERSION_DOWNGRADE_ERASE_ADDR *(uint32_t*)0x400e0338
-#define TBYB_FLAG_ADDR *(uint32_t*)0x400e0348
-#define IMAGE_DEF_VERIFIED(scan_workarea) *(uint32_t*)(0x64 + (uint32_t)scan_workarea)
-#define IMAGE_DEF_TBYB_FLAGGED(scan_workarea) *(bool*)(0x4c + (uint32_t)scan_workarea)
-#define IMAGE_DEF_BASE(scan_workarea) *(uint32_t*)(0x54 + (uint32_t)scan_workarea)
-#define IMAGE_DEF_REL_BLOCK_OFFSET(scan_workarea) *(uint32_t*)(0x5c + (uint32_t)scan_workarea)
-
 bool rom_get_boot_random(uint32_t out[4]) {
     uint32_t result[5];
     rom_get_sys_info_fn func = (rom_get_sys_info_fn) rom_func_lookup_inline(ROM_FUNC_GET_SYS_INFO);
@@ -130,6 +113,33 @@ int rom_add_flash_runtime_partition(uint32_t start_offset, uint32_t size, uint32
 }
 
 int rom_pick_ab_update_partition(uint32_t *workarea_base, uint32_t workarea_size, uint partition_a_num) {
+#if PICO_RP2350
+    // Generated from adding the following code into the bootrom
+    // scan_workarea_t* scan_workarea = (scan_workarea_t*)workarea;
+    // printf("VERSION_DOWNGRADE_ERASE_ADDR %08x\n", &(always->zero_init.version_downgrade_erase_flash_addr));
+    // printf("TBYB_FLAG_ADDR %08x\n", &(always->zero_init.tbyb_flag_flash_addr));
+    // printf("IMAGE_DEF_VERIFIED %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.verified) - (uint32_t)scan_workarea);
+    // printf("IMAGE_DEF_TBYB_FLAGGED %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.tbyb_flagged) - (uint32_t)scan_workarea);
+    // printf("IMAGE_DEF_BASE %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.enclosing_window.base) - (uint32_t)scan_workarea);
+    // printf("IMAGE_DEF_REL_BLOCK_OFFSET %08x\n", (uint32_t)&(scan_workarea->parsed_block_loops[0].image_def.core.window_rel_block_offset) - (uint32_t)scan_workarea);
+    #define VERSION_DOWNGRADE_ERASE_ADDR *(uint32_t*)0x400e0338
+    #define TBYB_FLAG_ADDR *(uint32_t*)0x400e0348
+    #define IMAGE_DEF_VERIFIED(scan_workarea) *(uint32_t*)(0x64 + (uint32_t)scan_workarea)
+    #define IMAGE_DEF_TBYB_FLAGGED(scan_workarea) *(bool*)(0x4c + (uint32_t)scan_workarea)
+    #define IMAGE_DEF_BASE(scan_workarea) *(uint32_t*)(0x54 + (uint32_t)scan_workarea)
+    #define IMAGE_DEF_REL_BLOCK_OFFSET(scan_workarea) *(uint32_t*)(0x5c + (uint32_t)scan_workarea)
+#else
+    // Prevent linting errors
+    #define VERSION_DOWNGRADE_ERASE_ADDR *(uint32_t*)NULL
+    #define TBYB_FLAG_ADDR *(uint32_t*)NULL
+    #define IMAGE_DEF_VERIFIED(scan_workarea) *(uint32_t*)(NULL + (uint32_t)scan_workarea)
+    #define IMAGE_DEF_TBYB_FLAGGED(scan_workarea) *(bool*)(NULL + (uint32_t)scan_workarea)
+    #define IMAGE_DEF_BASE(scan_workarea) *(uint32_t*)(NULL + (uint32_t)scan_workarea)
+    #define IMAGE_DEF_REL_BLOCK_OFFSET(scan_workarea) *(uint32_t*)(NULL + (uint32_t)scan_workarea)
+
+    panic_unsupported();
+#endif
+
     uint32_t flash_update_base = 0;
     bool tbyb_boot = false;
     uint32_t saved_erase_addr = 0;

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -749,6 +749,9 @@ static inline int rom_load_partition_table(uint8_t *workarea_base, uint32_t work
  * 
  * NOTE: This method does not look at owner partitions, only the A partition passed and it's corresponding B partition.
  * 
+ * NOTE: You should not call this method directly when performing a Flash Update Boot before calling `explicit_buy`, as it may prevent
+ * any version downgrade from occuring - instead \see rom_pick_ab_update_partition() which wraps this function.
+ * 
  * \param workarea_base base address of work area
  * \param workarea_size size of work area
  * \param partition_a_num the A partition of the pair
@@ -1090,6 +1093,30 @@ static inline int rom_get_last_boot_type(void) {
  *         PICO_ERROR_INVALID_ARG if the start_offset or size are out of range, or invalid permission bits are set.
  */
 int rom_add_flash_runtime_partition(uint32_t start_offset, uint32_t size, uint32_t permissions);
+
+/*! \brief Pick A/B partition without disturbing any in progress update or TBYB boot
+ * \ingroup pico_bootrom
+ *
+ * This will call `rom_pick_ab_partition` using the `flash_update_boot_window_base` from the current boot, while performing extra checks to prevent disrupting
+ * a main image TBYB boot. It requires the same minimum workarea size as `rom_pick_ab_partition`.
+ * \see rom_pick_ab_partition()
+ * 
+ * For example, if an `explicit_buy` is pending then calling `pick_ab_partition` would normally clear the saved flash erase address for the version downgrade,
+ * so the required erase of the other partition would not occur when `explicit_buy` is called - this function saves and restores that address to prevent this
+ * issue, and returns `BOOTROM_ERROR_NOT_PERMITTED` if the partition chosen by `pick_ab_partition` also requires a flash erase version downgrade (as you can't
+ * erase 2 partitions with one `explicit_buy` call).
+ * 
+ * It also checks that the chosen partition contained a valid image (eg a signed image when using secure boot), and returns `BOOTROM_ERROR_NOT_FOUND`
+ * if it does not.
+ *
+ * \param workarea_base base address of work area
+ * \param workarea_size size of work area
+ * \param partition_a_num the A partition of the pair
+ * \return >= 0 the partition number picked
+ *         BOOTROM_ERROR_NOT_PERMITTED if not possible to do an update correctly, eg if both main image and data image are TBYB
+ *         BOOTROM_ERROR_NOT_FOUND if the chosen partition failed verification
+ */
+int rom_pick_ab_update_partition(uint32_t *workarea_base, uint32_t workarea_size, uint partition_a_num);
 
 #endif
 

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -1106,14 +1106,14 @@ int rom_add_flash_runtime_partition(uint32_t start_offset, uint32_t size, uint32
  * issue, and returns `BOOTROM_ERROR_NOT_PERMITTED` if the partition chosen by `pick_ab_partition` also requires a flash erase version downgrade (as you can't
  * erase 2 partitions with one `explicit_buy` call).
  * 
- * It also checks that the chosen partition contained a valid image (eg a signed image when using secure boot), and returns `BOOTROM_ERROR_NOT_FOUND`
+ * It also checks that the chosen partition contained a valid image (e.g. a signed image when using secure boot), and returns `BOOTROM_ERROR_NOT_FOUND`
  * if it does not.
  *
  * \param workarea_base base address of work area
  * \param workarea_size size of work area
  * \param partition_a_num the A partition of the pair
  * \return >= 0 the partition number picked
- *         BOOTROM_ERROR_NOT_PERMITTED if not possible to do an update correctly, eg if both main image and data image are TBYB
+ *         BOOTROM_ERROR_NOT_PERMITTED if not possible to do an update correctly, e.g. if both main image and data image are TBYB
  *         BOOTROM_ERROR_NOT_FOUND if the chosen partition failed verification
  */
 int rom_pick_ab_update_partition(uint32_t *workarea_base, uint32_t workarea_size, uint partition_a_num);


### PR DESCRIPTION
This adds the `rom_pick_ab_update_partition` function taken from #1969, without the wi-fi firmware partition support from that PR (which doesn't compile with Risc-V).

I think this function has more uses beyond the wi-fi firmware partition support (eg in the encrypted bootloader example), so would like to get it merged.