### PR TITLE
rp2350/pad_checksum: fix set cpu

### DIFF
--- a/src/rp2350/boot_stage2/pad_checksum
+++ b/src/rp2350/boot_stage2/pad_checksum
@@ -44,7 +44,7 @@ odata = idata + bytes(args.pad - len(idata))
 with open(args.ofile, "w") as ofile:
     ofile.write("// Padded and checksummed version of: {}\n\n".format(args.ifile))
     if args.arch == "arm":
-        ofile.write(".cpu cortex-m0plus\n")
+        ofile.write(".cpu cortex-m33\n")
         ofile.write(".thumb\n\n")
     ofile.write(".section .boot2, \"ax\"\n\n")
     ofile.write(".global __boot2_entry_point\n")


### PR DESCRIPTION
See #2334 

This PR should hopefully fix the incorrect cpu for the rp2350 in the pad_checksum function.