### PR TITLE
Increase deault PICO_CONFIG: PICO_XOSC_STARTUP_DELAY_MULTIPLIER to 6ms

### DIFF
--- a/src/rp2_common/hardware_xosc/include/hardware/xosc.h
+++ b/src/rp2_common/hardware_xosc/include/hardware/xosc.h
@@ -13,9 +13,9 @@
 
 // Allow lengthening startup delay to accommodate slow-starting oscillators
 
-// PICO_CONFIG: PICO_XOSC_STARTUP_DELAY_MULTIPLIER, Multiplier to lengthen xosc startup delay to accommodate slow-starting oscillators, type=int, min=1, default=1, group=hardware_xosc
+// PICO_CONFIG: PICO_XOSC_STARTUP_DELAY_MULTIPLIER, Multiplier (from 1ms) for xosc startup delay to accommodate slow-starting oscillators, type=int, min=1, default=6, group=hardware_xosc
 #ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
-#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 1
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 6
 #endif
 
 


### PR DESCRIPTION
fixes #2234 

Also changed the description to make MULTIPLIER make sense!