### PR TITLE
Correct type in comment in CMakeLists.txt

### DIFF
--- a/src/rp2_common/cmsis/CMakeLists.txt
+++ b/src/rp2_common/cmsis/CMakeLists.txt
@@ -44,7 +44,7 @@
 #    message(WARNING "Non-standard vendor ${PICO_CMSIS_VENDOR} amd device ${PICO_CMSIS_DEVICE} specified, but PICO_CMSIS_PATH was not set")
 #endif()
 
-# ... using these 3 lines instead
+# ... using this line instead
 set(PICO_CMSIS_CORE_PATH ${CMAKE_CURRENT_LIST_DIR}/stub)
 
 if (PICO_CMSIS_CORE_PATH AND PICO_CMSIS_DEVICE)


### PR DESCRIPTION
correct outdated comment after 2 lines were deleted, but comment was not
Fixes #2273

