### PR TITLE
Move unique_id (configurably) earlier in the static init process

### DIFF
--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -42,6 +42,28 @@ extern "C" {
 #define PICO_UNIQUE_BOARD_ID_SIZE_BYTES 8
 
 /**
+ * \brief Static initialization order
+ * \ingroup pico_unique_id
+ *
+ * This defines the init_priority of the pico_unique_id. By default, it is 1000. The valid range is
+ * from 101-65535. Set to -1 to set the priority to none, thus putting it after 65535. Changing
+ * This value will initialize the unique_id earlier or later in the static initialization order.
+ * This is most useful for C++ consumers of the pico-sdk.
+ *
+ * See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-constructor-function-attribute
+ * and https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html#index-init_005fpriority-variable-attribute
+ *
+ * This is an example C++ static initializer that will to run before, and then after pico_unique_id:
+ *
+ * [[gnu::init_priority(500)]] my_class before_instance;
+ * [[gnu::init_priority(2000)]] my_class after_instance;
+ *
+ */
+#ifndef PICO_UNIQUE_BOARD_ID_INIT_PRIORITY
+#define PICO_UNIQUE_BOARD_ID_INIT_PRIORITY 1000
+#endif
+
+/**
  * \brief Unique board identifier
  * \ingroup pico_unique_id
  *

--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -46,14 +46,14 @@ extern "C" {
  * \ingroup pico_unique_id
  *
  * This defines the init_priority of the pico_unique_id. By default, it is 1000. The valid range is
- * from 101-65535. Set to -1 to set the priority to none, thus putting it after 65535. Changing
- * This value will initialize the unique_id earlier or later in the static initialization order.
+ * from 101-65535. Set it to -1 to set the priority to none, thus putting it after 65535. Changing
+ * this value will initialize the unique_id earlier or later in the static initialization order.
  * This is most useful for C++ consumers of the pico-sdk.
  *
  * See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-constructor-function-attribute
  * and https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html#index-init_005fpriority-variable-attribute
  *
- * This is an example C++ static initializer that will to run before, and then after pico_unique_id:
+ * Here is an example of C++ static initializers that will run before, and then after, pico_unique_id is loaded:
  *
  * [[gnu::init_priority(500)]] my_class before_instance;
  * [[gnu::init_priority(2000)]] my_class after_instance;

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -12,7 +12,13 @@ static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES <= FLASH_UNIQUE_ID_SIZE_BYTES, "Bo
 
 static pico_unique_board_id_t retrieved_id;
 
-static void __attribute__((constructor)) _retrieve_unique_id_on_boot(void) {
+#if PICO_UNIQUE_BOARD_ID_INIT_PRIORITY == -1
+#define PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES constructor
+#else
+#define PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES constructor(PICO_UNIQUE_BOARD_ID_INIT_PRIORITY)
+#endif
+
+static void __attribute__((PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES)) _retrieve_unique_id_on_boot(void) {
 #if PICO_RP2040
     #if PICO_NO_FLASH
         // The hardware_flash call will panic() if called directly on a NO_FLASH


### PR DESCRIPTION
Fixes #2373

Move unique_id (configurably) earlier in the static initialization process . This enables using the unique_id in C++ static initializers by default, and avoid the static initialization order fiasco.

I added the configuration in the off chance that someone would need to adjust it, but I think 1000 is probably a good-enough default. Values range from 101-65535, or "none", which is after 65535. Normal C++ static initializers are "none". Users can still manually specify to be earlier (101-999) without any configuration changes, via any of the following:

```cxx
// C  & C++
__attribute__((constructor(101))) some_function() {}
// C++ only
__attribute__((init_priority(101))) some_class instance;
[[gnu::init_priority(101)]] some_class instance;
```

The following will all be initialized after unique_id is initialized, by default

```cxx
// C  & C++
__attribute__((constructor(1001))) some_function() {}
__attribute__((constructor)) some_function() {}
// C++ only
__attribute__((init_priority(1001))) some_class instance;
[[gnu::init_priority(1001)]] some_class instance;
some_class instance;
```