### PR TITLE
Fix sign conversion error introduced by #2233

### DIFF
--- a/src/rp2_common/pico_runtime_init/runtime_init.c
+++ b/src/rp2_common/pico_runtime_init/runtime_init.c
@@ -216,7 +216,7 @@ void runtime_init_install_ram_vector_table(void) {
 #if !(PICO_NO_RAM_VECTOR_TABLE || PICO_NO_FLASH)
     extern uint32_t __vectors;
     extern uint32_t __vectors_end;
-    uint32_t stored_words = &__vectors_end - &__vectors;
+    uint32_t stored_words = (uint32_t)(&__vectors_end - &__vectors);
     __builtin_memcpy(ram_vector_table, &__vectors, 4 * MIN(stored_words, PICO_RAM_VECTOR_TABLE_SIZE));
     for(uint i = stored_words; i<count_of(ram_vector_table); i++) {
         ram_vector_table[i] = (uintptr_t)__unhandled_user_irq;


### PR DESCRIPTION
The changes to runtime_init in #2233 have introduced an error, which is failing CI runs on pico-examples (https://github.com/raspberrypi/pico-examples/actions/runs/14169572195/job/39690172401)

This is the simplest fix, to explicitly cast it as a uint32_t - there shouldn't be any actual overflow issues, because `__vectors_end` should always be after `__vectors`