### PR TITLE
Update Clang toolchain used by Bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,34 +54,34 @@ http_archive(
 http_archive(
     name = "clang_linux-x86_64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "dd4b3b0fc7186a4da2b52796b251e0757aefac4813f9f635982954fec3337d2e",
+    sha256 = "82302f8f0d9cb1062e60756147403c1525e965e1d7b777fab8076c74c7a5a19b",
     type = "zip",
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/linux-amd64/+/git_revision:9d3f9f47e6e630b8308562297757e0911be03a18",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/linux-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
 )
 
 http_archive(
     name = "clang_win-x86_64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "21092395df915ee5a899a832a592b137c9ea07fbc91e49ac6069ea0083d31899",
+    sha256 = "2e9b8ac889838754e5305b6fd73c7bba7a6ec7364f1ce8ac60268b6d3bc61e6c",
     type = "zip",
     # Windows doesn't like `:` in the produced filename, so replace it with `%3A`.
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/windows-amd64/+/git_revision:9d3f9f47e6e630b8308562297757e0911be03a18".replace("git_revision:", "git_revision%3A"),
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/windows-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c".replace("git_revision:", "git_revision%3A"),
 )
 
 http_archive(
     name = "clang_mac-x86_64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "bb397fdce21d068ea40fefa9618993baa4907a248f996f18316c8fa6ca24dee2",
+    sha256 = "d3f2ef6f391ef66141092cfdf07facd18d2587a25616e1251e6e6b13b05ab3df",
     type = "zip",
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-amd64/+/git_revision:9d3f9f47e6e630b8308562297757e0911be03a18",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
 )
 
 http_archive(
     name = "clang_mac-aarch64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "dad5583f96eabc913c1930d923c53a105d6ed73f56ca32451ea79ad70e495b0f",
+    sha256 = "61109b8464e9213ef8b9bfe55ce56298b94d4c66eaea308cf2b6556b0b85429e",
     type = "zip",
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:9d3f9f47e6e630b8308562297757e0911be03a18",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
 )
 
 new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")


### PR DESCRIPTION
* This includes an FMA issue fix that broke several math functions.