### PR TITLE
Add --recursive flag to git submodule cmd

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Checkout submodules
-        run: git submodule update --init
+        run: git submodule update --init --recursive
       - name: Install dependencies
         run: |
           brew install cmake

--- a/.github/workflows/multi-gcc.yml
+++ b/.github/workflows/multi-gcc.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Checkout submodules
-      run: git submodule update --init
+      run: git submodule update --init --recursive
 
     - name: Host Release
       run: cd ${{github.workspace}}; mkdir -p build; rm -rf build/*; cd build; cmake ../ -DPICO_SDK_TESTS_ENABLED=1 -DCMAKE_BUILD_TYPE=Release -DPICO_NO_PICOTOOL=1 -DPICO_PLATFORM=host; make --output-sync=target --no-builtin-rules --no-builtin-variables -j$(nproc)

--- a/.github/workflows/scripts/generate_multi_gcc_workflow.py
+++ b/.github/workflows/scripts/generate_multi_gcc_workflow.py
@@ -94,7 +94,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Checkout submodules
-      run: git submodule update --init
+      run: git submodule update --init --recursive
 
     - name: Host Release
       run: cd ${{github.workspace}}; mkdir -p build; rm -rf build/*; cd build; cmake ../ -DPICO_SDK_TESTS_ENABLED=1 -DCMAKE_BUILD_TYPE=Release -DPICO_NO_PICOTOOL=1 -DPICO_PLATFORM=host; make --output-sync=target --no-builtin-rules --no-builtin-variables -j$(nproc)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Checkout submodules
-        run: git submodule update --init
+        run: git submodule update --init --recursive
       - name: Install dependencies
         run: choco install .github/workflows/choco_packages.config
 


### PR DESCRIPTION
Update all github workflows because picotool is (properly) using mbedtls in pico-sdk and it now has its own submodules.
