### PR TITLE
Add support for creating self-decrypting binaries

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -460,7 +460,8 @@ endfunction()
 # This sets the target property PICOTOOL_EMBED_DECRYPTION to TRUE.
 #
 # Optionally, use MBEDTLS to to use the MbedTLS based decryption stage - this
-# is faster, but less secure.
+# is faster, but offers no security against power or timing sniffing attacks,
+# and takes up more code size.
 # This sets the target property PICOTOOL_USE_MBEDTLS_DECRYPTION to TRUE.
 #
 # Optionally, use OTP_KEY_PAGE to specify the OTP page storing the AES key.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -42,6 +42,12 @@ define_property(TARGET
     FULL_DOCS "AES key for encrypting"
 )
 define_property(TARGET
+    PROPERTY PICOTOOL_EMBED_DECRYPTION
+    INHERITED
+    BRIEF_DOCS "Embed decryption stage into encrypted binary"
+    FULL_DOCS "Embed decryption stage into encrypted binary"
+)
+define_property(TARGET
     PROPERTY PICOTOOL_ENC_SIGFILE
     INHERITED
     BRIEF_DOCS "Private key for signing encrypted binaries"
@@ -424,7 +430,7 @@ endfunction()
 # \brief_nodesc\ Encrypt the taget binary
 #
 # Encrypt the target binary with the given AES key (should be a binary
-# file containing 32 bytes of a random key), and sign the encrypted binary.
+# file containing 128 bytes of a random key), and sign the encrypted binary.
 #
 # This sets the target properties PICOTOOL_AESFILE to AESFILE,
 # and PICOTOOL_ENC_SIGFILE to SIGFILE if present, else PICOTOOL_SIGFILE.
@@ -435,6 +441,37 @@ function(pico_encrypt_binary TARGET AESFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
         PICOTOOL_AESFILE ${AESFILE}
+    )
+    if (ARGC EQUAL 3)
+        set_target_properties(${TARGET} PROPERTIES
+            PICOTOOL_ENC_SIGFILE ${ARGV2}
+        )
+    else()
+        get_target_property(enc_sig_file ${TARGET} PICOTOOL_ENC_SIGFILE)
+        if (NOT enc_sig_file)
+            get_target_property(sig_file ${TARGET} PICOTOOL_SIGFILE)
+            if (NOT sig_file)
+                message(FATAL_ERROR "Signature file not set for ${TARGET}")
+            else()
+                set_target_properties(${TARGET} PROPERTIES
+                    PICOTOOL_ENC_SIGFILE ${sig_file}
+                )
+            endif()
+        endif()
+    endif()
+endfunction()
+
+# pico_create_decrypting_binary(TARGET AESFILE [SIGFILE])
+# Encrypt the target binary with the given AES key (should be a binary
+# file containing 128 bytes of a random key), add a decryption stage to
+# decrypt the binary at runtime, and then sign the encrypted binary.
+# This sets PICOTOOL_AESFILE to AESFILE, PICOTOOL_EMBED_DECRYPTION to TRUE,
+# and PICOTOOL_ENC_SIGFILE to SIGFILE if present, else PICOTOOL_SIGFILE.
+function(pico_create_decrypting_binary TARGET AESFILE)
+    picotool_check_configurable(${TARGET})
+    set_target_properties(${TARGET} PROPERTIES
+        PICOTOOL_AESFILE ${AESFILE}
+        PICOTOOL_EMBED_DECRYPTION TRUE
     )
     if (ARGC EQUAL 3)
         set_target_properties(${TARGET} PROPERTIES
@@ -595,9 +632,20 @@ function(picotool_postprocess_binary TARGET)
         endif()
         # Encryption
         if (picotool_aesfile)
+            get_target_property(picotool_embed_decryption ${TARGET} PICOTOOL_EMBED_DECRYPTION)
+            if (picotool_embed_decryption)
+                list(APPEND picotool_encrypt_args "--embed")
+            endif()
+
             add_custom_command(TARGET ${TARGET} POST_BUILD
                 DEPENDS ${picotool_enc_sigfile} ${picotool_aesfile}
-                COMMAND picotool encrypt --quiet --hash --sign $<TARGET_FILE:${TARGET}> $<TARGET_FILE:${TARGET}> ${picotool_aesfile} ${picotool_enc_sigfile}
+                COMMAND picotool
+                ARGS encrypt
+                    --quiet --hash --sign
+                    ${picotool_encrypt_args}
+                    $<TARGET_FILE:${TARGET}> $<TARGET_FILE:${TARGET}>
+                    ${picotool_aesfile} ${picotool_enc_sigfile}
+                COMMAND_EXPAND_LISTS
                 VERBATIM)
             if (ARGC EQUAL 2)
                 set(${ARGV1} TRUE PARENT_SCOPE)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -48,6 +48,12 @@ define_property(TARGET
     FULL_DOCS "Embed decryption stage into encrypted binary"
 )
 define_property(TARGET
+    PROPERTY PICOTOOL_OTP_KEY_PAGE
+    INHERITED
+    BRIEF_DOCS "OTP page storing the AES key"
+    FULL_DOCS "OTP page storing the AES key"
+)
+define_property(TARGET
     PROPERTY PICOTOOL_ENC_SIGFILE
     INHERITED
     BRIEF_DOCS "Private key for signing encrypted binaries"
@@ -426,7 +432,7 @@ function(pico_embed_pt_in_binary TARGET PTFILE)
     )
 endfunction()
 
-# pico_encrypt_binary(TARGET AESFILE [SIGFILE])
+# pico_encrypt_binary(TARGET AESFILE [SIGFILE <file>] [EMBED] [OTP_KEY_PAGE <page>])
 # \brief_nodesc\ Encrypt the taget binary
 #
 # Encrypt the target binary with the given AES key (should be a binary
@@ -435,47 +441,41 @@ endfunction()
 # This sets the target properties PICOTOOL_AESFILE to AESFILE,
 # and PICOTOOL_ENC_SIGFILE to SIGFILE if present, else PICOTOOL_SIGFILE.
 #
+# Optionally, use EMBED to embed a decryption stage into the encrypted binary.
+# This sets the target property PICOTOOL_EMBED_DECRYPTION to TRUE.
+#
+# Optionally, use OTP_KEY_PAGE to specify the OTP page storing the AES key.
+# This sets the target property PICOTOOL_OTP_KEY_PAGE to OTP_KEY_PAGE.
+#
 # \param\ AESFILE The AES key file to use
 # \param\ SIGFILE The PEM signature file to use
+# \param\ EMBED Embed a decryption stage into the encrypted binary
+# \param\ OTP_KEY_PAGE The OTP page storing the AES key
 function(pico_encrypt_binary TARGET AESFILE)
+    set(options EMBED)
+    set(oneValueArgs OTP_KEY_PAGE SIGFILE)
+    # set(multiValueArgs )
+    cmake_parse_arguments(PARSE_ARGV 2 ENC "${options}" "${oneValueArgs}" "${multiValueArgs}")
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
         PICOTOOL_AESFILE ${AESFILE}
     )
-    if (ARGC EQUAL 3)
-        set_target_properties(${TARGET} PROPERTIES
-            PICOTOOL_ENC_SIGFILE ${ARGV2}
-        )
-    else()
-        get_target_property(enc_sig_file ${TARGET} PICOTOOL_ENC_SIGFILE)
-        if (NOT enc_sig_file)
-            get_target_property(sig_file ${TARGET} PICOTOOL_SIGFILE)
-            if (NOT sig_file)
-                message(FATAL_ERROR "Signature file not set for ${TARGET}")
-            else()
-                set_target_properties(${TARGET} PROPERTIES
-                    PICOTOOL_ENC_SIGFILE ${sig_file}
-                )
-            endif()
-        endif()
-    endif()
-endfunction()
 
-# pico_create_decrypting_binary(TARGET AESFILE [SIGFILE])
-# Encrypt the target binary with the given AES key (should be a binary
-# file containing 128 bytes of a random key), add a decryption stage to
-# decrypt the binary at runtime, and then sign the encrypted binary.
-# This sets PICOTOOL_AESFILE to AESFILE, PICOTOOL_EMBED_DECRYPTION to TRUE,
-# and PICOTOOL_ENC_SIGFILE to SIGFILE if present, else PICOTOOL_SIGFILE.
-function(pico_create_decrypting_binary TARGET AESFILE)
-    picotool_check_configurable(${TARGET})
-    set_target_properties(${TARGET} PROPERTIES
-        PICOTOOL_AESFILE ${AESFILE}
-        PICOTOOL_EMBED_DECRYPTION TRUE
-    )
-    if (ARGC EQUAL 3)
+    if (ENC_EMBED)
         set_target_properties(${TARGET} PROPERTIES
-            PICOTOOL_ENC_SIGFILE ${ARGV2}
+            PICOTOOL_EMBED_DECRYPTION TRUE
+        )
+    endif()
+
+    if (ENC_OTP_KEY_PAGE)
+        set_target_properties(${TARGET} PROPERTIES
+            PICOTOOL_OTP_KEY_PAGE ${ENC_OTP_KEY_PAGE}
+        )
+    endif()
+
+    if (ENC_SIGFILE)
+        set_target_properties(${TARGET} PROPERTIES
+            PICOTOOL_ENC_SIGFILE ${ENC_SIGFILE}
         )
     else()
         get_target_property(enc_sig_file ${TARGET} PICOTOOL_ENC_SIGFILE)
@@ -635,6 +635,11 @@ function(picotool_postprocess_binary TARGET)
             get_target_property(picotool_embed_decryption ${TARGET} PICOTOOL_EMBED_DECRYPTION)
             if (picotool_embed_decryption)
                 list(APPEND picotool_encrypt_args "--embed")
+            endif()
+
+            get_target_property(otp_key_page ${TARGET} PICOTOOL_OTP_KEY_PAGE)
+            if (otp_key_page)
+                list(APPEND picotool_encrypt_args "--otp-key-page" ${otp_key_page})
             endif()
 
             add_custom_command(TARGET ${TARGET} POST_BUILD

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -448,7 +448,8 @@ endfunction()
 # \brief_nodesc\ Encrypt the taget binary
 #
 # Encrypt the target binary with the given AES key (should be a binary
-# file containing 128 bytes of a random key), and sign the encrypted binary.
+# file containing 128 bytes of a random key share, or 32 bytes of a random key),
+# and sign the encrypted binary.
 #
 # Salts the public IV with the provided IVFILE (should be a binary file
 # containing 16 bytes of a random IV), to give the IV used by the encryption.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -649,7 +649,7 @@ function(picotool_postprocess_binary TARGET)
                     --quiet --hash --sign
                     ${picotool_encrypt_args}
                     $<TARGET_FILE:${TARGET}> $<TARGET_FILE:${TARGET}>
-                    ${picotool_aesfile} ${picotool_enc_sigfile}
+                    ${picotool_aesfile} ${picotool_enc_sigfile} ${otp_file}
                 COMMAND_EXPAND_LISTS
                 VERBATIM)
             if (ARGC EQUAL 2)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -491,6 +491,14 @@ function(pico_encrypt_binary TARGET AESFILE IVFILE)
         set_target_properties(${TARGET} PROPERTIES
             PICOTOOL_EMBED_DECRYPTION TRUE
         )
+
+        # Embedded decryption stage only works with packaged binaries
+        get_target_property(uf2_package_addr ${TARGET} PICOTOOL_UF2_PACKAGE_ADDR)
+        if (NOT uf2_package_addr)
+            set_target_properties(${TARGET} PROPERTIES
+                PICOTOOL_UF2_PACKAGE_ADDR 0x10000000
+            )
+        endif()
     endif()
 
     if (ENC_MBEDTLS)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -54,6 +54,12 @@ define_property(TARGET
     FULL_DOCS "Embed decryption stage into encrypted binary"
 )
 define_property(TARGET
+    PROPERTY PICOTOOL_USE_MBEDTLS_DECRYPTION
+    INHERITED
+    BRIEF_DOCS "Use MbedTLS based decryption stage - this is faster, but not secure against power snooping"
+    FULL_DOCS "Use MbedTLS based decryption stage - this is faster, but not secure against power snooping"
+)
+define_property(TARGET
     PROPERTY PICOTOOL_OTP_KEY_PAGE
     INHERITED
     BRIEF_DOCS "OTP page storing the AES key"
@@ -438,7 +444,7 @@ function(pico_embed_pt_in_binary TARGET PTFILE)
     )
 endfunction()
 
-# pico_encrypt_binary(TARGET AESFILE IVFILE [SIGFILE <file>] [EMBED] [OTP_KEY_PAGE <page>])
+# pico_encrypt_binary(TARGET AESFILE IVFILE [SIGFILE <file>] [EMBED] [MBEDTLS] [OTP_KEY_PAGE <page>])
 # \brief_nodesc\ Encrypt the taget binary
 #
 # Encrypt the target binary with the given AES key (should be a binary
@@ -453,15 +459,21 @@ endfunction()
 # Optionally, use EMBED to embed a decryption stage into the encrypted binary.
 # This sets the target property PICOTOOL_EMBED_DECRYPTION to TRUE.
 #
+# Optionally, use MBEDTLS to to use the MbedTLS based decryption stage - this
+# is faster, but less secure.
+# This sets the target property PICOTOOL_USE_MBEDTLS_DECRYPTION to TRUE.
+#
 # Optionally, use OTP_KEY_PAGE to specify the OTP page storing the AES key.
 # This sets the target property PICOTOOL_OTP_KEY_PAGE to OTP_KEY_PAGE.
 #
 # \param\ AESFILE The AES key file to use
+# \param\ IVFILE The IV file to use
 # \param\ SIGFILE The PEM signature file to use
 # \param\ EMBED Embed a decryption stage into the encrypted binary
+# \param\ MBEDTLS Use MbedTLS based decryption stage (faster, but less secure)
 # \param\ OTP_KEY_PAGE The OTP page storing the AES key
 function(pico_encrypt_binary TARGET AESFILE IVFILE)
-    set(options EMBED)
+    set(options EMBED MBEDTLS)
     set(oneValueArgs OTP_KEY_PAGE SIGFILE)
     # set(multiValueArgs )
     cmake_parse_arguments(PARSE_ARGV 3 ENC "${options}" "${oneValueArgs}" "${multiValueArgs}")
@@ -476,6 +488,12 @@ function(pico_encrypt_binary TARGET AESFILE IVFILE)
     if (ENC_EMBED)
         set_target_properties(${TARGET} PROPERTIES
             PICOTOOL_EMBED_DECRYPTION TRUE
+        )
+    endif()
+
+    if (ENC_MBEDTLS)
+        set_target_properties(${TARGET} PROPERTIES
+            PICOTOOL_USE_MBEDTLS_DECRYPTION TRUE
         )
     endif()
 
@@ -651,6 +669,11 @@ function(picotool_postprocess_binary TARGET)
             get_target_property(picotool_embed_decryption ${TARGET} PICOTOOL_EMBED_DECRYPTION)
             if (picotool_embed_decryption)
                 list(APPEND picotool_encrypt_args "--embed")
+            endif()
+
+            get_target_property(picotool_mbedtls_decryption ${TARGET} PICOTOOL_USE_MBEDTLS_DECRYPTION)
+            if (picotool_mbedtls_decryption)
+                list(APPEND picotool_encrypt_args "--use-mbedtls")
             endif()
 
             get_target_property(otp_key_page ${TARGET} PICOTOOL_OTP_KEY_PAGE)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -42,6 +42,12 @@ define_property(TARGET
     FULL_DOCS "AES key for encrypting"
 )
 define_property(TARGET
+    PROPERTY PICOTOOL_IVFILE
+    INHERITED
+    BRIEF_DOCS "IV OTP salt for encrypting"
+    FULL_DOCS "IV OTP salt for encrypting"
+)
+define_property(TARGET
     PROPERTY PICOTOOL_EMBED_DECRYPTION
     INHERITED
     BRIEF_DOCS "Embed decryption stage into encrypted binary"
@@ -432,14 +438,17 @@ function(pico_embed_pt_in_binary TARGET PTFILE)
     )
 endfunction()
 
-# pico_encrypt_binary(TARGET AESFILE [SIGFILE <file>] [EMBED] [OTP_KEY_PAGE <page>])
+# pico_encrypt_binary(TARGET AESFILE IVFILE [SIGFILE <file>] [EMBED] [OTP_KEY_PAGE <page>])
 # \brief_nodesc\ Encrypt the taget binary
 #
 # Encrypt the target binary with the given AES key (should be a binary
 # file containing 128 bytes of a random key), and sign the encrypted binary.
 #
-# This sets the target properties PICOTOOL_AESFILE to AESFILE,
-# and PICOTOOL_ENC_SIGFILE to SIGFILE if present, else PICOTOOL_SIGFILE.
+# Salts the public IV with the provided IVFILE (should be a binary file
+# containing 16 bytes of a random IV), to give the IV used by the encryption.
+#
+# This sets the target properties PICOTOOL_AESFILE to AESFILE, PICOTOOL_IVFILE to IVFILE, and
+# PICOTOOL_ENC_SIGFILE to SIGFILE if specified, else PICOTOOL_SIGFILE.
 #
 # Optionally, use EMBED to embed a decryption stage into the encrypted binary.
 # This sets the target property PICOTOOL_EMBED_DECRYPTION to TRUE.
@@ -451,14 +460,17 @@ endfunction()
 # \param\ SIGFILE The PEM signature file to use
 # \param\ EMBED Embed a decryption stage into the encrypted binary
 # \param\ OTP_KEY_PAGE The OTP page storing the AES key
-function(pico_encrypt_binary TARGET AESFILE)
+function(pico_encrypt_binary TARGET AESFILE IVFILE)
     set(options EMBED)
     set(oneValueArgs OTP_KEY_PAGE SIGFILE)
     # set(multiValueArgs )
-    cmake_parse_arguments(PARSE_ARGV 2 ENC "${options}" "${oneValueArgs}" "${multiValueArgs}")
+    cmake_parse_arguments(PARSE_ARGV 3 ENC "${options}" "${oneValueArgs}" "${multiValueArgs}")
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
         PICOTOOL_AESFILE ${AESFILE}
+    )
+    set_target_properties(${TARGET} PROPERTIES
+        PICOTOOL_IVFILE ${IVFILE}
     )
 
     if (ENC_EMBED)
