### PR TITLE
Fix compilation of pico_double_test on llvm 15 - workaround compiler bug

### DIFF
--- a/test/pico_float_test/pico_double_test.c
+++ b/test/pico_float_test/pico_double_test.c
@@ -365,7 +365,13 @@ int main() {
         printf("EXP %10.18g\n", check_close1(exp, x));
         printf("LN %10.18g\n", check_close1(log, x));
         printf("POW %10.18f\n", check_close2(pow, x, x));
+#if LIB_PICO_DOUBLE_PICO && __clang_major__ == 15
+        // seem to be a compiler/linker bug here with calls to __real_trunc, so just call trunc rather than doing
+        // a closeness check - at least we will know that the call works
+        printf("TRUNC %10.18f\n", trunc(x));
+#else
         printf("TRUNC %10.18f\n", check_close1(trunc, x));
+#endif
         printf("LDEXP %10.18f\n", check_close2(ldexp, x, x));
         // todo come pack
     //    printf("FMOD %10.18f\n", check_close2(fmod, x, 3.0f));


### PR DESCRIPTION
Seems to be an optimization issue related to the double value being an actual integer and not needing truncating..