### PR TITLE
Make doxygen buildable again

### DIFF
--- a/src/rp2_common/pico_lwip/doc.h
+++ b/src/rp2_common/pico_lwip/doc.h
@@ -51,18 +51,12 @@
  *
  * This library enables you to make use of the LwIP HTTP client and server library
  *
- * \par LwIP HTTP server
- *
  * To make use of the LwIP HTTP server you need to provide the HTML that the server will return to the client.
  * This is done by compiling the content directly into the executable.
- *
- * \par makefsdata
  *
  * LwIP provides a c-library tool `makefsdata` to compile your HTML into a source file for inclusion into your program.
  * This is quite hard to use as you need to compile the tool as a native binary, then run the tool to generate a source file
  * before compiling your code for the Pico device.
- *
- * \par pico_set_lwip_httpd_content
  *
  * To make this whole process easier, a python script `makefsdata.py` is provided to generate a source file for your HTML content.
  * A CMake function `pico_set_lwip_httpd_content` takes care of running the `makefsdata.py` python script for you.


### PR DESCRIPTION
Unfortunately in #2411 @peterharperuk used a doxygen `\par` keyword which isn't supported by our [`doxygentoasciidoc`](https://github.com/raspberrypi/doxygentoasciidoc) repo, and this broke the building of both https://www.raspberrypi.com/documentation/pico-sdk/ and https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf

@mudge It fails with:
```
....
  File ".../lib/doxygentoasciidoc/nodes.py", line 223, in nodefor
    return {
KeyError: 'title'
```

Removing these "erroneous" 3 lines from `pico_lwip/doc.h` is probably easier than fixing up the rest of our doxygen pipeline :wink: 
And I don't _think_ that this change has too much of an impact on the `pico_lwip_http` documentation?

(ping also @will-v-pi as he pointed out the problem to me)