### PR TITLE
Fix #2253  cybt_printf by wrapping with NDEBUG

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus.c
+++ b/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus.c
@@ -39,7 +39,11 @@ extern const int     brcm_patch_ram_length;
 #else
 #define cybt_debug(format, ...) ((void)0)
 #endif
+#ifndef NDEBUG
 #define cybt_printf(format, args...) printf("%d.%d: " format, (int)cyw43_hal_ticks_ms() / 1000, (int)cyw43_hal_ticks_ms() % 1000, ## args)
+#else
+#define cybt_printf(...)
+#endif
 
 #define ROUNDUP(x, a)               ((((x) + ((a) - 1)) / (a)) * (a))
 #define ROUNDDN(x, a)               ((x) & ~((a) - 1))


### PR DESCRIPTION
Observe that src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus_driver.c 
wraps the definition of cybt_printf with #ifndef NDEBUG 
Apply this to src/rp2_common/pico_cyw43_driver/cybt_shared_bus/cybt_shared_bus.c

