### PR TITLE
Properly respect setting PICO_DEFAULT_BINARY_TYPE

### DIFF
--- a/src/rp2_common/pico_standard_link/CMakeLists.txt
+++ b/src/rp2_common/pico_standard_link/CMakeLists.txt
@@ -59,7 +59,6 @@ if (NOT TARGET pico_standard_link)
         (PICO_COPY_TO_RAM AND PICO_NO_FLASH))
         message(FATAL_ERROR "Conflicting binary types specified amongst PICO_DEFAULT_BINARY_TYPE, PICO_NO_FLASH, PICO_USE_BLOCKED_RAM and PICO_COPY_TO_RAM")
     endif()
-    unset(_BINARY_TYPES_SPECIFIED)
 
     # todo only needed if not using a custom linker script
     if (NOT PICO_LINKER_SCRIPT_PATH)

--- a/src/rp2_common/pico_standard_link/CMakeLists.txt
+++ b/src/rp2_common/pico_standard_link/CMakeLists.txt
@@ -30,6 +30,7 @@ if (NOT TARGET pico_standard_link)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_BINARY_TYPE ${TYPE})
     endfunction()
 
+    # slightly messy as we support both the preferred PICO_DEFAULT_BINARY_TYPE and the individual variables
     if (NOT PICO_DEFAULT_BINARY_TYPE)
         if (PICO_NO_FLASH)
             set(PICO_DEFAULT_BINARY_TYPE no_flash)
@@ -40,7 +41,25 @@ if (NOT TARGET pico_standard_link)
         else()
             set(PICO_DEFAULT_BINARY_TYPE default)
         endif()
+    else()
+        # we must set the individual variables here, as they are used in generator expressions,
+        # but also for our checks below
+        if (PICO_DEFAULT_BINARY_TYPE STREQUAL no_flash)
+            set(PICO_NO_FLASH 1)
+        endif()
+        if (PICO_DEFAULT_BINARY_TYPE STREQUAL blocked_ram)
+            set(PICO_USE_BLOCKED_RAM 1)
+        endif()
+        if (PICO_DEFAULT_BINARY_TYPE STREQUAL copy_to_ram)
+            set(PICO_COPY_TO_RAM 1)
+        endif()
     endif()
+    if ((PICO_NO_FLASH AND PICO_USE_BLOCKED_RAM) OR
+        (PICO_USE_BLOCKED_RAM AND PICO_COPY_TO_RAM) OR
+        (PICO_COPY_TO_RAM AND PICO_NO_FLASH))
+        message(FATAL_ERROR "Conflicting binary types specified amongst PICO_DEFAULT_BINARY_TYPE, PICO_NO_FLASH, PICO_USE_BLOCKED_RAM and PICO_COPY_TO_RAM")
+    endif()
+    unset(_BINARY_TYPES_SPECIFIED)
 
     # todo only needed if not using a custom linker script
     if (NOT PICO_LINKER_SCRIPT_PATH)


### PR DESCRIPTION
`PICO_DEFAULT_BINARY_TYPE=no_flash` fir example did not define`PICO_NO_FLASH` for the compiler

This commit also adds a build error for specifying different types simultaneously
