### PR TITLE
Use cyw43_delay_ms() in cyw43_spi_reset() instead of sleep_ms()

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_bus_pio_spi.c
@@ -359,9 +359,9 @@ void cyw43_spi_gpio_setup(void) {
 // Reset wifi chip
 void cyw43_spi_reset(void) {
     gpio_put(CYW43_PIN_WL_REG_ON, false); // off
-    sleep_ms(20);
+    cyw43_delay_ms(20);
     gpio_put(CYW43_PIN_WL_REG_ON, true); // on
-    sleep_ms(250);
+    cyw43_delay_ms(250);
 
     // Setup IRQ (24) - also used for DO, DI
     gpio_init(CYW43_PIN_WL_HOST_WAKE);


### PR DESCRIPTION
Since `cyw43_spi_reset()` may be executed from an async context, we should use `cyw43_delay_ms()` instead of `sleep_ms()`. This is particularly a problem when using the `async_context_threadsafe_background` backend, because `sleep_ms()` will assert in an ISR.