@@ -592,6 +604,10 @@ function(picotool_postprocess_binary TARGET)
     if (picotool_aesfile)
         pico_add_link_depend(${TARGET} ${picotool_aesfile})
     endif()
+    get_target_property(picotool_ivfile ${TARGET} PICOTOOL_IVFILE)
+    if (picotool_ivfile)
+        pico_add_link_depend(${TARGET} ${picotool_ivfile})
+    endif()
     get_target_property(picotool_enc_sigfile ${TARGET} PICOTOOL_ENC_SIGFILE)
     if (picotool_enc_sigfile)
         pico_add_link_depend(${TARGET} ${picotool_enc_sigfile})
@@ -631,7 +647,7 @@ function(picotool_postprocess_binary TARGET)
             VERBATIM)
         endif()
         # Encryption
-        if (picotool_aesfile)
+        if (picotool_aesfile AND picotool_ivfile)
             get_target_property(picotool_embed_decryption ${TARGET} PICOTOOL_EMBED_DECRYPTION)
             if (picotool_embed_decryption)
                 list(APPEND picotool_encrypt_args "--embed")
@@ -643,13 +659,13 @@ function(picotool_postprocess_binary TARGET)
             endif()
 
             add_custom_command(TARGET ${TARGET} POST_BUILD
-                DEPENDS ${picotool_enc_sigfile} ${picotool_aesfile}
+                DEPENDS ${picotool_enc_sigfile} ${picotool_aesfile} ${picotool_ivfile}
                 COMMAND picotool
                 ARGS encrypt
                     --quiet --hash --sign
                     ${picotool_encrypt_args}
                     $<TARGET_FILE:${TARGET}> $<TARGET_FILE:${TARGET}>
-                    ${picotool_aesfile} ${picotool_enc_sigfile} ${otp_file}
+                    ${picotool_aesfile} ${picotool_ivfile} ${picotool_enc_sigfile} ${otp_file}
                 COMMAND_EXPAND_LISTS
                 VERBATIM)
             if (ARGC EQUAL 2)


