### PR TITLE
Fix bug in extract_configs.py

### DIFF
--- a/tools/extract_configs.py
+++ b/tools/extract_configs.py
@@ -241,6 +241,7 @@ for applicable, all_defines in chips_all_defines.items():
 
 for applicable, all_configs in chips_all_configs.items():
     all_defines = chips_all_defines[applicable]
+    resolved_defines = chips_resolved_defines[applicable]
     for config_name, config_obj in all_configs.items():
         file_path = os.path.join(scandir, config_obj['filename'])
         linenum = config_obj['line_number']


### PR DESCRIPTION
This bug was actually introduced by #1845 , but I never noticed until now because it depended on which order the filesystem traversed the directories