### PR TITLE
Add additional Bazel config tinyUSB and pico_stdio_usb

### DIFF
--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -186,6 +186,12 @@ int_flag(
     build_setting_default = 0,
 )
 
+# PICO_BAZEL_CONFIG: PICO_TINYUSB_CONFIG, [Bazel only] The library that provides TinyUSB config header (e.g. tusb_config.h), default=//src/rp2_common/pico_stdio_usb:tusb_config, group=build
+label_flag(
+    name = "PICO_TINYUSB_CONFIG",
+    build_setting_default = "//src/rp2_common/pico_stdio_usb:tusb_config",
+)
+
 # PICO_BAZEL_CONFIG: PICO_TINYUSB_LIB, [Bazel only] The library that provides TinyUSB, default=@tinyusb//:tinyusb, group=build
 label_flag(
     name = "PICO_TINYUSB_LIB",

--- a/src/rp2_common/pico_stdio_usb/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_usb/BUILD.bazel
@@ -24,6 +24,9 @@ cc_library(
     hdrs = ["include/tusb_config.h"],
     includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
+    deps = [
+        ":pico_stdio_usb_headers",
+    ],
 )
 
 pico_sdk_define(
@@ -43,10 +46,6 @@ cc_library(
     hdrs = ["include/pico/stdio_usb.h"],
     includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
-    visibility = [
-        ":__pkg__",
-        "//src/rp2_common/tinyusb:__pkg__",
-    ],
     deps = [
         ":LIB_PICO_STDIO_USB",
         ":PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS",

--- a/src/rp2_common/tinyusb/BUILD.bazel
+++ b/src/rp2_common/tinyusb/BUILD.bazel
@@ -15,6 +15,7 @@ cc_library(
     includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
     deps = [
+        "//bazel/config:PICO_TINYUSB_CONFIG",
         "//src/common/pico_binary_info",
         "//src/common/pico_stdlib_headers",
         "//src/common/pico_sync",
@@ -30,7 +31,6 @@ cc_library(
         "//src/rp2_common/pico_stdio_semihosting",
         "//src/rp2_common/pico_stdio_uart",
         "//src/rp2_common/pico_stdio_usb:pico_stdio_usb_headers",
-        "//src/rp2_common/pico_stdio_usb:tusb_config",
         "//src/rp2_common/pico_unique_id",
     ],
 )


### PR DESCRIPTION
This change the makes the following defines setable in Bazel:
- `LIB_TINYUSB_HOST`
- `LIB_TINYUSB_DEVICE`
- `PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE`
- `PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE`

This also adds `//bazel/config:PICO_TINYUSB_CONFIG`, which allows overriding the "tusb_config.h" header used to build tinyUSB. This might be used to add additional USB interfaces while preserving the functionality from pico_stdio_usb.
