### PR TITLE
Fix binary_info compilation in C++

### DIFF
--- a/src/common/pico_binary_info/include/pico/binary_info/code.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/code.h
@@ -156,8 +156,8 @@ static const struct _binary_info_named_group __bi_lineno_var_name = { \
             .tag = _parent_tag, \
         },\
         .parent_id = _parent_id, \
-        .group_tag = _group_tag, \
         .flags = _flags, \
+        .group_tag = _group_tag, \
         .group_id = _group_id, \
         .label = _label \
     }


### PR DESCRIPTION
Due to out-of-order designated initialisers, which C++ has a strict requirement that they be in the order declared in the struct.

Fixes #2425 