### PR TITLE
Fix pioasm generating an enum member which doesn't match pio.h

### DIFF
--- a/tools/pioasm/c_sdk_output.cpp
+++ b/tools/pioasm/c_sdk_output.cpp
@@ -139,7 +139,7 @@ struct c_sdk_output : public output_format {
                 const char *types[] = {
                         "STATUS_TX_LESSTHAN",
                         "STATUS_RX_LESSTHAN",
-                        "STATUS_IRQ_INDEX",
+                        "STATUS_IRQ_SET",
                 };
                 if (program.mov_status_type < 0 || program.mov_status_type >= 3) {
                     throw std::runtime_error("unknown mov_status type");


### PR DESCRIPTION
When including the `.mov_status` directive to configure STATUS based on an IRQ flag (ex: `.mov_status irq set 0`), pioasm generates code with a reference to "STATUS_IRQ_INDEX", but this is different from the member name as defined in [pio.h](https://github.com/raspberrypi/pico-sdk/blob/ee68c78d0afae2b69c03ae1a72bf5cc267a2d94c/src/rp2_common/hardware_pio/include/hardware/pio.h#L126).

This generated the following code:
```
sm_config_set_mov_status(&c, STATUS_IRQ_INDEX, 0);
```
And thus caused the compile error:
```
error: 'STATUS_IRQ_INDEX' undeclared (first use in this function); did you mean 'STATUS_IRQ_SET'?
```
This fix changes the generated name so it matches the enum.