### PR TITLE
Add new feature defines to pico_stdio_usb

### DIFF
--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
@@ -44,10 +44,30 @@
 // this variable is no longer set by default (one is claimed dynamically), but will be respected if specified
 #endif
 
+// PICO_CONFIG: PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK, Enable/disable the use of a background task to call tud_task(), type=bool, default=1 if the application is not using tinyUSB directly, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK
+#if !LIB_TINYUSB_HOST && !LIB_TINYUSB_DEVICE
+#define PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK 1
+#else
+#define PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK 0
+#endif
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_ENABLE_TINYUSB_INIT, Enable/disable calling tinyUSB tusb_init() during initialization, type=bool, default=1 if the application is not using tinyUSB directly, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_ENABLE_TINYUSB_INIT
+#if !LIB_TINYUSB_HOST && !LIB_TINYUSB_DEVICE
+#define PICO_STDIO_USB_ENABLE_TINYUSB_INIT 1
+#else
+#define PICO_STDIO_USB_ENABLE_TINYUSB_INIT 0
+#endif
+#endif
+
 // PICO_CONFIG: PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE, Enable/disable resetting into BOOTSEL mode if the host sets the baud rate to a magic value (PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE), type=bool, default=1 if application is not using TinyUSB directly, group=pico_stdio_usb
 #ifndef PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE
-#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
+#if !LIB_TINYUSB_HOST && !LIB_TINYUSB_DEVICE
 #define PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE 1
+#else
+#define PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE 0
 #endif
 #endif
 
@@ -91,8 +111,10 @@
 
 // PICO_CONFIG: PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE, Enable/disable resetting into BOOTSEL mode via an additional VENDOR USB interface - enables picotool based reset, type=bool, default=1 if application is not using TinyUSB directly, group=pico_stdio_usb
 #ifndef PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
-#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
+#if !LIB_TINYUSB_HOST && !LIB_TINYUSB_DEVICE
 #define PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE 1
+#else
+#define PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE 0
 #endif
 #endif
 
@@ -114,6 +136,15 @@
 // PICO_CONFIG: PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS, Delay in ms before rebooting via regular flash boot, default=100, group=pico_stdio_usb
 #ifndef PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS
 #define PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS 100
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_USE_DEFAULT_DESCRIPTORS, Defines the default USB descriptors needed for USB communication, type=bool, default=1 if the application is not using tinyUSB directly, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_USE_DEFAULT_DESCRIPTORS
+#if !LIB_TINYUSB_HOST && !LIB_TINYUSB_DEVICE
+#define PICO_STDIO_USB_USE_DEFAULT_DESCRIPTORS 1
+#else
+#define PICO_STDIO_USB_USE_DEFAULT_DESCRIPTORS 0
+#endif
 #endif
 
 // PICO_CONFIG: PICO_STDIO_USB_CONNECTION_WITHOUT_DTR, Disable use of DTR for connection checking meaning connection is assumed to be valid, type=bool, default=0, group=pico_stdio_usb

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -26,8 +26,7 @@ static void (*chars_available_callback)(void*);
 static void *chars_available_param;
 #endif
 
-// when tinyusb_device is explicitly linked we do no background tud processing
-#if !LIB_TINYUSB_DEVICE
+#if PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK
 // if this crit_sec is initialized, we are not in periodic timer mode, and must make sure
 // we don't either create multiple one shot timers, or miss creating one. this crit_sec
 // is used to protect the one_shot_timer_pending flag
@@ -197,8 +196,8 @@ bool stdio_usb_init(void) {
     bi_decl_if_func_used(bi_program_feature("USB stdin / stdout"));
 #endif
 
-#if !defined(LIB_TINYUSB_DEVICE)
-    // initialize TinyUSB, as user hasn't explicitly linked it
+#if PICO_STDIO_USB_ENABLE_TINYUSB_INIT
+    // initialize TinyUSB
     tusb_init();
 #else
     assert(tud_inited()); // we expect the caller to have initialized if they are using TinyUSB
@@ -206,7 +205,7 @@ bool stdio_usb_init(void) {
 
     if (!mutex_is_initialized(&stdio_usb_mutex)) mutex_init(&stdio_usb_mutex);
     bool rc = true;
-#if !LIB_TINYUSB_DEVICE
+#if PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK
 #ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
     user_irq_claim(PICO_STDIO_USB_LOW_PRIORITY_IRQ);
 #else
@@ -265,7 +264,7 @@ bool stdio_usb_deinit(void) {
     sleep_ms(PICO_STDIO_USB_DEINIT_DELAY_MS);
 #endif
 
-#if !LIB_TINYUSB_DEVICE
+#if PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK
     if (irq_has_shared_handler(USBCTRL_IRQ)) {
         spin_lock_unclaim(spin_lock_get_num(one_shot_timer_crit_sec.spin_lock));
         critical_section_deinit(&one_shot_timer_crit_sec);

--- a/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
@@ -26,11 +26,12 @@
  * THE SOFTWARE.
  */
 
-#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
-
-#include "tusb.h"
+#include "pico/stdio_usb.h"
 #include "pico/stdio_usb/reset_interface.h"
 #include "pico/unique_id.h"
+#include "tusb.h"
+
+#if PICO_STDIO_USB_USE_DEFAULT_DESCRIPTORS
 
 #ifndef USBD_VID
 #define USBD_VID (0x2E8A) // Raspberry Pi


### PR DESCRIPTION
This change adds the following to pico_stdio_usb:
- `PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK`
- `PICO_STDIO_USB_ENABLE_TINYUSB_INIT`
- `PICO_STDIO_USB_USE_DEFAULT_DESCRIPTORS`

These defines replace some ifdefs that were previously gated by the `LIB_TINYUSB_DEVICE` define and will allow finer grained control. All of these defines default to 1 if LIB_TINYUSB_DEVICE is not defined and 0 if LIB_TINYUSB_DEVICE is defined, which should preserve the old behavior.
