### PR TITLE
Fix variable pathname spacing

### DIFF
--- a/external/pico_sdk_import.cmake
+++ b/external/pico_sdk_import.cmake
@@ -26,7 +26,7 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
-    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    set(PICO_SDK_PATH "$ENV{PICO_SDK_PATH}")
     message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
 endif ()
 
@@ -36,7 +36,7 @@ if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
 endif ()
 
 if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
-    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    set(PICO_SDK_FETCH_FROM_GIT_PATH "$ENV{PICO_SDK_FETCH_FROM_GIT_PATH}")
     message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
 endif ()
 
@@ -58,7 +58,7 @@ set(PICO_SDK_FETCH_FROM_GIT_TAG "${PICO_SDK_FETCH_FROM_GIT_TAG}" CACHE FILEPATH 
 if (NOT PICO_SDK_PATH)
     if (PICO_SDK_FETCH_FROM_GIT)
         include(FetchContent)
-        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        set(FETCHCONTENT_BASE_DIR_SAVE "${FETCHCONTENT_BASE_DIR}")
         if (PICO_SDK_FETCH_FROM_GIT_PATH)
             get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
         endif ()
@@ -96,9 +96,9 @@ if (NOT PICO_SDK_PATH)
                 )
             endif ()
 
-            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+            set(PICO_SDK_PATH "${pico_sdk_SOURCE_DIR}")
         endif ()
-        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+        set(FETCHCONTENT_BASE_DIR "${FETCHCONTENT_BASE_DIR_SAVE}")
     else ()
         message(FATAL_ERROR
                 "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
@@ -107,15 +107,15 @@ if (NOT PICO_SDK_PATH)
 endif ()
 
 get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
-if (NOT EXISTS ${PICO_SDK_PATH})
+if (NOT EXISTS "${PICO_SDK_PATH}")
     message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
 endif ()
 
-set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
-if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+set(PICO_SDK_INIT_CMAKE_FILE "${PICO_SDK_PATH}/pico_sdk_init.cmake")
+if (NOT EXISTS "${PICO_SDK_INIT_CMAKE_FILE}")
     message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
 endif ()
 
-set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
 
-include(${PICO_SDK_INIT_CMAKE_FILE})
+include("${PICO_SDK_INIT_CMAKE_FILE}")


### PR DESCRIPTION
Fixes #1043 (additional fixes, this time for `external/pico_sdk_import.cmake`).

Some pathname spacing (and special characters) still causes issues.
Related to [this pull request](https://github.com/raspberrypi/debugprobe/pull/164) from [raspberrypi/debugprobe](https://github.com/raspberrypi/debugprobe).

I'm not 100% sure about this pull request because I couldn't replicate the issue with pico-sdk, but since I had this issue with downstream and these fixes worked (and for consistency), I figured it was worth pushing the changes upstream anyway. 