### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/choco_packages.config
+++ b/.github/workflows/choco_packages.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="gcc-arm-embedded" version="10.2.1" />
-  <package id="cmake" version="3.31.0" installArguments="ADD_CMAKE_TO_PATH=System" />
   <package id="mingw" version="12.2.0" />
   <package id="ninja" version="1.11.1" />
 </packages>


### PR DESCRIPTION
Don't install CMake, as it comes pre-installed on GitHub runners. We already rely on other pre-installed software like Python, so this should be fine.

This fixes the CMake version incompatibilities that keep appearing with the Windows CI build.