### PR TITLE
Fix unreliable writes to cyw43.

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -308,11 +308,13 @@ int cyw43_spi_transfer(cyw43_int_t *self, const uint8_t *tx, size_t tx_length, u
 
         dma_channel_configure(bus_data->dma_out, &out_config, &bus_data->pio->txf[bus_data->pio_sm], tx, tx_length / 4, true);
 
+        pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, true);
+        dma_channel_wait_for_finish_blocking(bus_data->dma_out);
+
         uint32_t fdebug_tx_stall = 1u << (PIO_FDEBUG_TXSTALL_LSB + bus_data->pio_sm);
         bus_data->pio->fdebug = fdebug_tx_stall;
-        pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, true);
         while (!(bus_data->pio->fdebug & fdebug_tx_stall)) {
-            tight_loop_contents(); // todo timeout
+            tight_loop_contents();
         }
         __compiler_memory_barrier();
         pio_sm_set_enabled(bus_data->pio, bus_data->pio_sm, false);


### PR DESCRIPTION
We use a pio and dma to write to the cyw43 chip using spi. Normally you write an address and then read the data from that address, so the pio program does does a write then read.

If you just want to write data in the case of uploading firmware we use the fdebug_tx_stall flag to work out if the pio has stalled waiting to read data which will never arrive.

The theory is that this flag will also get set if the bus is busy. So we mistakenly think a write to cyw43 has completed.

Add a check for the dma irq as well.

Fixes #2206
