### PR TITLE
Fix semicolon in makefsdata.py

### DIFF
--- a/src/rp2_common/pico_lwip/tools/makefsdata.py
+++ b/src/rp2_common/pico_lwip/tools/makefsdata.py
@@ -94,7 +94,7 @@ def process_file_list(fd, input):
         fd.write(f"static const unsigned char {data_var}[] = {{\n")
         for entry in results:
             fd.write(f"\n    /* {entry['comment']} */\n")
-            byte_count = 0;
+            byte_count = 0
             for b in entry['data']:
                 if byte_count % 16 == 0:
                     fd.write("    ")


### PR DESCRIPTION
Simple semicolon that breaks the file otherwise (it used to break my project but it doesn't anymore for some reason)
There is no associated issue for this, but no semi colon should be at the end of an instruction line in Python.