### PR DESCRIPTION
This adds extra functionality to the `pico_encrypt_binary` function to allow creating self-decrypting binaries, including specifying the OTP page to use for the AES key.

```cmake
pico_encrypt_binary(hello_encrypted
    ${CMAKE_CURRENT_LIST_DIR}/privateaes.bin
    ${CMAKE_CURRENT_LIST_DIR}/ivsalt.bin
    EMBED
    OTP_KEY_PAGE 29)
```

The main non-backwards-compatible change is the addition of a new IV salt bin file which is required and must be passed as the second argument. This will break any uses of `pico_encrypt_binary`, and has been added for security purposes, as we now salt the public IV with a salt stored in OTP.

The other non-backwards-compatible change it that if you previously called:
```cmake
pico_encrypt_binary(my_target my_aesfile.bin my_sigfile.pem)
```
you now need to call
```cmake
pico_encrypt_binary(my_target my_aesfile.bin my_iv_salt.bin SIGFILE my_sigfile.pem)
```
due to the new argument parsing. I think that this is fine, because the only time you'd pass a separated `SIGFILE` to `pico_encrypt_binary` is when you're using a different signing key for the binary vs the encrypted blob, which is not a common use case.

This PR requires use of the picotool encrypted-shares branch (https://github.com/raspberrypi/picotool/pull/207), so should be merged after that.