### PR TITLE
Disable irq before removing handler in cyw43_irq_deinit

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
@@ -63,8 +63,8 @@ uint32_t cyw43_irq_deinit(__unused void *param) {
 #ifndef NDEBUG
     assert(get_core_num() == async_context_core_num(cyw43_async_context));
 #endif
-    gpio_remove_raw_irq_handler(CYW43_PIN_WL_HOST_WAKE, cyw43_gpio_irq_handler);
     cyw43_set_irq_enabled(false);
+    gpio_remove_raw_irq_handler(CYW43_PIN_WL_HOST_WAKE, cyw43_gpio_irq_handler);
     return 0;
 }
 


### PR DESCRIPTION
This changes cyw43_irq_deinit to disable the irq before removing the handler otherwise the irq can occur after the handler has been removed causing the unhandled irq handler to be used thus hanging the device.

Fixes #2176
