### PR TITLE
Fix submodule path typos

### DIFF
--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -1,4 +1,4 @@
-# PICO_CMAKE_CONFIG: PICO_BTSTACK_PATH, Path to an alternative version of btstack overriding the version in pico-sdk/libs/btstack. Can be passed to cmake or set in your environment, type=string, group=pico_btstack
+# PICO_CMAKE_CONFIG: PICO_BTSTACK_PATH, Path to an alternative version of btstack overriding the version in pico-sdk/lib/btstack. Can be passed to cmake or set in your environment, type=string, group=pico_btstack
 if (DEFINED ENV{PICO_BTSTACK_PATH} AND (NOT PICO_BTSTACK_PATH))
     set(PICO_BTSTACK_PATH $ENV{PICO_BTSTACK_PATH})
     message("Using PICO_BTSTACK_PATH from environment ('${PICO_BTSTACK_PATH}')")

--- a/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# PICO_CMAKE_CONFIG: PICO_CYW43_DRIVER_PATH, Path to an alternative version of cyw43-driver overriding the version in pico-sdk/libs/cyw43-driver, type=string, group=pico_cyw43_driver
+# PICO_CMAKE_CONFIG: PICO_CYW43_DRIVER_PATH, Path to an alternative version of cyw43-driver overriding the version in pico-sdk/lib/cyw43-driver, type=string, group=pico_cyw43_driver
 if (DEFINED ENV{PICO_CYW43_DRIVER_PATH} AND (NOT PICO_CYW43_DRIVER_PATH))
     set(PICO_CYW43_DRIVER_PATH $ENV{PICO_CYW43_DRIVER_PATH})
     message("Using PICO_CYW43_DRIVER_PATH from environment ('${PICO_CYW43_DRIVER_PATH}')")

--- a/src/rp2_common/pico_lwip/CMakeLists.txt
+++ b/src/rp2_common/pico_lwip/CMakeLists.txt
@@ -1,4 +1,4 @@
-# PICO_CMAKE_CONFIG: PICO_LWIP_PATH, Path to an alternative version of lwip overriding the version in pico-sdk/libs/lwip. Can be passed to cmake or set in your environment, type=string, group=pico_lwip
+# PICO_CMAKE_CONFIG: PICO_LWIP_PATH, Path to an alternative version of lwip overriding the version in pico-sdk/lib/lwip. Can be passed to cmake or set in your environment, type=string, group=pico_lwip
 if (DEFINED ENV{PICO_LWIP_PATH} AND (NOT PICO_LWIP_PATH))
     set(PICO_LWIP_PATH $ENV{PICO_LWIP_PATH})
     message("Using PICO_LWIP_PATH from environment ('${PICO_LWIP_PATH}')")

--- a/src/rp2_common/pico_mbedtls/CMakeLists.txt
+++ b/src/rp2_common/pico_mbedtls/CMakeLists.txt
@@ -1,4 +1,4 @@
-# PICO_CMAKE_CONFIG: PICO_MBEDTLS_PATH, Path to an alternative version of mbedtls overriding the version in pico-sdk/libs/mbedtls. Can be passed to cmake or set in your environment, type=string, group=pico_mbedtls
+# PICO_CMAKE_CONFIG: PICO_MBEDTLS_PATH, Path to an alternative version of mbedtls overriding the version in pico-sdk/lib/mbedtls. Can be passed to cmake or set in your environment, type=string, group=pico_mbedtls
 if (DEFINED ENV{PICO_MBEDTLS_PATH} AND (NOT PICO_MBEDTLS_PATH))
     set(PICO_MBEDTLS_PATH $ENV{PICO_MBEDTLS_PATH})
     message("Using PICO_MBEDTLS_PATH from environment ('${PICO_MBEDTLS_PATH}')")

--- a/src/rp2_common/tinyusb/CMakeLists.txt
+++ b/src/rp2_common/tinyusb/CMakeLists.txt
@@ -1,4 +1,4 @@
-# PICO_CMAKE_CONFIG: PICO_TINYUSB_PATH, Path to an alternative version of tinyusb overriding the version in pico-sdk/libs/tinyusb. Can be passed to cmake or set in your environment, type=string, group=tinyusb_device
+# PICO_CMAKE_CONFIG: PICO_TINYUSB_PATH, Path to an alternative version of tinyusb overriding the version in pico-sdk/lib/tinyusb. Can be passed to cmake or set in your environment, type=string, group=tinyusb_device
 if (DEFINED ENV{PICO_TINYUSB_PATH} AND (NOT PICO_TINYUSB_PATH))
     set(PICO_TINYUSB_PATH $ENV{PICO_TINYUSB_PATH})
     message("Using PICO_TINYUSB_PATH from environment ('${PICO_TINYUSB_PATH}')")


### PR DESCRIPTION
Fix a common typo introduced in #2405 - our submodules are in [`lib/`](https://github.com/raspberrypi/pico-sdk/tree/develop/lib) not `libs/`.