### PR TITLE
boards/adafruit_feather_rp2350.h: add PICO_XOSC_STARTUP_DELAY_MULTIPLIER

### DIFF
--- a/src/boards/include/boards/adafruit_feather_rp2350.h
+++ b/src/boards/include/boards/adafruit_feather_rp2350.h
@@ -16,6 +16,11 @@
 #ifndef _BOARDS_ADAFRUIT_FEATHER_RP2350_H
 #define _BOARDS_ADAFRUIT_FEATHER_RP2350_H
 
+// On some samples, the xosc can take longer to stabilize than is usual
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+#endif
+
 // For board detection
 #define ADAFRUIT_FEATHER_RP2350
 


### PR DESCRIPTION
- Fixes #2136.

Set `PICO_XOSC_STARTUP_DELAY_MULTIPLIER` in `boards/adafruit_feather_rp2350.h` to allow more time for XOSC to start.