### PR TITLE
Add new stdio_usb_call_chars_available_callback() function

### DIFF
--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
@@ -163,7 +163,7 @@ bool stdio_usb_deinit(void);
 bool stdio_usb_connected(void);
 
 #if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
-/*! \brief Explicitly runs the registered USB stdio chars_available_callback
+/*! \brief Explicitly calls the registered USB stdio chars_available_callback
  *  \ingroup pico_stdio_usb
  *
  * \ref This method is normally called by the internal USB stdio background thread when there is new USB CDC
@@ -171,7 +171,7 @@ bool stdio_usb_connected(void);
  * directly links tinyUSB), the user will need to implement their own background thread and call this
  * method directly.
  */
-void stdio_usb_run_chars_available_callback(void);
+void stdio_usb_call_chars_available_callback(void);
 #endif
 
 #ifdef __cplusplus

--- a/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
+++ b/src/rp2_common/pico_stdio_usb/include/pico/stdio_usb.h
@@ -161,6 +161,19 @@ bool stdio_usb_deinit(void);
  *  \return true if stdio is connected over CDC
  */
 bool stdio_usb_connected(void);
+
+#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+/*! \brief Explicitly runs the registered USB stdio chars_available_callback
+ *  \ingroup pico_stdio_usb
+ *
+ * \ref This method is normally called by the internal USB stdio background thread when there is new USB CDC
+ * data available to read. However, if the internal background thread is disabled (e.g. when the user
+ * directly links tinyUSB), the user will need to implement their own background thread and call this
+ * method directly.
+ */
+void stdio_usb_run_chars_available_callback(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -66,7 +66,7 @@ static void low_priority_worker_irq(void) {
 #endif
         mutex_exit(&stdio_usb_mutex);
 #if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
-        if (chars_avail && chars_available_callback) stdio_usb_run_chars_available_callback();
+        if (chars_avail && chars_available_callback) chars_available_callback(chars_available_param);
 #endif
     } else {
         // if the mutex is already owned, then we are in non IRQ code in this file.

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -172,7 +172,7 @@ void stdio_usb_set_chars_available_callback(void (*fn)(void*), void *param) {
     chars_available_param = param;
 }
 
-void stdio_usb_run_chars_available_callback(void) {
+void stdio_usb_call_chars_available_callback(void) {
     if (chars_available_callback) {
         chars_available_callback(chars_available_param);
     }

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -66,7 +66,7 @@ static void low_priority_worker_irq(void) {
 #endif
         mutex_exit(&stdio_usb_mutex);
 #if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
-        if (chars_avail && chars_available_callback) chars_available_callback(chars_available_param);
+        if (chars_avail && chars_available_callback) stdio_usb_run_chars_available_callback();
 #endif
     } else {
         // if the mutex is already owned, then we are in non IRQ code in this file.
@@ -170,6 +170,12 @@ int stdio_usb_in_chars(char *buf, int length) {
 void stdio_usb_set_chars_available_callback(void (*fn)(void*), void *param) {
     chars_available_callback = fn;
     chars_available_param = param;
+}
+
+void stdio_usb_run_chars_available_callback(void) {
+    if (chars_available_callback) {
+        chars_available_callback(chars_available_param);
+    }
 }
 #endif
 


### PR DESCRIPTION
When the user links in tinyUSB directly, the pico_stdio_usb library disables some of its functionality, including its built-in background processing thread. The user can implement their own background thread in order to continue using the stdio functionality, except that there is no wey to trigger the registered chars_available_callback. This commit adds a new `stdio_usb_calls_chars_available_callback()` method to allow user's background threads to call the callback.
