### PR TITLE
Fix pioasm build failure caused by GCC 15 changes (#2448)

### DIFF
--- a/tools/pioasm/output_format.h
+++ b/tools/pioasm/output_format.h
@@ -7,6 +7,7 @@
 #ifndef _OUTPUT_FORMAT_H
 #define _OUTPUT_FORMAT_H
 
+#include <cstdint>
 #include <vector>
 #include <map>
 #include <string>

--- a/tools/pioasm/pio_types.h
+++ b/tools/pioasm/pio_types.h
@@ -7,6 +7,7 @@
 #ifndef _PIO_TYPES_H
 #define _PIO_TYPES_H
 
+#include <cstdint>
 #include <string>
 #include <map>
 #include <set>


### PR DESCRIPTION
Fixes #2448 .
Inserted missing `<cstdint>` in several files to make it possible to build `pioasm` on GCC 15 again. Tested on latest Arch Linux with GCC 15.1.1.