### PR TITLE
Add pioasm c++ constexpr output target

### DIFF
--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(pioasm
 target_sources(pioasm PRIVATE c_sdk_output.cpp)
 target_sources(pioasm PRIVATE python_output.cpp)
 target_sources(pioasm PRIVATE hex_output.cpp)
+target_sources(pioasm PRIVATE constexpr_output.cpp)
 target_sources(pioasm PRIVATE json_output.cpp)
 target_sources(pioasm PRIVATE ada_output.cpp)
 target_sources(pioasm PRIVATE go_output.cpp)

--- a/tools/pioasm/constexpr_output.cpp
+++ b/tools/pioasm/constexpr_output.cpp
@@ -15,7 +15,7 @@ struct constexpr_output : public output_format {
     constexpr_output() : output_format("constexpr") {}
 
     std::string get_description() {
-        return "c++ constexpr array output (only raw program are output) ";
+        return "c++ constexpr array output (only raw programs are output) ";
     }
 
     virtual int output(std::string destination,

--- a/tools/pioasm/constexpr_output.cpp
+++ b/tools/pioasm/constexpr_output.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "output_format.h"
+#include "pio_disassembler.h"
+
+struct constexpr_output : public output_format {
+    struct factory {
+        factory() { output_format::add(new constexpr_output()); }
+    };
+
+    constexpr_output() : output_format("constexpr") {}
+
+    std::string get_description() {
+        return "c++ constexpr array output (only raw program are output) ";
+    }
+
+    virtual int output(std::string destination,
+                       std::vector<std::string> output_options,
+                       const compiled_source &source) {
+        FILE *out = open_single_output(destination);
+        if (!out)
+            return 1;
+
+        fprintf(out, "#pragma once\n\n");
+        fprintf(out, "#include <array>\n");
+        fprintf(out, "#include <cstdint>\n\n");
+
+        fprintf(out, "namespace Pioasm {\n\n");
+
+        for (auto &p : source.programs) {
+            fprintf(out, "inline constexpr std::array<uint16_t, %lu> %s = {\n",
+                    p.instructions.size(), p.name.c_str());
+            for (auto i = 0u; i < p.instructions.size(); ++i) {
+                const auto &inst = p.instructions[i];
+                if (i == p.wrap_target) {
+                    fprintf(out, "            //     .wrap_target\n");
+                }
+                fprintf(out, "    0x%04x, // %2d: %s\n", inst, i,
+                        disassemble(inst, p.sideset_bits_including_opt.get(),
+                                    p.sideset_opt)
+                            .c_str());
+                if (i == p.wrap) {
+                    fprintf(out, "            //     .wrap\n");
+                }
+            }
+            fprintf(out, "};\n\n");
+        }
+
+        fprintf(out, "}");
+
+        if (out != stdout) {
+            fclose(out);
+        }
+        return 0;
+    }
+};
+
+static constexpr_output::factory creator;


### PR DESCRIPTION
Adds pioasm output that creates a c++ header file with a `constexpr` `std::array` containing the raw instructions.

Similar to the hex output option, only the raw instructions are generated. However, unlike the hex output option, multiple programs are supported in a single pio source file, with a `std::array` generated for each one.

One thing I'm unsure of is what namespace to put the generated arrays in. I went with "Pioasm" here but we could also go with "PIOInstructions" or something else entirely.

Input example: "ws2812.pio"
```
.program ws2812 
.side_set 1

.wrap_target
bitloop:
    out x, 1       side 0 [2];
    jmp !x do_zero side 1 [1];
do_one:
    jmp  bitloop   side 1 [4];
do_zero:
    nop            side 0 [4];
.wrap
```

`pioasm -o constexpr "ws2812.pio.hpp" "ws2812.pio"`

Output: "ws2812.pio.hpp"
```
#pragma once

#include <array>
#include <cstdint>

namespace Pioasm {

inline constexpr std::array<uint16_t, 4> ws2812 = {
            //     .wrap_target
    0x6221, //  0: out    x, 1            side 0 [2]
    0x1123, //  1: jmp    !x, 3           side 1 [1]
    0x1400, //  2: jmp    0               side 1 [4]
    0xa442, //  3: nop                    side 0 [4]
            //     .wrap
};

}
```