### PR TITLE
Add script to extract CMake function descriptions

### DIFF
--- a/src/cmake/on_device.cmake
+++ b/src/cmake/on_device.cmake
@@ -16,21 +16,21 @@ function(pico_get_runtime_output_directory TARGET output_path_name)
 endfunction()
 
 # pico_add_hex_output(TARGET)
-# Generate a hex file for the target
+# \brief\ Generate a hex file for the target
 function(pico_add_hex_output TARGET)
     pico_get_runtime_output_directory(${TARGET} output_path)
     add_custom_command(TARGET ${TARGET} POST_BUILD COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${TARGET}> ${output_path}$<IF:$<BOOL:$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>>,$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>,$<TARGET_PROPERTY:${TARGET},NAME>>.hex VERBATIM)
 endfunction()
 
 # pico_add_bin_output(TARGET)
-# Generate a bin file for the target
+# \brief\ Generate a bin file for the target
 function(pico_add_bin_output TARGET)
     pico_get_runtime_output_directory(${TARGET} output_path)
     add_custom_command(TARGET ${TARGET} POST_BUILD COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${TARGET}> ${output_path}$<IF:$<BOOL:$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>>,$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>,$<TARGET_PROPERTY:${TARGET},NAME>>.bin VERBATIM)
 endfunction()
 
 # pico_add_dis_output(TARGET)
-# Generate a disassembly file for the target
+# \brief\ Generate a disassembly file for the target
 function(pico_add_dis_output TARGET)
     pico_get_runtime_output_directory(${TARGET} output_path)
 
@@ -52,6 +52,8 @@ function(pico_add_dis_output TARGET)
 endfunction()
 
 # pico_add_extra_outputs(TARGET)
+# \brief_nodesc\ Perform post-build actions for the target
+#
 # Perform picotool processing and add disassembly, hex, bin, map, and uf2 outputs for the target
 function(pico_add_extra_outputs TARGET)
     # Disassembly will be nonsense for encrypted binaries,

--- a/src/cmake/on_device.cmake
+++ b/src/cmake/on_device.cmake
@@ -15,16 +15,22 @@ function(pico_get_runtime_output_directory TARGET output_path_name)
     set(${output_path_name} ${output_path} PARENT_SCOPE)
 endfunction()
 
+# pico_add_hex_output(TARGET)
+# Generate a hex file for the target
 function(pico_add_hex_output TARGET)
     pico_get_runtime_output_directory(${TARGET} output_path)
     add_custom_command(TARGET ${TARGET} POST_BUILD COMMAND ${CMAKE_OBJCOPY} -Oihex $<TARGET_FILE:${TARGET}> ${output_path}$<IF:$<BOOL:$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>>,$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>,$<TARGET_PROPERTY:${TARGET},NAME>>.hex VERBATIM)
 endfunction()
 
+# pico_add_bin_output(TARGET)
+# Generate a bin file for the target
 function(pico_add_bin_output TARGET)
     pico_get_runtime_output_directory(${TARGET} output_path)
     add_custom_command(TARGET ${TARGET} POST_BUILD COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${TARGET}> ${output_path}$<IF:$<BOOL:$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>>,$<TARGET_PROPERTY:${TARGET},OUTPUT_NAME>,$<TARGET_PROPERTY:${TARGET},NAME>>.bin VERBATIM)
 endfunction()
 
+# pico_add_dis_output(TARGET)
+# Generate a disassembly file for the target
 function(pico_add_dis_output TARGET)
     pico_get_runtime_output_directory(${TARGET} output_path)
 
@@ -45,6 +51,8 @@ function(pico_add_dis_output TARGET)
             )
 endfunction()
 
+# pico_add_extra_outputs(TARGET)
+# Perform picotool processing and add disassembly, hex, bin, map, and uf2 outputs for the target
 function(pico_add_extra_outputs TARGET)
     # Disassembly will be nonsense for encrypted binaries,
     # so disassemble before picotool processing

--- a/src/common/pico_binary_info/CMakeLists.txt
+++ b/src/common/pico_binary_info/CMakeLists.txt
@@ -9,11 +9,15 @@ endif()
 
 target_link_libraries(pico_binary_info INTERFACE pico_binary_info_headers)
 
+# pico_set_program_name(TARGET name)
+# Set the program name for the target
 function(pico_set_program_name TARGET name)
     # PICO_BUILD_DEFINE: PICO_PROGRAM_NAME, value passed to pico_set_program_name, type=string, group=pico_binary_info
     target_compile_definitions(${TARGET} PRIVATE -DPICO_PROGRAM_NAME="${name}")
 endfunction()
 
+# pico_set_program_description(TARGET description)
+# Set the program description for the target
 function(pico_set_program_description TARGET description)
     # since this is the command line, we will remove newlines
     string(REPLACE "\n" " " description ${description})
@@ -22,11 +26,15 @@ function(pico_set_program_description TARGET description)
     target_compile_definitions(${TARGET} PRIVATE -DPICO_PROGRAM_DESCRIPTION="${description}")
 endfunction()
 
+# pico_set_program_url(TARGET url)
+# Set the program URL for the target
 function(pico_set_program_url TARGET url)
     # PICO_BUILD_DEFINE: PICO_PROGRAM_URL, value passed to pico_set_program_url, type=string, group=pico_binary_info
     target_compile_definitions(${TARGET} PRIVATE -DPICO_PROGRAM_URL="${url}")
 endfunction()
 
+# pico_set_program_version(TARGET version)
+# Set the program version for the target
 function(pico_set_program_version TARGET version)
     # PICO_BUILD_DEFINE: PICO_PROGRAM_VERSION_STRING, value passed to pico_set_program_version, type=string, group=pico_binary_info
     target_compile_definitions(${TARGET} PRIVATE -DPICO_PROGRAM_VERSION_STRING="${version}")

--- a/src/common/pico_binary_info/CMakeLists.txt
+++ b/src/common/pico_binary_info/CMakeLists.txt
@@ -10,14 +10,18 @@ endif()
 target_link_libraries(pico_binary_info INTERFACE pico_binary_info_headers)
 
 # pico_set_program_name(TARGET name)
-# Set the program name for the target
+# \brief\ Set the program name for the target
+#
+# \param\ name The program name to set
 function(pico_set_program_name TARGET name)
     # PICO_BUILD_DEFINE: PICO_PROGRAM_NAME, value passed to pico_set_program_name, type=string, group=pico_binary_info
     target_compile_definitions(${TARGET} PRIVATE -DPICO_PROGRAM_NAME="${name}")
 endfunction()
 
 # pico_set_program_description(TARGET description)
-# Set the program description for the target
+# \brief\ Set the program description for the target
+#
+# \param\ description The program description to set
 function(pico_set_program_description TARGET description)
     # since this is the command line, we will remove newlines
     string(REPLACE "\n" " " description ${description})
@@ -27,14 +31,18 @@ function(pico_set_program_description TARGET description)
 endfunction()
 
 # pico_set_program_url(TARGET url)
-# Set the program URL for the target
+# \brief\ Set the program URL for the target
+#
+# \param\ url The program URL to set
 function(pico_set_program_url TARGET url)
     # PICO_BUILD_DEFINE: PICO_PROGRAM_URL, value passed to pico_set_program_url, type=string, group=pico_binary_info
     target_compile_definitions(${TARGET} PRIVATE -DPICO_PROGRAM_URL="${url}")
 endfunction()
 
 # pico_set_program_version(TARGET version)
