### PR TITLE
Add ability to override number of IRQ vectors

### DIFF
--- a/src/rp2040/pico_platform/include/pico/platform.h
+++ b/src/rp2040/pico_platform/include/pico/platform.h
@@ -66,7 +66,7 @@
 #define PICO_RP2040_B2_SUPPORTED 1
 #endif
 
-// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, default=NUM_IRQS, advanced=true, group=pico_platform
+// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, min=0, max=NUM_IRQS, default=NUM_IRQS, advanced=true, group=pico_platform
 #ifndef PICO_VECTOR_TABLE_NUM_IRQS
 #define PICO_VECTOR_TABLE_NUM_IRQS NUM_IRQS
 #endif

--- a/src/rp2040/pico_platform/include/pico/platform.h
+++ b/src/rp2040/pico_platform/include/pico/platform.h
@@ -66,8 +66,13 @@
 #define PICO_RP2040_B2_SUPPORTED 1
 #endif
 
+// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, default=NUM_IRQS, advanced=true, group=pico_platform
+#ifndef PICO_VECTOR_TABLE_NUM_IRQS
+#define PICO_VECTOR_TABLE_NUM_IRQS NUM_IRQS
+#endif
+
 #ifndef PICO_RAM_VECTOR_TABLE_SIZE
-#define PICO_RAM_VECTOR_TABLE_SIZE (VTABLE_FIRST_IRQ + NUM_IRQS)
+#define PICO_RAM_VECTOR_TABLE_SIZE (VTABLE_FIRST_IRQ + PICO_VECTOR_TABLE_NUM_IRQS)
 #endif
 
 // PICO_CONFIG: PICO_CLKDIV_ROUND_NEAREST, True if floating point clock divisors should be rounded to the nearest possible clock divisor by default rather than rounding down, type=bool, default=1, group=pico_platform

--- a/src/rp2350/pico_platform/include/pico/platform.h
+++ b/src/rp2350/pico_platform/include/pico/platform.h
@@ -54,7 +54,7 @@
 #define PICO_NO_RAM_VECTOR_TABLE 0
 #endif
 
-// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, default=NUM_IRQS, advanced=true, group=pico_platform
+// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, min=0, max=NUM_IRQS, default=NUM_IRQS, advanced=true, group=pico_platform
 #ifndef PICO_VECTOR_TABLE_NUM_IRQS
 #define PICO_VECTOR_TABLE_NUM_IRQS NUM_IRQS
 #endif

--- a/src/rp2350/pico_platform/include/pico/platform.h
+++ b/src/rp2350/pico_platform/include/pico/platform.h
@@ -54,8 +54,13 @@
 #define PICO_NO_RAM_VECTOR_TABLE 0
 #endif
 
+// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, default=NUM_IRQS, advanced=true, group=pico_platform
+#ifndef PICO_VECTOR_TABLE_NUM_IRQS
+#define PICO_VECTOR_TABLE_NUM_IRQS NUM_IRQS
+#endif
+
 #ifndef PICO_RAM_VECTOR_TABLE_SIZE
-#define PICO_RAM_VECTOR_TABLE_SIZE (VTABLE_FIRST_IRQ + NUM_IRQS)
+#define PICO_RAM_VECTOR_TABLE_SIZE (VTABLE_FIRST_IRQ + PICO_VECTOR_TABLE_NUM_IRQS)
 #endif
 
 // PICO_CONFIG: PICO_USE_STACK_GUARDS, Enable/disable stack guards, type=bool, default=0, advanced=true, group=pico_platform
@@ -284,4 +289,3 @@ __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
 #endif // __ASSEMBLER__
 
 #endif
-

--- a/src/rp2_common/hardware_irq/include/hardware/irq.h
+++ b/src/rp2_common/hardware_irq/include/hardware/irq.h
@@ -195,7 +195,7 @@ extern "C" {
 typedef void (*irq_handler_t)(void);
 
 static inline void check_irq_param(__unused uint num) {
-    invalid_params_if(HARDWARE_IRQ, num >= NUM_IRQS);
+    invalid_params_if(HARDWARE_IRQ, num >= PICO_VECTOR_TABLE_NUM_IRQS);
 }
 
 /*! \brief Set specified interrupt's priority

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -52,8 +52,12 @@ __vectors:
 // we don't include any IRQ vectors; we will initialize them during runtime_init in the RAM vector table
 #else
 
+#ifndef PICO_VECTOR_TABLE_NUM_IRQS
+#define PICO_VECTOR_TABLE_NUM_IRQS NUM_IRQS
+#endif
+
 .macro if_irq_word num func
-.if \num < NUM_IRQS
+.if \num < PICO_VECTOR_TABLE_NUM_IRQS
 .word \func
 .endif
 .endm
@@ -142,7 +146,7 @@ if_irq_word 76 isr_irq76
 if_irq_word 77 isr_irq77
 if_irq_word 78 isr_irq78
 if_irq_word 79 isr_irq79
-#if NUM_IRQS > 80
+#if PICO_VECTOR_TABLE_NUM_IRQS > 80
 #error more IRQ entries required
 #endif
 #endif

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -52,6 +52,7 @@ __vectors:
 // we don't include any IRQ vectors; we will initialize them during runtime_init in the RAM vector table
 #else
 
+// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, default=NUM_IRQS, group=pico_crt0
 #ifndef PICO_VECTOR_TABLE_NUM_IRQS
 #define PICO_VECTOR_TABLE_NUM_IRQS NUM_IRQS
 #endif

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -52,11 +52,6 @@ __vectors:
 // we don't include any IRQ vectors; we will initialize them during runtime_init in the RAM vector table
 #else
 
-// PICO_CONFIG: PICO_VECTOR_TABLE_NUM_IRQS, Number of IRQ vectors to include in the vector table, type=int, default=NUM_IRQS, group=pico_crt0
-#ifndef PICO_VECTOR_TABLE_NUM_IRQS
-#define PICO_VECTOR_TABLE_NUM_IRQS NUM_IRQS
-#endif
-
 .macro if_irq_word num func
 .if \num < PICO_VECTOR_TABLE_NUM_IRQS
 .word \func


### PR DESCRIPTION
Adds `PICO_VECTOR_TABLE_NUM_IRQS` define to allow overriding the number of IRQ vectors in the vector table. This is useful to reduce the size of the vector table when not using some IRQs.

For example, if no IRQs are being used then you can add this to your CMakeLists.txt to reduce the size of the vector table in the binary
```cmake
target_compile_definitions(my_executable PRIVATE PICO_VECTOR_TABLE_NUM_IRQS=0)
```