### PR TITLE
Fix DST bug in aon_timer_get_time for rp2040

### DIFF
--- a/src/common/pico_util/datetime.c
+++ b/src/common/pico_util/datetime.c
@@ -63,6 +63,7 @@ void datetime_to_tm(const datetime_t *dt, struct tm *tm) {
     tm->tm_hour = dt->hour;
     tm->tm_min = dt->min;
     tm->tm_sec = dt->sec;
+    tm->tm_isdst  = -1;
 }
 
 void tm_to_datetime(const struct tm *tm, datetime_t *dt) {


### PR DESCRIPTION
If you set the timezone, aon_timer_get_time can wrongly apply a daylight saving time adjustment based on the stack contents. This can make it appear that time has gone backwards.

Make sure datetime_to_tm initialises tm_isdst to -1.

Fixes #2374
