### PR TITLE
update stdio_usb CDC constants to the defaults used by TinyUSB, and allow the user to override them

### DIFF
--- a/src/rp2_common/pico_stdio_usb/include/tusb_config.h
+++ b/src/rp2_common/pico_stdio_usb/include/tusb_config.h
@@ -33,8 +33,19 @@
 #define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE)
 
 #define CFG_TUD_CDC             (1)
-#define CFG_TUD_CDC_RX_BUFSIZE  (256)
-#define CFG_TUD_CDC_TX_BUFSIZE  (256)
+
+// CDC FIFO size of TX and RX
+#ifndef CFG_TUD_CDC_RX_BUFSIZE
+#define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#endif
+#ifndef CFG_TUD_CDC_TX_BUFSIZE
+#define CFG_TUD_CDC_TX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#endif
+
+// CDC Endpoint transfer buffer size, more is faster
+#ifndef CFG_TUD_CDC_EP_BUFSIZE
+#define CFG_TUD_CDC_EP_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)
+#endif
 
 // We use a vendor specific interface but with our own driver
 // Vendor driver only used for Microsoft OS 2.0 descriptor


### PR DESCRIPTION
`CFG_TUD_CDC_RX_BUFSIZE`, `CFG_TUD_CDC_TX_BUFSIZE` and `CFG_TUD_CDC_EP_BUFSIZE`
