### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
    
    When building for a board other than the Raspberry Pi Pico, you should pass `-DPICO_BOARD=board_name` to the `cmake` command above, e.g. `cmake -DPICO_BOARD=pico2 ..` or `cmake -DPICO_BOARD=pico_w ..` to configure the SDK and build options accordingly for that particular board.
 
-   Specifying `PICO_BOARD=<booardname>` sets up various compiler defines (e.g. default pin numbers for UART and other hardware) and in certain 
+   Specifying `PICO_BOARD=<boardname>` sets up various compiler defines (e.g. default pin numbers for UART and other hardware) and in certain 
    cases also enables the use of additional libraries (e.g. wireless support when building for `PICO_BOARD=pico_w`) which cannot
    be built without a board which provides the requisite hardware functionality.
 


### PR DESCRIPTION
Fix Issue #2288
 Correct spelling of boardname in README.md
 
 changing
 ```
 Specifying `PICO_BOARD=<booardname>`
 ```
 to
 ```
 Specifying `PICO_BOARD=<boardname>`
 ```