### PR TITLE
Fixed linker error for lwIP PPP support (#2272)

### DIFF
--- a/src/rp2_common/pico_lwip/lwip_nosys.c
+++ b/src/rp2_common/pico_lwip/lwip_nosys.c
@@ -71,4 +71,8 @@ void sys_arch_unprotect(__unused sys_prot_t pval) {
 uint32_t sys_now(void) {
     return to_ms_since_boot(get_absolute_time());
 }
+
+__weak uint32_t sys_jiffies(void) {
+    return time_us_32();
+}
 #endif


### PR DESCRIPTION
Very straightforward, added `sys_jiffies` right under `sys_now`.

Left with weak linking in case someone wants to override the implementation.