### PR TITLE
Lock picotool version on master to 2.1.1

### DIFF
--- a/tools/Findpicotool.cmake
+++ b/tools/Findpicotool.cmake
@@ -37,7 +37,7 @@ if (NOT TARGET picotool)
         message("Downloading Picotool")
         FetchContent_Populate(picotool QUIET
             GIT_REPOSITORY https://github.com/raspberrypi/picotool.git
-            GIT_TAG develop
+            GIT_TAG 2.1.1
 
             SOURCE_DIR ${picotool_INSTALL_DIR}/picotool-src
             BINARY_DIR ${picotool_INSTALL_DIR}/picotool-build


### PR DESCRIPTION
The master SDK branch (and the SDK release tags eg 2.1.1) should point to specific picotool tags, to ensure you get a compatible picotool - currently it points to the `develop` branch of picotool

This has been set to `develop` for the 2.1.0 and 2.1.1 releases, so those releases may break in the future if `picotool` loses backwards compatibility (eg SDK header movement, or changes to `picotool` commands)