### PR TITLE
Fix WindowsCI (again)

### DIFF
--- a/.github/workflows/choco_packages.config
+++ b/.github/workflows/choco_packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="gcc-arm-embedded" version="10.2.1" />
   <package id="mingw" version="12.2.0" />
-  <package id="ninja" version="1.11.1" />
+  <package id="ninja" version="1.12.1" />
 </packages>


### PR DESCRIPTION
Use newer version of ninja

https://github.com/raspberrypi/pico-sdk/commit/bb5b5f96e2bfca6baaa5604bea5408b5f0e9d5c2 failed on Windows CI with:
```
 - ninja - A newer version of ninja (v1.12.1) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
Error: Process completed with exit code 1.
```

However the preceding commit https://github.com/raspberrypi/pico-sdk/commit/a5ba689cb551cb36583619e0d57811ad98192f1b passed Windows CI just fine.

A bit of investigation reveals that the passing commit used GitHub runner image https://github.com/actions/runner-images/blob/win22/20250309.1/images/windows/Windows2022-Readme.md (which _doesn't_ have `ninja` pre-installed) whereas the failing commit used GitHub runner image https://github.com/actions/runner-images/blob/win22/20250324.3/images/windows/Windows2022-Readme.md which has Ninja 1.12.1 pre-installed.

I don't think that we can assume that ninja is pre-installed on **all** GiitHub runner images yet, so rather than removing it from `choco_packages.config` (i.e. similar to what was done in #2241 ), just update the ninja install to a matching version instead, to hopefully suppress the "A newer version of ninja is already installed" error.