-# Set the program version for the target
+# \brief\ Set the program version for the target
+#
+# \param\ version The program version to set
 function(pico_set_program_version TARGET version)
     # PICO_BUILD_DEFINE: PICO_PROGRAM_VERSION_STRING, value passed to pico_set_program_version, type=string, group=pico_binary_info
     target_compile_definitions(${TARGET} PRIVATE -DPICO_PROGRAM_VERSION_STRING="${version}")

--- a/src/rp2040/boot_stage2/CMakeLists.txt
+++ b/src/rp2040/boot_stage2/CMakeLists.txt
@@ -34,8 +34,12 @@ pico_add_library(boot_stage2_headers)
 target_include_directories(boot_stage2_headers SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
 # pico_define_boot_stage2(NAME SOURCES)
-# Define a boot stage 2 target.
+# \brief\ Define a boot stage 2 target.
+#
 # By convention the first source file name without extension is used for the binary info name
+#
+# \param\ NAME The name of the boot stage 2 target
+# \param\ SOURCES The source files to link into the boot stage 2
 function(pico_define_boot_stage2 NAME SOURCES)
     add_executable(${NAME}
             ${SOURCES}
@@ -100,7 +104,11 @@ endmacro()
 pico_define_boot_stage2(bs2_default ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 
 # pico_clone_default_boot_stage2(NAME)
+# \brief_nodesc\ Clone the default boot stage 2 target.
+#
 # Create a new boot stage 2 target using the default implementation for the current build (PICO_BOARD derived)
+#
+# \param\ NAME The name of the new boot stage 2 target
 function(pico_clone_default_boot_stage2 NAME)
     pico_define_boot_stage2(${NAME} ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 endfunction()

--- a/src/rp2040/boot_stage2/CMakeLists.txt
+++ b/src/rp2040/boot_stage2/CMakeLists.txt
@@ -33,7 +33,7 @@ set(PICO_BOOT_STAGE2_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
 pico_add_library(boot_stage2_headers)
 target_include_directories(boot_stage2_headers SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-# pico_define_boot_stage2(TARGET NAME SOURCES)
+# pico_define_boot_stage2(NAME SOURCES)
 # Define a boot stage 2 target.
 # By convention the first source file name without extension is used for the binary info name
 function(pico_define_boot_stage2 NAME SOURCES)
@@ -99,7 +99,7 @@ endmacro()
 
 pico_define_boot_stage2(bs2_default ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 
-# pico_clone_default_boot_stage2(TARGET NAME)
+# pico_clone_default_boot_stage2(NAME)
 # Create a new boot stage 2 target using the default implementation for the current build (PICO_BOARD derived)
 function(pico_clone_default_boot_stage2 NAME)
     pico_define_boot_stage2(${NAME} ${PICO_DEFAULT_BOOT_STAGE2_FILE})

--- a/src/rp2040/boot_stage2/CMakeLists.txt
+++ b/src/rp2040/boot_stage2/CMakeLists.txt
@@ -33,7 +33,9 @@ set(PICO_BOOT_STAGE2_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
 pico_add_library(boot_stage2_headers)
 target_include_directories(boot_stage2_headers SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-# by convention the first source file name without extension is used for the binary info name
+# pico_define_boot_stage2(TARGET NAME SOURCES)
+# Define a boot stage 2 target.
+# By convention the first source file name without extension is used for the binary info name
 function(pico_define_boot_stage2 NAME SOURCES)
     add_executable(${NAME}
             ${SOURCES}
@@ -97,6 +99,7 @@ endmacro()
 
 pico_define_boot_stage2(bs2_default ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 
+# pico_clone_default_boot_stage2(TARGET NAME)
 # Create a new boot stage 2 target using the default implementation for the current build (PICO_BOARD derived)
 function(pico_clone_default_boot_stage2 NAME)
     pico_define_boot_stage2(${NAME} ${PICO_DEFAULT_BOOT_STAGE2_FILE})

--- a/src/rp2350/boot_stage2/CMakeLists.txt
+++ b/src/rp2350/boot_stage2/CMakeLists.txt
@@ -34,8 +34,12 @@ pico_add_library(boot_stage2_headers)
 target_include_directories(boot_stage2_headers SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
 # pico_define_boot_stage2(NAME SOURCES)
-# Define a boot stage 2 target.
+# \brief\ Define a boot stage 2 target.
+#
 # By convention the first source file name without extension is used for the binary info name
+#
+# \param\ NAME The name of the boot stage 2 target
+# \param\ SOURCES The source files to link into the boot stage 2
 function(pico_define_boot_stage2 NAME SOURCES)
     add_executable(${NAME}
             ${SOURCES}
@@ -100,7 +104,11 @@ endmacro()
 pico_define_boot_stage2(bs2_default ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 
 # pico_clone_default_boot_stage2(NAME)
+# \brief_nodesc\ Clone the default boot stage 2 target.
+#
 # Create a new boot stage 2 target using the default implementation for the current build (PICO_BOARD derived)
+#
+# \param\ NAME The name of the new boot stage 2 target
 function(pico_clone_default_boot_stage2 NAME)
     pico_define_boot_stage2(${NAME} ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 endfunction()

--- a/src/rp2350/boot_stage2/CMakeLists.txt
+++ b/src/rp2350/boot_stage2/CMakeLists.txt
@@ -33,7 +33,7 @@ set(PICO_BOOT_STAGE2_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
 pico_add_library(boot_stage2_headers)
 target_include_directories(boot_stage2_headers SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-# pico_define_boot_stage2(TARGET NAME SOURCES)
+# pico_define_boot_stage2(NAME SOURCES)
 # Define a boot stage 2 target.
 # By convention the first source file name without extension is used for the binary info name
 function(pico_define_boot_stage2 NAME SOURCES)
@@ -99,7 +99,7 @@ endmacro()
 
 pico_define_boot_stage2(bs2_default ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 
-# pico_clone_default_boot_stage2(TARGET NAME)
+# pico_clone_default_boot_stage2(NAME)
 # Create a new boot stage 2 target using the default implementation for the current build (PICO_BOARD derived)
 function(pico_clone_default_boot_stage2 NAME)
     pico_define_boot_stage2(${NAME} ${PICO_DEFAULT_BOOT_STAGE2_FILE})

--- a/src/rp2350/boot_stage2/CMakeLists.txt
+++ b/src/rp2350/boot_stage2/CMakeLists.txt
@@ -33,7 +33,9 @@ set(PICO_BOOT_STAGE2_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
 pico_add_library(boot_stage2_headers)
 target_include_directories(boot_stage2_headers SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-# by convention the first source file name without extension is used for the binary info name
+# pico_define_boot_stage2(TARGET NAME SOURCES)
+# Define a boot stage 2 target.
+# By convention the first source file name without extension is used for the binary info name
 function(pico_define_boot_stage2 NAME SOURCES)
     add_executable(${NAME}
             ${SOURCES}
@@ -97,6 +99,7 @@ endmacro()
 
 pico_define_boot_stage2(bs2_default ${PICO_DEFAULT_BOOT_STAGE2_FILE})
 
+# pico_clone_default_boot_stage2(TARGET NAME)
 # Create a new boot stage 2 target using the default implementation for the current build (PICO_BOARD derived)
 function(pico_clone_default_boot_stage2 NAME)
     pico_define_boot_stage2(${NAME} ${PICO_DEFAULT_BOOT_STAGE2_FILE})

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -302,6 +302,7 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
 
     pico_promote_common_scope_vars()
 
+    # pico_btstack_make_gatt_header(TARGET_LIB TARGET_TYPE GATT_FILE)
     # Make a GATT header file from a BTstack GATT file
     # Pass the target library name library type and path to the GATT input file
     # To add additional directories to the gatt #import path, add them to the end of the argument list.

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -304,7 +304,7 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
 
     # pico_btstack_make_gatt_header(TARGET_LIB TARGET_TYPE GATT_FILE)
     # Make a GATT header file from a BTstack GATT file.
-    # Pass the target library name library type and path to the GATT input file.
+    # Pass the target library name, library type, and path to the GATT input file.
     # To add additional directories to the gatt #import path, add them to the end of the argument list.
     function(pico_btstack_make_gatt_header TARGET_LIB TARGET_TYPE GATT_FILE)
             find_package (Python3 REQUIRED COMPONENTS Interpreter)

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -303,8 +303,8 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
     pico_promote_common_scope_vars()
 
     # pico_btstack_make_gatt_header(TARGET_LIB TARGET_TYPE GATT_FILE)
-    # Make a GATT header file from a BTstack GATT file
-    # Pass the target library name library type and path to the GATT input file
+    # Make a GATT header file from a BTstack GATT file.
+    # Pass the target library name library type and path to the GATT input file.
     # To add additional directories to the gatt #import path, add them to the end of the argument list.
     function(pico_btstack_make_gatt_header TARGET_LIB TARGET_TYPE GATT_FILE)
             find_package (Python3 REQUIRED COMPONENTS Interpreter)

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -303,9 +303,14 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
     pico_promote_common_scope_vars()
 
     # pico_btstack_make_gatt_header(TARGET_LIB TARGET_TYPE GATT_FILE)
-    # Make a GATT header file from a BTstack GATT file.
+    # \brief\ Make a GATT header file from a BTstack GATT file.
+    #
     # Pass the target library name, library type, and path to the GATT input file.
     # To add additional directories to the gatt #import path, add them to the end of the argument list.
+    #
+    # \param\ TARGET_LIB The target library name
+    # \param\ TARGET_TYPE The target library type
+    # \param\ GATT_FILE The path to the GATT input file
     function(pico_btstack_make_gatt_header TARGET_LIB TARGET_TYPE GATT_FILE)
             find_package (Python3 REQUIRED COMPONENTS Interpreter)
             get_filename_component(GATT_NAME "${GATT_FILE}" NAME_WE)

--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -306,7 +306,7 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
     # \brief\ Make a GATT header file from a BTstack GATT file.
     #
     # Pass the target library name, library type, and path to the GATT input file.
-    # To add additional directories to the gatt #import path, add them to the end of the argument list.
+    # To add additional directories to the gatt import path, add them to the end of the argument list.
     #
     # \param\ TARGET_LIB The target library name
     # \param\ TARGET_TYPE The target library type

--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -132,7 +132,8 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
     endif()
 
     # pico_configure_ip4_address(TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
-    # Set an ip address in a compile definition;
+    # \brief\ Set an ip address in a compile definition
+    #
     # This can be used to set the following compile definitions;
     # CYW43_DEFAULT_IP_STA_ADDRESS;
     # CYW43_DEFAULT_IP_STA_GATEWAY;
@@ -141,6 +142,11 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
     # CYW43_DEFAULT_IP_MASK;
     # CYW43_DEFAULT_IP_DNS;
     # e.g. pico_configure_ip4_address(picow_tcpip_server_background PRIVATE CYW43_DEFAULT_IP_STA_ADDRESS "10.3.15.204")
+    #
+    # \param\ TARGET_LIB The target library to set the ip address for
+    # \param\ TARGET_TYPE The type of target library
+    # \param\ DEF_NAME The name of the compile definition to set
+    # \param\ IP_ADDRESS_STR The ip address to set
     function(pico_configure_ip4_address TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
             string(REGEX MATCHALL "[0-9]+" IP_ADDRESS_LIST ${IP_ADDRESS_STR})
             list(LENGTH IP_ADDRESS_LIST IP_ADDRESS_COMPONENT_COUNT)

--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -131,15 +131,15 @@ if (EXISTS ${PICO_CYW43_DRIVER_PATH}/${CYW43_DRIVER_TEST_FILE})
                 )
     endif()
 
-    # Set an ip address in a compile definition
-    # target name, target type, compile definition name to set then address in a string
-    # This can be used to set the following compile definitions
-    # CYW43_DEFAULT_IP_STA_ADDRESS
-    # CYW43_DEFAULT_IP_STA_GATEWAY
-    # CYW43_DEFAULT_IP_AP_ADDRESS
-    # CYW43_DEFAULT_IP_AP_GATEWAY
-    # CYW43_DEFAULT_IP_MASK
-    # CYW43_DEFAULT_IP_DNS
+    # pico_configure_ip4_address(TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
+    # Set an ip address in a compile definition;
+    # This can be used to set the following compile definitions;
+    # CYW43_DEFAULT_IP_STA_ADDRESS;
+    # CYW43_DEFAULT_IP_STA_GATEWAY;
+    # CYW43_DEFAULT_IP_AP_ADDRESS;
+    # CYW43_DEFAULT_IP_AP_GATEWAY;
+    # CYW43_DEFAULT_IP_MASK;
+    # CYW43_DEFAULT_IP_DNS;
     # e.g. pico_configure_ip4_address(picow_tcpip_server_background PRIVATE CYW43_DEFAULT_IP_STA_ADDRESS "10.3.15.204")
     function(pico_configure_ip4_address TARGET_LIB TARGET_TYPE DEF_NAME IP_ADDRESS_STR)
             string(REGEX MATCHALL "[0-9]+" IP_ADDRESS_LIST ${IP_ADDRESS_STR})

--- a/src/rp2_common/pico_lwip/tools/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
-# Compile the http content into a source file "pico_fsdata.inc" in a format suitable for the lwip httpd server
-# Pass the target library name library type and the list of httpd content
+# pico_set_lwip_httpd_content(TARGET_LIB TARGET_TYPE HTTPD_FILES...)
+# Compile the http content into a source file "pico_fsdata.inc" in a format suitable for the lwip httpd server.
+# Pass the target library name library type and the list of httpd content files to compile.
 function(pico_set_lwip_httpd_content TARGET_LIB TARGET_TYPE)
     find_package (Python3 REQUIRED COMPONENTS Interpreter)
     set(HTTPD_CONTENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")

--- a/src/rp2_common/pico_lwip/tools/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/tools/CMakeLists.txt
@@ -1,6 +1,12 @@
 # pico_set_lwip_httpd_content(TARGET_LIB TARGET_TYPE HTTPD_FILES...)
+# \brief_nodesc\ Compile the http content into a source file for lwip.
+#
 # Compile the http content into a source file "pico_fsdata.inc" in a format suitable for the lwip httpd server.
 # Pass the target library name library type and the list of httpd content files to compile.
+#
+# \param\ TARGET_LIB The target library name
+# \param\ TARGET_TYPE The type of the target library
+# \param\ HTTPD_FILES The list of httpd content files to compile
 function(pico_set_lwip_httpd_content TARGET_LIB TARGET_TYPE)
     find_package (Python3 REQUIRED COMPONENTS Interpreter)
     set(HTTPD_CONTENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")

--- a/src/rp2_common/pico_lwip/tools/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 # pico_set_lwip_httpd_content(TARGET_LIB TARGET_TYPE HTTPD_FILES...)
+# \ingroup\ pico_lwip
 # \brief_nodesc\ Compile the http content into a source file for lwip.
 #
 # Compile the http content into a source file "pico_fsdata.inc" in a format suitable for the lwip httpd server.

--- a/src/rp2_common/pico_lwip/tools/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/tools/CMakeLists.txt
@@ -2,7 +2,7 @@
 # \brief_nodesc\ Compile the http content into a source file for lwip.
 #
 # Compile the http content into a source file "pico_fsdata.inc" in a format suitable for the lwip httpd server.
-# Pass the target library name library type and the list of httpd content files to compile.
+# Pass the target library name, library type, and the list of httpd content files to compile.
 #
 # \param\ TARGET_LIB The target library name
 # \param\ TARGET_TYPE The type of the target library

--- a/src/rp2_common/pico_runtime/CMakeLists.txt
+++ b/src/rp2_common/pico_runtime/CMakeLists.txt
@@ -51,7 +51,8 @@ elseif (PICO_C_COMPILER_IS_CLANG)
    # target_link_options(pico_runtime INTERFACE "-nostdlib")
 endif()
 
-# pico_minimize_runtime([INCLUDE ...] [EXCLUDE ...])
+# pico_minimize_runtime(TARGET [INCLUDE ...] [EXCLUDE ...])
+# \brief\ Minimize the runtime components for the target
 #
 # INCLUDE/EXCLUDE can contain any of the following (all defaulting to not included)
 #
@@ -67,6 +68,9 @@ endif()
 # FPGA_CHECK            - checks for FPGA which allows Raspberry Pi to run your binary on FPGA;
 # PANIC                 - default panic impl which brings in stdio;
 # AUTO_INIT_MUTEX       - auto init mutexes, without this you get no printf mutex either;
+#
+# \param\ INCLUDE The items to include
+# \param\ EXCLUDE The items to exclude
 function(pico_minimize_runtime TARGET)
     set(ALL_ITEMS
             DEFAULT_ALARM_POOL

--- a/src/rp2_common/pico_runtime/CMakeLists.txt
+++ b/src/rp2_common/pico_runtime/CMakeLists.txt
@@ -51,22 +51,22 @@ elseif (PICO_C_COMPILER_IS_CLANG)
    # target_link_options(pico_runtime INTERFACE "-nostdlib")
 endif()
 
-# pico_minimize_runtime((INCLUDE ...) (EXCLUDE ...))
+# pico_minimize_runtime([INCLUDE ...] [EXCLUDE ...])
 #
 # INCLUDE/EXCLUDE can contain any of the following (all defaulting to not included)
 #
-# DEFAULT_ALARM_POOL    - default alarm pool setup
-# PRINTF                - full printf support
-# PRINTF_MINIMAL        - printf support without the following
-# PRINTF_FLOAT          - to control float support if printf is enabled
-# PRINTF_EXPONENTIAL
-# PRINTF_LONG_LONG
-# PRINTF_PTRDIFF_T
-# FLOAT                 - support for single-precision floating point
-# DOUBLE                - support for double-precision floating point
-# FPGA_CHECK            - checks for FPGA which allows Raspberry Pi to run your binary on FPGA
-# PANIC                 - default panic impl which brings in stdio
-# AUTO_INIT_MUTEX       - auto init mutexes; without this you get no printf mutex either               -
+# DEFAULT_ALARM_POOL    - default alarm pool setup;
+# PRINTF                - full printf support;
+# PRINTF_MINIMAL        - printf support without the following;
+# PRINTF_FLOAT          - to control float support if printf is enabled;
+# PRINTF_EXPONENTIAL    - to control exponential support if printf is enabled;
+# PRINTF_LONG_LONG      - to control long long support if printf is enabled;
+# PRINTF_PTRDIFF_T      - to control ptrdiff_t support if printf is enabled;
+# FLOAT                 - support for single-precision floating point;
+# DOUBLE                - support for double-precision floating point;
+# FPGA_CHECK            - checks for FPGA which allows Raspberry Pi to run your binary on FPGA;
+# PANIC                 - default panic impl which brings in stdio;
+# AUTO_INIT_MUTEX       - auto init mutexes, without this you get no printf mutex either;
 function(pico_minimize_runtime TARGET)
     set(ALL_ITEMS
             DEFAULT_ALARM_POOL

--- a/src/rp2_common/pico_standard_link/CMakeLists.txt
+++ b/src/rp2_common/pico_standard_link/CMakeLists.txt
@@ -5,6 +5,8 @@ if (NOT TARGET pico_standard_link)
         target_link_libraries(pico_standard_link INTERFACE boot_stage2_headers)
     endif()
 
+    # pico_add_link_depend(TARGET dependency)
+    # Add a link time dependency to the target
     function(pico_add_link_depend TARGET dependency)
         get_target_property(target_type ${TARGET} TYPE)
         if (${target_type} STREQUAL "INTERFACE_LIBRARY")
@@ -21,11 +23,14 @@ if (NOT TARGET pico_standard_link)
         set_target_properties(${TARGET} PROPERTIES ${PROP} "${_LINK_DEPENDS}")
     endfunction()
 
-    # need this because cmake does not appear to have a way to override an INTERFACE variable
+    # pico_set_linker_script(TARGET LDSCRIPT)
+    # Set the linker script for the target
     function(pico_set_linker_script TARGET LDSCRIPT)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_LINKER_SCRIPT ${LDSCRIPT})
     endfunction()
 
+    # pico_set_binary_type(TARGET TYPE)
+    # Set the binary type for the target
     function(pico_set_binary_type TARGET TYPE)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_BINARY_TYPE ${TYPE})
     endfunction()

--- a/src/rp2_common/pico_standard_link/CMakeLists.txt
+++ b/src/rp2_common/pico_standard_link/CMakeLists.txt
@@ -6,7 +6,9 @@ if (NOT TARGET pico_standard_link)
     endif()
 
     # pico_add_link_depend(TARGET dependency)
-    # Add a link time dependency to the target
+    # \brief\ Add a link time dependency to the target
+    #
+    # \param\ dependency The dependency to add
     function(pico_add_link_depend TARGET dependency)
         get_target_property(target_type ${TARGET} TYPE)
         if (${target_type} STREQUAL "INTERFACE_LIBRARY")
@@ -24,13 +26,17 @@ if (NOT TARGET pico_standard_link)
     endfunction()
 
     # pico_set_linker_script(TARGET LDSCRIPT)
-    # Set the linker script for the target
+    # \brief\ Set the linker script for the target
+    #
+    # \param\ LDSCRIPT Full path to the linker script to set
     function(pico_set_linker_script TARGET LDSCRIPT)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_LINKER_SCRIPT ${LDSCRIPT})
     endfunction()
 
     # pico_set_binary_type(TARGET TYPE)
-    # Set the binary type for the target
+    # \brief\ Set the binary type for the target
+    #
+    # \param\ TYPE The binary type to set
     function(pico_set_binary_type TARGET TYPE)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_BINARY_TYPE ${TYPE})
     endfunction()

--- a/src/rp2_common/pico_stdio/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio/CMakeLists.txt
@@ -26,18 +26,26 @@ if (NOT TARGET pico_stdio)
         pico_mirrored_target_link_libraries(pico_stdio INTERFACE pico_printf)
     endif()
 
+    # pico_enable_stdio_uart(TARGET ENABLED)
+    # Enable stdio UART for the target
     function(pico_enable_stdio_uart TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_UART ${ENABLED})
     endfunction()
 
+    # pico_enable_stdio_usb(TARGET ENABLED)
+    # Enable stdio USB for the target
     function(pico_enable_stdio_usb TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_USB ${ENABLED})
     endfunction()
 
+    # pico_enable_stdio_semihosting(TARGET ENABLED)
+    # Enable stdio semi-hosting for the target
     function(pico_enable_stdio_semihosting TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_SEMIHOSTING ${ENABLED})
     endfunction()
 
+    # pico_enable_stdio_rtt(TARGET ENABLED)
+    # Enable stdio RTT for the target
     function(pico_enable_stdio_rtt TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_RTT ${ENABLED})
     endfunction()

--- a/src/rp2_common/pico_stdio/CMakeLists.txt
+++ b/src/rp2_common/pico_stdio/CMakeLists.txt
@@ -27,25 +27,33 @@ if (NOT TARGET pico_stdio)
     endif()
 
     # pico_enable_stdio_uart(TARGET ENABLED)
-    # Enable stdio UART for the target
+    # \brief\ Enable stdio UART for the target
+    #
+    # \param\ ENABLED Whether to enable stdio UART
     function(pico_enable_stdio_uart TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_UART ${ENABLED})
     endfunction()
 
     # pico_enable_stdio_usb(TARGET ENABLED)
-    # Enable stdio USB for the target
+    # \brief\ Enable stdio USB for the target
+    #
+    # \param\ ENABLED Whether to enable stdio USB
     function(pico_enable_stdio_usb TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_USB ${ENABLED})
     endfunction()
 
     # pico_enable_stdio_semihosting(TARGET ENABLED)
-    # Enable stdio semi-hosting for the target
+    # \brief\ Enable stdio semi-hosting for the target
+    #
+    # \param\ ENABLED Whether to enable stdio semi-hosting
     function(pico_enable_stdio_semihosting TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_SEMIHOSTING ${ENABLED})
     endfunction()
 
     # pico_enable_stdio_rtt(TARGET ENABLED)
-    # Enable stdio RTT for the target
+    # \brief\ Enable stdio RTT for the target
+    #
+    # \param\ ENABLED Whether to enable stdio RTT
     function(pico_enable_stdio_rtt TARGET ENABLED)
         set_target_properties(${TARGET} PROPERTIES PICO_TARGET_STDIO_RTT ${ENABLED})
     endfunction()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -176,6 +176,7 @@ function(picotool_check_default_keys TARGET)
 endfunction()
 
 # pico_generate_pio_header(TARGET PIO_FILES... [OUTPUT_FORMAT <format>] [OUTPUT_DIR <dir>])
+# \ingroup\ pico_pio
 # \brief\ Generate pio header and include it in the build
 #
 # \param\ PIO_FILES The PIO files to generate the header for

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -175,7 +175,9 @@ function(picotool_check_default_keys TARGET)
     picotool_compare_keys(${TARGET} ${picotool_enc_sigfile} private.pem "encrypted signing")
 endfunction()
 
+# pico_generate_pio_header(TARGET PIO_FILES... [OUTPUT_FORMAT <format>] [OUTPUT_DIR <dir>])
 # Generate pio header and include it in the build
+#
 # PICO_CMAKE_CONFIG: PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, Default output format used by pioasm when using pico_generate_pio_header, type=string, default=c-sdk, group=build
 function(pico_generate_pio_header TARGET)
     pico_init_pioasm()
@@ -233,6 +235,7 @@ endfunction()
 # Package a UF2 output to be written to the PACKADDR address. This can be
 # used with a no_flash binary to write the UF2 to flash when dragging &
 # dropping, and it will be copied to SRAM by the bootrom before execution.
+#
 # This sets PICOTOOL_UF2_PACKAGE_ADDR to PACKADDR.
 function(pico_package_uf2_output TARGET PACKADDR)
     picotool_check_configurable(${TARGET})
@@ -243,6 +246,7 @@ endfunction()
 
 # pico_set_otp_key_output_file(TARGET OTPFILE)
 # Output the public key hash and other necessary rows to an otp JSON file.
+#
 # This sets PICOTOOL_OTP_FILE to OTPFILE.
 function(pico_set_otp_key_output_file TARGET OTPFILE)
     picotool_check_configurable(${TARGET})
@@ -253,8 +257,9 @@ endfunction()
 
 # pico_load_map_clear_sram(TARGET)
 # Adds an entry to the load map to instruct the bootrom to clear all of SRAM
-# before loading the binary. This appends the `--clear` argument
-# to PICOTOOL_EXTRA_PROCESS_ARGS.
+# before loading the binary.
+#
+# This appends the `--clear` argument to PICOTOOL_EXTRA_PROCESS_ARGS.
 function(pico_load_map_clear_sram TARGET)
     picotool_check_configurable(${TARGET})
     # get and set, to inherit list
@@ -270,9 +275,11 @@ endfunction()
 
 # pico_set_binary_version(<TARGET> [MAJOR <version>] [MINOR <version>] [ROLLBACK <version>] [ROLLBACK_ROWS <rows...>])
 # Adds a version item to the metadata block, with the given major, minor and
-# rollback version, along with the rollback rows. These are appended as arguments
-# to PICOTOOL_EXTRA_PROCESS_ARGS if setting the rollback version, or set as compile
-# definitions if only setting the major/minor versions.
+# rollback version, along with the rollback rows.
+#
+# These are appended as arguments to PICOTOOL_EXTRA_PROCESS_ARGS if setting the
+# rollback version, or set as compile definitions if only setting the major/minor
+# versions.
 function(pico_set_binary_version TARGET)
     picotool_check_configurable(${TARGET})
     set(oneValueArgs MAJOR MINOR ROLLBACK)
@@ -322,6 +329,7 @@ endfunction()
 
 # pico_set_uf2_family(TARGET FAMILY)
 # Set the UF2 family to use when creating the UF2.
+#
 # This sets PICOTOOL_UF2_FAMILY to FAMILY.
 function(pico_set_uf2_family TARGET FAMILY)
     picotool_check_configurable(${TARGET})
@@ -331,10 +339,12 @@ function(pico_set_uf2_family TARGET FAMILY)
 endfunction()
 
 # pico_sign_binary(TARGET [SIGFILE])
-# Sign the target binary with the given PEM signature. This sets
-# PICOTOOL_SIGN_OUTPUT to true, PICOTOOL_SIGFILE to SIGFILE (if specified),
-# and PICOTOOL_OTP_FILE to ${TARGET}.otp.json (if not already set). To
-# specify a common SIGFILE for multiple targets, the SIGFILE property can be
+# Sign the target binary with the given PEM signature.
+#
+# This sets PICOTOOL_SIGN_OUTPUT to true, PICOTOOL_SIGFILE to SIGFILE (if
+# specified), and PICOTOOL_OTP_FILE to ${TARGET}.otp.json (if not already set).
+#
+# To specify a common SIGFILE for multiple targets, the SIGFILE property can be
 # set for a given scope, and then the SIGFILE argument is optional.
 function(pico_sign_binary TARGET)
     picotool_check_configurable(${TARGET})
@@ -361,7 +371,9 @@ function(pico_sign_binary TARGET)
 endfunction()
 
 # pico_hash_binary(TARGET)
-# Hash the target binary. This sets PICOTOOL_HASH_OUTPUT to true.
+# Hash the target binary.
+#
+# This sets PICOTOOL_HASH_OUTPUT to true.
 function(pico_hash_binary TARGET)
     picotool_check_configurable(${TARGET})
     # Enforce hashing through target properties
@@ -372,7 +384,9 @@ endfunction()
 
 # pico_embed_pt_in_binary(TARGET PTFILE)
 # Create the specified partition table from JSON, and embed it in the
-# block loop. This sets PICOTOOL_EMBED_PT to PTFILE.
+# block loop.
+#
+# This sets PICOTOOL_EMBED_PT to PTFILE.
 function(pico_embed_pt_in_binary TARGET PTFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -176,7 +176,11 @@ function(picotool_check_default_keys TARGET)
 endfunction()
 
 # pico_generate_pio_header(TARGET PIO_FILES... [OUTPUT_FORMAT <format>] [OUTPUT_DIR <dir>])
-# Generate pio header and include it in the build
+# \brief\ Generate pio header and include it in the build
+#
+# \param\ PIO_FILES The PIO files to generate the header for
+# \param\ OUTPUT_FORMAT The output format to use for the pio header
+# \param\ OUTPUT_DIR The directory to output the pio header to
 function(pico_generate_pio_header TARGET)
     pico_init_pioasm()
     # Note that PATH is not a valid argument but was previously ignored (and happens to be passed by pico-extras)
@@ -231,11 +235,13 @@ function(pico_generate_pio_header TARGET)
 endfunction()
 
 # pico_package_uf2_output(TARGET PACKADDR)
-# Package a UF2 output to be written to the PACKADDR address. This can be
-# used with a no_flash binary to write the UF2 to flash when dragging &
+# \brief\ Package a UF2 output to be written to the PACKADDR address.
+# This can be used with a no_flash binary to write the UF2 to flash when dragging &
 # dropping, and it will be copied to SRAM by the bootrom before execution.
 #
 # This sets the target property PICOTOOL_UF2_PACKAGE_ADDR to PACKADDR.
+#
+# \param\ PACKADDR The address to package the UF2 to
 function(pico_package_uf2_output TARGET PACKADDR)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -244,9 +250,11 @@ function(pico_package_uf2_output TARGET PACKADDR)
 endfunction()
 
 # pico_set_otp_key_output_file(TARGET OTPFILE)
-# Output the public key hash and other necessary rows to an otp JSON file.
+# \brief\ Output the public key hash and other necessary rows to an otp JSON file.
 #
 # This sets the target property PICOTOOL_OTP_FILE to OTPFILE.
+#
+# \param\ OTPFILE The OTP file to output the public key hash and other necessary rows to
 function(pico_set_otp_key_output_file TARGET OTPFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -255,6 +263,8 @@ function(pico_set_otp_key_output_file TARGET OTPFILE)
 endfunction()
 
 # pico_load_map_clear_sram(TARGET)
+# \brief_nodesc\ Adds a load map entry to clear all of SRAM
+#
 # Adds an entry to the load map to instruct the bootrom to clear all of SRAM
 # before loading the binary.
 #
@@ -273,12 +283,19 @@ function(pico_load_map_clear_sram TARGET)
 endfunction()
 
 # pico_set_binary_version(<TARGET> [MAJOR <version>] [MINOR <version>] [ROLLBACK <version>] [ROLLBACK_ROWS <rows...>])
+# \brief_nodesc\ Add a version item to the metadata block
+#
 # Adds a version item to the metadata block, with the given major, minor and
 # rollback version, along with the rollback rows.
 #
 # These are appended as arguments to the target property PICOTOOL_EXTRA_PROCESS_ARGS if setting the
 # rollback version, or set as compile definitions if only setting the major/minor
 # versions.
+#
+# \param\ MAJOR The major version to set
+# \param\ MINOR The minor version to set
+# \param\ ROLLBACK The rollback version to set
+# \param\ ROWS The OTP rows to use for the rollback version
 function(pico_set_binary_version TARGET)
     picotool_check_configurable(${TARGET})
     set(oneValueArgs MAJOR MINOR ROLLBACK)
@@ -327,9 +344,11 @@ function(pico_set_binary_version TARGET)
 endfunction()
 
 # pico_set_uf2_family(TARGET FAMILY)
-# Set the UF2 family to use when creating the UF2.
+# \brief\ Set the UF2 family to use when creating the UF2.
 #
 # This sets the target property PICOTOOL_UF2_FAMILY to FAMILY.
+#
+# \param\ FAMILY The UF2 family to use
 function(pico_set_uf2_family TARGET FAMILY)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -338,7 +357,7 @@ function(pico_set_uf2_family TARGET FAMILY)
 endfunction()
 
 # pico_sign_binary(TARGET [SIGFILE])
-# Sign the target binary with the given PEM signature.
+# \brief\ Sign the target binary with the given PEM signature.
 #
 # This sets the target properties PICOTOOL_SIGN_OUTPUT to true,
 # PICOTOOL_SIGFILE to SIGFILE (if specified), and PICOTOOL_OTP_FILE to
@@ -346,6 +365,8 @@ endfunction()
 #
 # To specify a common SIGFILE for multiple targets, the SIGFILE property can be
 # set for a given scope, and then the SIGFILE argument is optional.
+#
+# \param\ SIGFILE The PEM signature file to use
 function(pico_sign_binary TARGET)
     picotool_check_configurable(${TARGET})
     # Enforce signing through target properties
@@ -371,7 +392,7 @@ function(pico_sign_binary TARGET)
 endfunction()
 
 # pico_hash_binary(TARGET)
-# Hash the target binary.
+# \brief\ Hash the target binary.
 #
 # This sets the target property PICOTOOL_HASH_OUTPUT to true.
 function(pico_hash_binary TARGET)
@@ -383,10 +404,14 @@ function(pico_hash_binary TARGET)
 endfunction()
 
 # pico_embed_pt_in_binary(TARGET PTFILE)
+# \brief_nodesc\ Embed a partition table in the binary
+#
 # Create the specified partition table from JSON, and embed it in the
 # block loop.
 #
 # This sets the target property PICOTOOL_EMBED_PT to PTFILE.
+#
+# \param\ PTFILE The partition table JSON file to use
 function(pico_embed_pt_in_binary TARGET PTFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -395,10 +420,16 @@ function(pico_embed_pt_in_binary TARGET PTFILE)
 endfunction()
 
 # pico_encrypt_binary(TARGET AESFILE [SIGFILE])
+# \brief_nodesc\ Encrypt the taget binary
+#
 # Encrypt the target binary with the given AES key (should be a binary
 # file containing 32 bytes of a random key), and sign the encrypted binary.
+#
 # This sets the target properties PICOTOOL_AESFILE to AESFILE,
 # and PICOTOOL_ENC_SIGFILE to SIGFILE if present, else PICOTOOL_SIGFILE.
+#
+# \param\ AESFILE The AES key file to use
+# \param\ SIGFILE The PEM signature file to use
 function(pico_encrypt_binary TARGET AESFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -424,6 +455,8 @@ function(pico_encrypt_binary TARGET AESFILE)
 endfunction()
 
 # pico_add_uf2_output(TARGET)
+# \brief_nodesc\ Add a UF2 output using picotool
+#
 # Add a UF2 output using picotool - must be called after
 # all required properties have been set
 function(pico_add_uf2_output TARGET)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -283,7 +283,7 @@ function(pico_load_map_clear_sram TARGET)
     )
 endfunction()
 
-# pico_set_binary_version(<TARGET> [MAJOR <version>] [MINOR <version>] [ROLLBACK <version>] [ROWS <rows...>])
+# pico_set_binary_version(TARGET [MAJOR <version>] [MINOR <version>] [ROLLBACK <version>] [ROWS <rows...>])
 # \brief_nodesc\ Add a version item to the metadata block
 #
 # Adds a version item to the metadata block, with the given major, minor and

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -282,7 +282,7 @@ function(pico_load_map_clear_sram TARGET)
     )
 endfunction()
 
-# pico_set_binary_version(<TARGET> [MAJOR <version>] [MINOR <version>] [ROLLBACK <version>] [ROLLBACK_ROWS <rows...>])
+# pico_set_binary_version(<TARGET> [MAJOR <version>] [MINOR <version>] [ROLLBACK <version>] [ROWS <rows...>])
 # \brief_nodesc\ Add a version item to the metadata block
 #
 # Adds a version item to the metadata block, with the given major, minor and

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -235,7 +235,7 @@ endfunction()
 # used with a no_flash binary to write the UF2 to flash when dragging &
 # dropping, and it will be copied to SRAM by the bootrom before execution.
 #
-# This sets PICOTOOL_UF2_PACKAGE_ADDR to PACKADDR.
+# This sets the target property PICOTOOL_UF2_PACKAGE_ADDR to PACKADDR.
 function(pico_package_uf2_output TARGET PACKADDR)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -246,7 +246,7 @@ endfunction()
 # pico_set_otp_key_output_file(TARGET OTPFILE)
 # Output the public key hash and other necessary rows to an otp JSON file.
 #
-# This sets PICOTOOL_OTP_FILE to OTPFILE.
+# This sets the target property PICOTOOL_OTP_FILE to OTPFILE.
 function(pico_set_otp_key_output_file TARGET OTPFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -258,7 +258,7 @@ endfunction()
 # Adds an entry to the load map to instruct the bootrom to clear all of SRAM
 # before loading the binary.
 #
-# This appends the `--clear` argument to PICOTOOL_EXTRA_PROCESS_ARGS.
+# This appends the `--clear` argument to the target property PICOTOOL_EXTRA_PROCESS_ARGS.
 function(pico_load_map_clear_sram TARGET)
     picotool_check_configurable(${TARGET})
     # get and set, to inherit list
@@ -276,7 +276,7 @@ endfunction()
 # Adds a version item to the metadata block, with the given major, minor and
 # rollback version, along with the rollback rows.
 #
-# These are appended as arguments to PICOTOOL_EXTRA_PROCESS_ARGS if setting the
+# These are appended as arguments to the target property PICOTOOL_EXTRA_PROCESS_ARGS if setting the
 # rollback version, or set as compile definitions if only setting the major/minor
 # versions.
 function(pico_set_binary_version TARGET)
@@ -329,7 +329,7 @@ endfunction()
 # pico_set_uf2_family(TARGET FAMILY)
 # Set the UF2 family to use when creating the UF2.
 #
-# This sets PICOTOOL_UF2_FAMILY to FAMILY.
+# This sets the target property PICOTOOL_UF2_FAMILY to FAMILY.
 function(pico_set_uf2_family TARGET FAMILY)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -340,8 +340,9 @@ endfunction()
 # pico_sign_binary(TARGET [SIGFILE])
 # Sign the target binary with the given PEM signature.
 #
-# This sets PICOTOOL_SIGN_OUTPUT to true, PICOTOOL_SIGFILE to SIGFILE (if
-# specified), and PICOTOOL_OTP_FILE to ${TARGET}.otp.json (if not already set).
+# This sets the target properties PICOTOOL_SIGN_OUTPUT to true,
+# PICOTOOL_SIGFILE to SIGFILE (if specified), and PICOTOOL_OTP_FILE to
+# ${TARGET}.otp.json (if not already set).
 #
 # To specify a common SIGFILE for multiple targets, the SIGFILE property can be
 # set for a given scope, and then the SIGFILE argument is optional.
@@ -372,7 +373,7 @@ endfunction()
 # pico_hash_binary(TARGET)
 # Hash the target binary.
 #
-# This sets PICOTOOL_HASH_OUTPUT to true.
+# This sets the target property PICOTOOL_HASH_OUTPUT to true.
 function(pico_hash_binary TARGET)
     picotool_check_configurable(${TARGET})
     # Enforce hashing through target properties
@@ -385,7 +386,7 @@ endfunction()
 # Create the specified partition table from JSON, and embed it in the
 # block loop.
 #
-# This sets PICOTOOL_EMBED_PT to PTFILE.
+# This sets the target property PICOTOOL_EMBED_PT to PTFILE.
 function(pico_embed_pt_in_binary TARGET PTFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES
@@ -396,8 +397,8 @@ endfunction()
 # pico_encrypt_binary(TARGET AESFILE [SIGFILE])
 # Encrypt the target binary with the given AES key (should be a binary
 # file containing 32 bytes of a random key), and sign the encrypted binary.
-# This sets PICOTOOL_AESFILE to AESFILE, and PICOTOOL_ENC_SIGFILE to SIGFILE
-# if present, else PICOTOOL_SIGFILE.
+# This sets the target properties PICOTOOL_AESFILE to AESFILE,
+# and PICOTOOL_ENC_SIGFILE to SIGFILE if present, else PICOTOOL_SIGFILE.
 function(pico_encrypt_binary TARGET AESFILE)
     picotool_check_configurable(${TARGET})
     set_target_properties(${TARGET} PROPERTIES

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -177,13 +177,12 @@ endfunction()
 
 # pico_generate_pio_header(TARGET PIO_FILES... [OUTPUT_FORMAT <format>] [OUTPUT_DIR <dir>])
 # Generate pio header and include it in the build
-#
-# PICO_CMAKE_CONFIG: PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, Default output format used by pioasm when using pico_generate_pio_header, type=string, default=c-sdk, group=build
 function(pico_generate_pio_header TARGET)
     pico_init_pioasm()
     # Note that PATH is not a valid argument but was previously ignored (and happens to be passed by pico-extras)
     cmake_parse_arguments(pico_generate_pio_header "" "OUTPUT_FORMAT;OUTPUT_DIR;PATH" "" ${ARGN} )
 
+    # PICO_CMAKE_CONFIG: PICO_DEFAULT_PIOASM_OUTPUT_FORMAT, Default output format used by pioasm when using pico_generate_pio_header, type=string, default=c-sdk, group=build
     if (pico_generate_pio_header_OUTPUT_FORMAT)
         set(OUTPUT_FORMAT "${pico_generate_pio_header_OUTPUT_FORMAT}")
     elseif(DEFINED PICO_DEFAULT_PIOASM_OUTPUT_FORMAT)

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -142,7 +142,7 @@ for dirpath, dirnames, filenames in os.walk(scandir):
                     signature = match.group(1).strip()
                     if signature.startswith(name):
                         description, brief, params = process_commands(match.group(2).replace('#', ''), name, group, signature)
-                        all_functions[name] = {
+                        new_dict = {
                             'name': name,
                             'group': group,
                             'signature': signature,
@@ -150,6 +150,10 @@ for dirpath, dirnames, filenames in os.walk(scandir):
                             'description': description,
                             'params': params
                         }
+                        if all_functions.get(name):
+                            if new_dict != all_functions[name]:
+                                logger.warning("{}:{} has multiple different definitions - using the new one from {}".format(group, name, file_path))
+                        all_functions[name] = new_dict
 
                 for match in CMAKE_PICO_FUNCTIONS_RE.finditer(text):
                     name = match.group(1)

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -94,9 +94,11 @@ def process_commands(description, name, group, signature):
     if any([';' in x for x in params]):
         logger.error("{}:{} has a parameter description containing ';'".format(group, name))
     # Check that all parameters are in the signature
+    signature_words = set(re.split('\W+', signature))
     for param in params:
-        if param.split(' ')[0] not in signature:
-            logger.error("{}:{} has a parameter {} which is not in the signature {}".format(group, name, param.split(' ')[0], signature))
+        param_name = param.split(' ', maxsplit=1)[0]
+        if param_name not in signature_words:
+            logger.error("{}:{} has a parameter {} which is not in the signature {}".format(group, name, param_name, signature))
     # Check that the brief description is not empty
     if not brief:
         logger.warning("{}:{} has no brief description".format(group, name))

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -72,17 +72,18 @@ def process_commands(description, name, group, signature):
     for line in description.split('\n'):
         line = line.strip()
         if line.startswith('\\'):
-            command = line.split('\\')[1]
+            _, command, remainder = line.split('\\', 2)
+            remainder = remainder.strip()
             if command == 'param':
                 # Parameter name and description
-                params.append(line.split('\\')[2].strip())
+                params.append(remainder)
             elif command == 'brief':
                 # Brief description
-                brief = line.split('\\')[2].strip()
+                brief = remainder
                 desc += brief + '\\n'
             elif command == 'brief_nodesc':
                 # Brief description which should not be included in the main description
-                brief = line.split('\\')[2].strip()
+                brief = remainder
             else:
                 logger.error("{}:{} has unknown command: {}".format(group, name, command))
         elif '\\' in line:
@@ -100,6 +101,7 @@ def process_commands(description, name, group, signature):
     if not brief:
         logger.warning("{}:{} has no brief description".format(group, name))
 
+    desc = re.sub(r'^(\\n)*(.*?)(\\n)*$', r'\2', desc)
     return desc.strip(), brief, ';'.join(params)
 
 

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -28,9 +28,31 @@ logging.basicConfig(level=logging.INFO)
 scandir = sys.argv[1]
 outfile = sys.argv[2] if len(sys.argv) > 2 else 'pico_cmake_functions.tsv'
 
-CMAKE_FUNCTION_RE = re.compile(r'^#(.*)((\n\s*#.*)*)\nfunction\(([^\s]*)', re.MULTILINE)
+CMAKE_FUNCTION_RE = re.compile(r'^\s*#(.*)((\n\s*#.*)*)\n\s*function\(([^\s]*)', re.MULTILINE)
 
-CMAKE_PICO_FUNCTIONS_RE = re.compile(r'^\s*function\((pico_[^\s]*)', re.MULTILINE)
+CMAKE_PICO_FUNCTIONS_RE = re.compile(r'^\s*function\((pico_[^\s\)]*)', re.MULTILINE)
+
+# Files containing internal functions that don't need to be documented publicly
+skip_files = set([
+    "pico_sdk_init.cmake",
+    "pico_utils.cmake",
+    "no_hardware.cmake",
+    "find_compiler.cmake",
+])
+
+skip_groups = set([
+    "src",  # skip the root src/CMakeLists.txt
+])
+
+# Other internal functions that don't need to be documented publicly
+allowed_missing_functions = set([
+    "pico_init_pioasm",
+    "pico_init_picotool",
+    "pico_add_platform_library",
+    "pico_get_runtime_output_directory",
+    "pico_set_printf_implementation",
+    "pico_expand_pico_platform",
+])
 
 all_functions = {}
 
@@ -39,7 +61,11 @@ all_functions = {}
 
 for dirpath, dirnames, filenames in os.walk(scandir):
     for filename in filenames:
+        if filename in skip_files:
+            continue
         group = os.path.basename(dirpath)
+        if group in skip_groups:
+            continue
         file_ext = os.path.splitext(filename)[1]
         if filename == 'CMakeLists.txt' or file_ext == '.cmake':
             file_path = os.path.join(dirpath, filename)
@@ -56,8 +82,8 @@ for dirpath, dirnames, filenames in os.walk(scandir):
 
                 for match in CMAKE_PICO_FUNCTIONS_RE.finditer(text):
                     name = match.group(1)
-                    if name not in all_functions:
-                        print(f"Warning: {name} function has no description")
+                    if name not in all_functions and name not in allowed_missing_functions:
+                        print(f"Warning: {name} function has no description in {file_path}")
 
 
 with open(outfile, 'w', newline='') as csvfile:

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+# Copyright (c) 2025 Raspberry Pi (Trading) Ltd.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
 #
 # Script to scan the Raspberry Pi Pico SDK tree searching for CMake functions
 # Outputs a tab separated file of the function:
-# name	signature	description
+# name	signature	description	group
 #
 # Usage:
 #
@@ -83,7 +83,7 @@ for dirpath, dirnames, filenames in os.walk(scandir):
                 for match in CMAKE_PICO_FUNCTIONS_RE.finditer(text):
                     name = match.group(1)
                     if name not in all_functions and name not in allowed_missing_functions:
-                        print(f"Warning: {name} function has no description in {file_path}")
+                        logger.warning("{} function has no description in {}".format(name, file_path))
 
 
 with open(outfile, 'w', newline='') as csvfile:

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -104,8 +104,8 @@ def process_commands(description, name, group, signature):
 
 
 def sort_functions(item):
-    group = item[1]['group']
-    name = item[1]['name']
+    group = item['group']
+    name = item['name']
 
     precedence = 5
     if group == 'other':
@@ -166,5 +166,5 @@ with open(outfile, 'w', newline='') as csvfile:
     writer = csv.DictWriter(csvfile, fieldnames=fieldnames, extrasaction='ignore', dialect='excel-tab')
 
     writer.writeheader()
-    for name, row in sorted(all_functions.items(), key=sort_functions):
+    for row in sorted(all_functions.values(), key=sort_functions):
         writer.writerow(row)

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+#
+# Script to scan the Raspberry Pi Pico SDK tree searching for CMake functions
+# Outputs a tab separated file of the function:
+# name	signature	description
+#
+# Usage:
+#
+# tools/extract_cmake_functions.py <root of repo> [output file]
+#
+# If not specified, output file will be `pico_cmake_functions.tsv`
+
+
+import os
+import sys
+import re
+import csv
+import logging
+
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+scandir = sys.argv[1]
+outfile = sys.argv[2] if len(sys.argv) > 2 else 'pico_cmake_functions.tsv'
+
+CMAKE_FUNCTION_RE = re.compile(r'^#(.*)((\n\s*#.*)*)\nfunction\(([^\s]*)', re.MULTILINE)
+
+
+all_functions = {}
+
+
+# Scan all CMakeLists.txt and .cmake files in the specific path, recursively.
+
+for dirpath, dirnames, filenames in os.walk(scandir):
+    # dirnames[:] = [d for d in dirnames if d != "lib"]
+    for filename in filenames:
+        file_ext = os.path.splitext(filename)[1]
+        if filename == 'CMakeLists.txt' or file_ext == '.cmake':
+            file_path = os.path.join(dirpath, filename)
+
+            with open(file_path, encoding="ISO-8859-1") as fh:
+                text = fh.read()
+                for match in CMAKE_FUNCTION_RE.finditer(text):
+                    name = match.group(4)
+                    signature = match.group(1).strip()
+                    description = match.group(2)
+                    description = description.replace('\n#\n', '\n\n').strip()
+                    description = description.replace('\n#', '').strip()
+                    description = description.replace('#', '').strip()
+                    if signature.startswith(name):
+                        all_functions[name] = (signature, description)
+
+
+print(all_functions)
+
+
+with open(outfile, 'w', newline='') as csvfile:
+    fieldnames = ('name', 'signature', 'description')
+    writer = csv.DictWriter(csvfile, fieldnames=fieldnames, extrasaction='ignore', dialect='excel-tab')
+
+    writer.writeheader()
+    for name, (signature, description) in sorted(all_functions.items()):
+        writer.writerow({'name': name, 'signature': signature, 'description': description})


### PR DESCRIPTION
This adds a script to extract CMake functions and output them as a TSV file, similar to `extract_cmake_configs.py` for `PICO_CMAKE_CONFIG` variables

Also adds basic descriptions for all functions missing them, other than some which are set as allowed to be missing them in the script