### PR TITLE
Support multiple .pio file in pico_generate_pio_header

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -155,7 +155,7 @@ endfunction()
 
 # Generate pio header and include it in the build
 # PICO_CMAKE_CONFIG: PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, Default output format used by pioasm when using pico_generate_pio_header, type=string, default=c-sdk, group=build
-function(pico_generate_pio_header TARGET PIO)
+function(pico_generate_pio_header TARGET)
     pico_init_pioasm()
     cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR" "" ${ARGN} )
 
@@ -173,24 +173,31 @@ function(pico_generate_pio_header TARGET PIO)
     else()
         set(HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
-    get_filename_component(PIO_NAME ${PIO} NAME)
-    set(HEADER "${HEADER_DIR}/${PIO_NAME}.h")
-    #message("Will generate ${HEADER}")
-    get_filename_component(HEADER_GEN_TARGET ${PIO} NAME_WE)
-    set(HEADER_GEN_TARGET "${TARGET}_${HEADER_GEN_TARGET}_pio_h")
 
-    add_custom_target(${HEADER_GEN_TARGET} DEPENDS ${HEADER})
+    # Loop through each PIO file
+    foreach(PIO ${pico_generate_pio_header_UNPARSED_ARGUMENTS})
+        get_filename_component(PIO_NAME ${PIO} NAME)
+        set(HEADER "${HEADER_DIR}/${PIO_NAME}.h")
+        #message("Will generate ${HEADER}")
+        get_filename_component(HEADER_GEN_TARGET ${PIO} NAME_WE)
+        set(HEADER_GEN_TARGET "${TARGET}_${HEADER_GEN_TARGET}_pio_h")
 
-    if (PICO_PIO_VERSION)
-        set(VERSION_STRING "${PICO_PIO_VERSION}")
-    else()
-        set(VERSION_STRING "0")
-    endif()
-    add_custom_command(OUTPUT ${HEADER}
-            DEPENDS ${PIO}
-            COMMAND pioasm -o ${OUTPUT_FORMAT} -v ${VERSION_STRING} ${PIO} ${HEADER}
-            VERBATIM)
-    add_dependencies(${TARGET} ${HEADER_GEN_TARGET})
+        add_custom_target(${HEADER_GEN_TARGET} DEPENDS ${HEADER})
+
+        if (PICO_PIO_VERSION)
+            set(VERSION_STRING "${PICO_PIO_VERSION}")
+        else()
+            set(VERSION_STRING "0")
+        endif()
+
+        add_custom_command(OUTPUT ${HEADER}
+                DEPENDS ${PIO}
+                COMMAND pioasm -o ${OUTPUT_FORMAT} -v ${VERSION_STRING} ${PIO} ${HEADER}
+                VERBATIM)
+
+        add_dependencies(${TARGET} ${HEADER_GEN_TARGET})
+    endforeach()
+
     get_target_property(target_type ${TARGET} TYPE)
     if ("INTERFACE_LIBRARY" STREQUAL "${target_type}")
         target_include_directories(${TARGET} INTERFACE ${HEADER_DIR})


### PR DESCRIPTION
Fixes #1448

This PR changed code in CMake function `pico_generate_pio_header`. Specifically:

- Deleted the fixed parameter `PIO` that was used to fetch PIO assembler file
- `pico_generate_pio_header_UNPARSED_ARGUMENTS` variable that was created during CMake argument parsing is used instead, extracting every .pio file that was possibly specified

Self-test with `message` uncommented:

Configure:

![clipboard_2025-01-18_01-17](https://github.com/user-attachments/assets/4fba89c6-8d8d-4cae-8aee-242466c91797)

Build:

![image](https://github.com/user-attachments/assets/e72386c8-3f43-4899-ac8b-62aed7800ebd)
