### PR TITLE
Declare platform.h functions with C linkage

### DIFF
--- a/src/rp2040/pico_platform/include/pico/platform.h
+++ b/src/rp2040/pico_platform/include/pico/platform.h
@@ -77,6 +77,10 @@
 
 #ifndef __ASSEMBLER__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*! \brief No-op function for the body of tight loops
  *  \ingroup pico_platform
  *
@@ -209,6 +213,10 @@ return a;
 #define __fast_mul(a, b) __builtin_choose_expr(__builtin_constant_p(b) && !__builtin_constant_p(a), \
     (__builtin_popcount(b) >= 2 ? __mul_instruction(a,b) : (a)*(b)), \
     (a)*(b))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __ASSEMBLER__
 

--- a/src/rp2350/pico_platform/include/pico/platform.h
+++ b/src/rp2350/pico_platform/include/pico/platform.h
@@ -70,6 +70,10 @@
 
 #ifndef __ASSEMBLER__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*! \brief No-op function for the body of tight loops
  *  \ingroup pico_platform
  *
@@ -280,6 +284,10 @@ __force_inline static int32_t __mul_instruction(int32_t a, int32_t b) {
 #define __fast_mul(a, b) __builtin_choose_expr(__builtin_constant_p(b) && !__builtin_constant_p(a), \
     (__builtin_popcount(b) >= 2 ? __mul_instruction(a,b) : (a)*(b)), \
     (a)*(b))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // __ASSEMBLER__
 


### PR DESCRIPTION
The platform.h headers for both RP2040 and RP2350 need `extern "C"` declarations when included from C++ code or `rp2040_chip_version` and `rp2350_chip_version` won't be found by the linker.

Fixes #2217 
