### PR TITLE
Crashes after calling btstack_cyw43_deinit

### DIFF
--- a/src/rp2_common/pico_btstack/btstack_run_loop_async_context.c
+++ b/src/rp2_common/pico_btstack/btstack_run_loop_async_context.c
@@ -129,6 +129,14 @@ const btstack_run_loop_t *btstack_run_loop_async_context_get_instance(async_cont
     return &btstack_run_loop_async_context;
 }
 
+void btstack_run_loop_async_context_deinit(void) {
+    if (btstack_async_context) {
+        async_context_remove_at_time_worker(btstack_async_context, &btstack_timeout_worker);
+        async_context_remove_when_pending_worker(btstack_async_context, &btstack_processing_worker);
+        btstack_async_context = NULL;
+    }
+}
+
 static void btstack_timeout_reached(__unused async_context_t *context, __unused async_at_time_worker_t *worker) {
     // simply wakeup worker
     async_context_set_work_pending(btstack_async_context, &btstack_processing_worker);

--- a/src/rp2_common/pico_btstack/include/pico/btstack_run_loop_async_context.h
+++ b/src/rp2_common/pico_btstack/include/pico/btstack_run_loop_async_context.h
@@ -23,6 +23,12 @@ extern "C" {
  */
 const btstack_run_loop_t *btstack_run_loop_async_context_get_instance(async_context_t *context);
 
+/**
+ * \brief Deinitialize the BTstack state to stop it using the async_context API
+ * \ingroup pico_btstack
+ */
+void btstack_run_loop_async_context_deinit(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rp2_common/pico_cyw43_driver/btstack_cyw43.c
+++ b/src/rp2_common/pico_cyw43_driver/btstack_cyw43.c
@@ -69,6 +69,7 @@ bool btstack_cyw43_init(async_context_t *context) {
 void btstack_cyw43_deinit(__unused async_context_t *context) {
     hci_power_control(HCI_POWER_OFF);
     hci_close();
+    btstack_run_loop_async_context_deinit();
     btstack_run_loop_deinit();
     btstack_memory_deinit();
 }


### PR DESCRIPTION
You can deinitialise cyw43 and btstack by calling btstack_cyw43_deinit but its pending and timeout workers are not removed which means they can keep running, which causes a crash.

Add a btstack_run_loop_async_context_deinit method and call this from btstack_cyw43_deinit.
