### PR TITLE
move irq_has_handler() so it can be used without shared handlers

### DIFF
--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -196,12 +196,6 @@ static inline bool is_shared_irq_raw_handler(irq_handler_t raw_handler) {
     return (uintptr_t)raw_handler - (uintptr_t)irq_handler_chain_slots < sizeof(irq_handler_chain_slots);
 }
 
-bool irq_has_handler(uint irq_num) {
-    check_irq_param(irq_num);
-    irq_handler_t handler = irq_get_vtable_handler(irq_num);
-    return handler && handler != __unhandled_user_irq;
-}
-
 bool irq_has_shared_handler(uint irq_num) {
     check_irq_param(irq_num);
     irq_handler_t handler = irq_get_vtable_handler(irq_num);
@@ -223,10 +217,15 @@ bool irq_has_shared_handler(uint irq_num) {
 }
 #endif
 
-
 irq_handler_t irq_get_vtable_handler(uint num) {
     check_irq_param(num);
     return get_vtable()[VTABLE_FIRST_IRQ + num];
+}
+
+bool irq_has_handler(uint irq_num) {
+    check_irq_param(irq_num);
+    irq_handler_t handler = irq_get_vtable_handler(irq_num);
+    return handler && handler != __unhandled_user_irq;
 }
 
 void irq_set_exclusive_handler(uint num, irq_handler_t handler) {


### PR DESCRIPTION
fixes #2353 