### PR TITLE
Change BT flash storage default for rp2350 A2

### DIFF
--- a/src/rp2_common/pico_btstack/include/pico/btstack_flash_bank.h
+++ b/src/rp2_common/pico_btstack/include/pico/btstack_flash_bank.h
@@ -20,16 +20,24 @@ extern "C" {
 #define PICO_FLASH_BANK_TOTAL_SIZE (FLASH_SECTOR_SIZE * 2u)
 #endif
 
-// PICO_CONFIG: PICO_FLASH_BANK_STORAGE_OFFSET, Offset in flash of the Bluetooth flash storage, type=int, default=PICO_FLASH_SIZE_BYTES - PICO_FLASH_BANK_TOTAL_SIZE, group=pico_btstack
+// PICO_CONFIG: PICO_FLASH_BANK_STORAGE_OFFSET, Offset in flash of the Bluetooth flash storage, type=int, default=PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE - PICO_FLASH_BANK_TOTAL_SIZE on RP2350 otherwise PICO_FLASH_SIZE_BYTES - PICO_FLASH_BANK_TOTAL_SIZE, group=pico_btstack
 #ifndef PICO_FLASH_BANK_STORAGE_OFFSET
+#if PICO_RP2350 && PICO_RP2350_A2_SUPPORTED
+#define PICO_FLASH_BANK_STORAGE_OFFSET (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE - PICO_FLASH_BANK_TOTAL_SIZE)
+#else
 #define PICO_FLASH_BANK_STORAGE_OFFSET (PICO_FLASH_SIZE_BYTES - PICO_FLASH_BANK_TOTAL_SIZE)
+#endif
 #endif
 
 /**
  * \brief Return the singleton BTstack HAL flash instance, used for non-volatile storage
  * \ingroup pico_btstack
  *
- * \note By default two sectors at the end of flash are used (see \c PICO_FLASH_BANK_STORAGE_OFFSET and \c PICO_FLASH_BANK_TOTAL_SIZE)
+ * \note By default, two sectors near the end of flash are used.
+ * For RP2350 when PICO_RP2350_A2_SUPPORTED is true, two sectors that are three sectors from the end of flash are used.
+ * This keeps the last sector free for a workaround for chip errata RP2350-E10. See the RP2350 datasheet for more details about this.
+ * Otherwise, two sectors directly at the end of flash are used.
+ * See \c PICO_FLASH_BANK_STORAGE_OFFSET and \c PICO_FLASH_BANK_TOTAL_SIZE)
  */
 const hal_flash_bank_t *pico_flash_bank_instance(void);
 


### PR DESCRIPTION
The workaround for errata RP2350-E10 overwrites the last block in flash. This will overwrite the BT flash storage causing a paired BT connection to fail. Move the default flash storage location to 3 sectors from the end of flash for RP2350 where A2 support is required.

This will require existing BT pairings to a Pico device to be removed and readded.

Fixes #2322
