### PR TITLE
Set PICO_RP2350A to 1 for Pimoroni PGA2350

### DIFF
--- a/src/boards/include/boards/pimoroni_pga2350.h
+++ b/src/boards/include/boards/pimoroni_pga2350.h
@@ -21,7 +21,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2350)
 #define PIMORONI_PGA2350_16MB
 
 // --- RP2350 VARIANT ---
-#define PICO_RP2350A 0
+#define PICO_RP2350A 1
 
 // --- BOARD SPECIFIC ---
 #define PIMORONI_PGA2350_PSRAM_CS_PIN 47


### PR DESCRIPTION
- **start 2.1.2-develop**
- **Fix misleading error messages in spin_lock.h (#2326)**
- **Add upcoming sparkfun board (#2329)**
- **fix return type of enable/disable interrupt methods... add host versions for completeness (#2310)**
- **Fix use of PICO_RP2040 macro. (#2356)**
- **Add SparkFun XRP Controller header (#2347)**
- **Add board file for Eelectronicparts Pico Mini in 2,4,8,16MB variants (#2346)**
- **Remove assignment of cyw43 last_size/header/backplane_window variables (#2306)**
- **Check for the misuse of '#define PICO_RP2350B' in board headers (#2290)**
- **Remove FIXME delete comment (#2341)**
- **Adjust generated name to match pio_mov_status_type (#2324)**
- **Add Bazel label flag for overriding tusb_config.h (#2264)**
- **Missed doc change in #850 (#2302)**
- **Fix tools/build_all_headers.py to cope with chip-specific headers (#2292)**
- **pico_lwip_arch is actually what depends on pico_rand (#2303)**
- **Fix PICO_PREVIOUS_PLATFORM error (#2357)**
- **Update hellbender_0001.h (#2359)**
- **Fix #2253  cybt_printf by wrapping with NDEBUG (#2323)**
- **Add new feature defines to pico_stdio_usb (#2296)**
- **Add rom_pick_ab_update_partition function (#2182)**
- **Throw a warning when using the example signing/encryption keys (#2352)**
- **Add new stdio_usb_call_chars_available_callback() function (#2300)**
- **Look for PICO_CONFIG: entries in .S files too (#2368)**
- **Add SPARE_IRQs to the SVD (#2271)**
- **Initial commit pulled in a bunch of stuff - see description**
- **Move unique_id (configurably) earlier in the static init process (#2379)**
- **Fix sign conversion error introduced by #2233 (#2392)**
- **move irq_has_handler() so it can be used without shared handlers (#2383)**
- **unclaim alarm on correct timer in ta_disable_irq_handler (#2382)**
- **Properly respect setting PICO_DEFAULT_BINARY_TYPE (#2381)**
- **Fix bug in extract_configs.py (#2389)**
- **Fix WindowsCI (again) (#2388)**
- **Ensure that all RP2350 board-headers explicitly define PICO_RP2350A (#2370)**
- **Set default GATT path to CMAKE_CURRENT_LIST_DIR if not specified (#2385)**
- **Lots of small doxygen fixes (#2390)**
- **define __force_inline in host compiles (#2396)**
- **Force inline critical_section_{enter,exit} (#2393)**
- **Update mbedtls, lwip and cyw43-driver (#2405)**
- **Fix DST bug in aon_timer_get_time for rp2040 (#2409)**
- **Add some docs for pico_set_lwip_httpd_content (#2411)**
- **Change BT flash storage default for rp2350 A2 (#2412)**
- **Fix #2413 - Misleading comment about bootloader in rp2350/memmap_copy_to_ram.ld (#2415)**
- **Add --recursive flag to git submodule cmd (#2416)**
- **Rework use of pico_cmake_set in board headers to make it slightly less magic/confusing (#2397)**
- **Make doxygen buildable again (#2423)**
- **add word alignment for rtwopi (#2429)**
- **Revert "Make doxygen buildable again (#2423)" (#2437)**
- **Fix submodule path typos (#2424)**
- **Add CYW43_WL_GPIO_SMPS_PIN for pico_w and pico2_w (#2410)**
- **Ensure each test has a unique name (followup to #2208) (#2443)**
- **More board-header checks (followup to #2397) (#2442)**
- **Update hellbender_2350A_devboard.h for release version of the board. (#2441)**
- **Add script to extract CMake function descriptions (#2422)**
- **Revert "Add --recursive flag to git submodule cmd (#2416)" (#2445)**
- **Crashes after calling btstack_cyw43_deinit (#2446)**
- **Fix sha build issues with mbedtls 3.x (#2447)**
- **Fix binary_info compilation in C++ due to out-of-order designated initialisers (#2438)**
- **Fix wrong value used for lposc_freq_khz_frac and xosc_freq_khz_frac**
- **Small PICO_CONFIG tweak (#2456)**
- **Add PICO_CRT0_NO_RESET_SECTION (#2453)**
- **Add PICO_CRT0_NEAR_CALLS to indicate that crt0 can call runtimine_init/main/exit etc via near calls (#2452)**
- **Use cyw43_delay_ms() in cyw43_spi_reset() instead of sleep_ms() (#2431)**
- **fix typo in PICO_RUNTIME_SKIP_INIT_POST_CLOCK_RESETS (was missing INIT) (#2457)**
- **Set PICO_RP2350A to 1 for Pimoroni PGA2350**

_Instructions: (please delete)_
 - _please do not submit against `master`, use `develop` instead_
 - _please make sure there is an associated issue for your PR, and reference it via "Fixes #num" in the description_
 - _please enter a detailed description_
