### PR TITLE
Add printout of picotool location

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -139,6 +139,14 @@ function(pico_init_picotool)
         endif()
     endif()
 
+    if (TARGET picotool AND NOT DEFINED ENV{_PICOTOOL_FOUND_THIS_RUN})
+        # Internal environment variable to prevent printing multiple times
+        set(ENV{_PICOTOOL_FOUND_THIS_RUN} 1)
+
+        get_property(picotool_location TARGET picotool PROPERTY LOCATION)
+        message("Using picotool from ${picotool_location}")
+    endif()
+
     if (TARGET picotool)
         set(picotool_FOUND 1 PARENT_SCOPE)
     else()


### PR DESCRIPTION
This prints out the location of the picotool executable being used when configuring CMake. Note that for a picotool fetched by the SDK, this may not exist yet, as it is only build during the build step.

For example:
* `Using picotool from /usr/local/bin/picotool` for a system install
* `Using picotool from /home/name/pico-examples/build/_deps/picotool/picotool` for a picotool fetched by the SDK
