### PR TITLE
Fix misleading error messages in spin_lock.h

### DIFF
--- a/src/rp2_common/hardware_sync_spin_lock/include/hardware/sync/spin_lock.h
+++ b/src/rp2_common/hardware_sync_spin_lock/include/hardware/sync/spin_lock.h
@@ -149,7 +149,7 @@ typedef SW_SPIN_LOCK_TYPE spin_lock_t;
     __mem_fence_acquire();                                                      \
     })
 #else
-#error no SW_SPIN_TRY_LOCK available for PICO_USE_SW_SPIN_LOCK on this platform
+#error no SW_SPIN_LOCK_LOCK available for PICO_USE_SW_SPIN_LOCK on this platform
 #endif
 #endif
 
@@ -210,7 +210,7 @@ typedef SW_SPIN_LOCK_TYPE spin_lock_t;
     *(lock) = 0; /* write to spinlock register (release lock) */  \
     })
 #else
-#error no SW_SPIN_TRY_LOCK available for PICO_USE_SW_SPIN_LOCK on this platform
+#error no SW_SPIN_LOCK_UNLOCK available for PICO_USE_SW_SPIN_LOCK on this platform
 #endif
 #endif
 


### PR DESCRIPTION
(looks like this was a copy-paste mistake)