### PR TITLE
Add support for wiznet_w5100s_evb_pico2

### DIFF
--- a/src/boards/include/boards/wiznet_w5100s_evb_pico2.h
+++ b/src/boards/include/boards/wiznet_w5100s_evb_pico2.h
@@ -17,6 +17,9 @@ pico_board_cmake_set(PICO_PLATFORM, rp2350)
 // For board detection
 #define WIZNET_W5100S_EVB_PICO2
 
+// --- RP2350 VARIANT ---
+#define PICO_RP2350A 1
+
 // --- BOARD SPECIFIC ---
 #ifndef W5100S_EVB_PICO2_INTN_PIN
 #define W5100S_EVB_PICO2_INTN_PIN 21

--- a/src/boards/include/boards/wiznet_w5100s_evb_pico2.h
+++ b/src/boards/include/boards/wiznet_w5100s_evb_pico2.h
@@ -9,10 +9,10 @@
 //       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
 // -----------------------------------------------------
 
-// pico_cmake_set PICO_PLATFORM=rp2350
-
 #ifndef _BOARDS_WIZNET_W5100S_EVB_PICO2_H
 #define _BOARDS_WIZNET_W5100S_EVB_PICO2_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2350)
 
 // For board detection
 #define WIZNET_W5100S_EVB_PICO2
@@ -89,7 +89,7 @@
 #define PICO_FLASH_SPI_CLKDIV 2
 #endif
 
-// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (2 * 1024 * 1024)
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (2 * 1024 * 1024))
 #ifndef PICO_FLASH_SIZE_BYTES
 #define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
 #endif
@@ -107,7 +107,7 @@
 #define PICO_VSYS_PIN 29
 #endif
 
-// pico_cmake_set_default PICO_RP2350_A2_SUPPORTED = 1
+pico_board_cmake_set_default(PICO_RP2350_A2_SUPPORTED, 1)
 #ifndef PICO_RP2350_A2_SUPPORTED
 #define PICO_RP2350_A2_SUPPORTED 1
 #endif

--- a/src/boards/include/boards/wiznet_w5100s_evb_pico2.h
+++ b/src/boards/include/boards/wiznet_w5100s_evb_pico2.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// pico_cmake_set PICO_PLATFORM=rp2350
+
+#ifndef _BOARDS_WIZNET_W5100S_EVB_PICO2_H
+#define _BOARDS_WIZNET_W5100S_EVB_PICO2_H
+
+// For board detection
+#define WIZNET_W5100S_EVB_PICO2
+
+// --- BOARD SPECIFIC ---
+#ifndef W5100S_EVB_PICO2_INTN_PIN
+#define W5100S_EVB_PICO2_INTN_PIN 21
+#endif
+
+#ifndef W5100S_EVB_PICO2_RSTN_PIN
+#define W5100S_EVB_PICO2_RSTN_PIN 20
+#endif
+
+#ifndef W5100S_EVB_PICO2_A0_PIN
+#define W5100S_EVB_PICO2_A0_PIN 26
+#endif
+#ifndef W5100S_EVB_PICO2_A1_PIN
+#define W5100S_EVB_PICO2_A1_PIN 27
+#endif
+#ifndef W5100S_EVB_PICO2_A2_PIN
+#define W5100S_EVB_PICO2_A2_PIN 28
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (2 * 1024 * 1024)
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+#define PICO_SMPS_MODE_PIN 23
+
+// The GPIO Pin used to read VBUS to determine if the device is battery powered.
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+// pico_cmake_set_default PICO_RP2350_A2_SUPPORTED = 1
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+#endif


### PR DESCRIPTION
This board has an RP2350 and a smaller 2MB flash
Building for this board requires manually setting flash size. There already is a board definition for its RP2040 sibling, why not adding one for this board ?
No related issues
