### PR TITLE
Eat PATH argument to pico_generate_pio_header which was ignored before supporting multi-target on pico_generate_pio_header

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -157,7 +157,8 @@ endfunction()
 # PICO_CMAKE_CONFIG: PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, Default output format used by pioasm when using pico_generate_pio_header, type=string, default=c-sdk, group=build
 function(pico_generate_pio_header TARGET)
     pico_init_pioasm()
-    cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR" "" ${ARGN} )
+    # Note that PATH is not a valid argument but was previously ignored (and happens to be passed by pico-extras)
+    cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR;PATH" "" ${ARGN} )
 
     if (pico_generate_pio_header_OUTPUT_FORMAT)
         set(OUTPUT_FORMAT "${pico_generate_pio_header_OUTPUT_FORMAT}")


### PR DESCRIPTION
see #2188 