### PR TITLE
Revert "Add --recursive flag to git submodule cmd (#2416)"

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Checkout submodules
-        run: git submodule update --init --recursive
+        run: git submodule update --init
       - name: Install dependencies
         run: |
           brew install cmake

--- a/.github/workflows/multi-gcc.yml
+++ b/.github/workflows/multi-gcc.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Checkout submodules
-      run: git submodule update --init --recursive
+      run: git submodule update --init
 
     - name: Host Release
       run: cd ${{github.workspace}}; mkdir -p build; rm -rf build/*; cd build; cmake ../ -DPICO_SDK_TESTS_ENABLED=1 -DCMAKE_BUILD_TYPE=Release -DPICO_NO_PICOTOOL=1 -DPICO_PLATFORM=host; make --output-sync=target --no-builtin-rules --no-builtin-variables -j$(nproc)

--- a/.github/workflows/scripts/generate_multi_gcc_workflow.py
+++ b/.github/workflows/scripts/generate_multi_gcc_workflow.py
@@ -94,7 +94,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Checkout submodules
-      run: git submodule update --init --recursive
+      run: git submodule update --init
 
     - name: Host Release
       run: cd ${{github.workspace}}; mkdir -p build; rm -rf build/*; cd build; cmake ../ -DPICO_SDK_TESTS_ENABLED=1 -DCMAKE_BUILD_TYPE=Release -DPICO_NO_PICOTOOL=1 -DPICO_PLATFORM=host; make --output-sync=target --no-builtin-rules --no-builtin-variables -j$(nproc)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Checkout submodules
-        run: git submodule update --init --recursive
+        run: git submodule update --init
       - name: Install dependencies
         run: choco install .github/workflows/choco_packages.config
 


### PR DESCRIPTION
This reverts commit 5592322465b449ef01ca5b4290f2f03fdff71381.

We shouldn't need this change anymore. It was caused by picotool using mbedtls and this issue has been fixed. Remove the --recursive flag so we notice issues like this in future.