### PR TITLE
fix typo in PICO_RUNTIME_SKIP_INIT_POST_CLOCK_RESETS (was missing INIT)

### DIFF
--- a/src/rp2_common/pico_runtime_init/runtime_init.c
+++ b/src/rp2_common/pico_runtime_init/runtime_init.c
@@ -152,7 +152,7 @@ void __weak runtime_init_post_clock_resets(void) {
 }
 #endif
 
-#if !PICO_RUNTIME_SKIP_POST_CLOCK_RESETS
+#if !PICO_RUNTIME_SKIP_INIT_POST_CLOCK_RESETS
 PICO_RUNTIME_INIT_FUNC_HW(runtime_init_post_clock_resets, PICO_RUNTIME_INIT_POST_CLOCK_RESETS);
 #endif
 


### PR DESCRIPTION
I don't feel the need to preserve backwards compatibility here as I don't imagine anyone has much used it (it now matches the naming of everything else)