### PR TITLE
Look for other possible "missing PICO_CONFIG" lines, and make message more obvious

### DIFF
--- a/tools/extract_configs.py
+++ b/tools/extract_configs.py
@@ -231,8 +231,9 @@ for all_configs in chips_all_configs.values():
 chips_resolved_defines = defaultdict(dict)
 for applicable, all_defines in chips_all_defines.items():
     for d in all_defines:
-        if d not in all_config_names and d.startswith("PICO_"):
-            logger.warning("Potential unmarked PICO define {}".format(d))
+        for define_prefix in ('PICO', 'PARAM', 'CYW43'):
+            if d not in all_config_names and d.startswith(define_prefix+'_'):
+                logger.warning("#define {} is potentially missing a {}: entry".format(d, BASE_CONFIG_NAME))
         resolved_defines = chips_resolved_defines[applicable]
         # resolve "nested defines" - this allows e.g. USB_DPRAM_MAX to resolve to USB_DPRAM_SIZE which is set to 4096 (which then matches the relevant PICO_CONFIG entry)
         for val in all_defines[d]:


### PR DESCRIPTION
This was inspired after writing [this comment](https://github.com/raspberrypi/pico-sdk/pull/2470#issuecomment-2896808387) last night. It changes the warning-output of `tools/extract_configs.py` to:
```
WARNING:__main__:#define PICO_FLASH_SPI_CLKDIV is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_FLASH_SPI_RXDELAY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_BOOT_STAGE2_NAME is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_BOOT_STAGE2_ASM is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_FLASH_BANK_SIZE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_POWMAN_DEBUG is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_GPIO_IRQ_HANDLER_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_SLEEP_CHECK_MS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_PACKET_HEADER_SIZE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_HOST_NAME is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_GPIO is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_LOGIC_DEBUG is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_USE_OTP_MAC is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_NO_NETUTILS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_IOCTL_TIMEOUT_US is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_USE_STATS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_HAL_MAC_WLAN0 is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_USE_SPI is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_SPI_PIO is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_CHIPSET_FIRMWARE_INCLUDE_FILE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_WIFI_NVRAM_INCLUDE_FILE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_EPERM is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_EIO is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_EINVAL is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_ETIMEDOUT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_WL_GPIO_COUNT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_NUM_GPIOS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_PIN_WL_REG_ON is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_PIN_WL_DATA_OUT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_PIN_WL_DATA_IN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_PIN_WL_HOST_WAKE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_PIN_WL_CLOCK is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_PIN_WL_CS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_HAL_PIN_MODE_INPUT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_HAL_PIN_MODE_OUTPUT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_HAL_PIN_PULL_NONE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_HAL_PIN_PULL_UP is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_HAL_PIN_PULL_DOWN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_THREAD_ENTER is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_THREAD_EXIT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_THREAD_LOCK_CHECK is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_SDPCM_SEND_COMMON_WAIT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_DO_IOCTL_WAIT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_POST_POLL_HOOK is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_FLOAT_IN_RAM is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_LWIP_CUSTOM_LOCK_TCPIP_CORE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_UNIQUE_BOARD_ID_SIZE_BYTES is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_UNIQUE_BOARD_ID_INIT_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_LOWEST_IRQ_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_HIGHEST_IRQ_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SHARED_IRQ_HANDLER_LOWEST_ORDER_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_EMULATE_DIVIDER is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_PANIC_FUNCTION_EMPTY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RAM_VECTOR_TABLE_SIZE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_EARLIEST is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_BOOTROM_RESET is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_PER_CORE_BOOTROM_RESET is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_PER_CORE_H3_IRQ_REGISTERS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_EARLY_RESETS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_USB_POWER_DOWN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_PER_CORE_ENABLE_COPROCESSORS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_AEABI_MEM_OPS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_AEABI_BIT_OPS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_AEABI_FLOAT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_AEABI_DOUBLE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_CLOCKS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_POST_CLOCK_RESETS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_RP2040_GPIO_IE_DISABLE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_SPIN_LOCKS_RESET is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_BOOT_LOCKS_RESET is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_BOOTROM_LOCKING_ENABLE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_MUTEX is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_PER_CORE_IRQ_PRIORITIES is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_PER_CORE_TLS_SETUP is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_INSTALL_RAM_VECTOR_TABLE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_DEFAULT_ALARM_POOL is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_PER_CORE_INSTALL_STACK_GUARD is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_C_COMPILER_IS_CLANG is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_C_COMPILER_IS_GNU is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ASSEMBLER_IS_CLANG is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ASSEMBLER_IS_GNU is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_PROGRAM_BUILD_DATE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_PROGRAM_NAME is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_CRT0_INCLUDE_PICOBIN_IMAGE_TYPE_ITEM is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_CRT0_INCLUDE_PICOBIN_VECTOR_TABLE_ITEM is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_CRT0_INCLUDE_PICOBIN_ENTRY_POINT_ITEM is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_CRT0_INCLUDE_PICOBIN_BLOCK is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_CRT0_INCLUDE_PICOBIN_END_BLOCK is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_CRT0_VERSION_MAJOR is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_LOWEST_EXCEPTION_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_HIGHEST_EXCEPTION_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_FLASH_SAFE_EXECUTE_USE_FREERTOS_SMP is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_PLL_VCO_MIN_FREQ_HZ is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_PLL_VCO_MAX_FREQ_HZ is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_BINARY_INFO_USE_PINS_64 is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_FLASH_SPI_CLKDIV is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SMPS_MODE_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_DEFAULT_WS2812_NUM_PIXELS is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_VBUS_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_VSYS_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_WL_GPIO_LED_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_UART1_TX_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_UART1_RX_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_I2C0_SDA_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_I2C0_SCL_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SPI1_CSN_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SPI1_SCK_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SPI1_TX_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SPI1_RX_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ADC_A0_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ADC_A1_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ADC_A2_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ADC_BAT_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ADC_BAT_EN_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SD_CLK_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SD_CMD_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SD_DAT0_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SD_DAT3_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SD_DAT_PIN_COUNT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_WL_GPIO_VBUS_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_DEFAULT_PIO_USB_DP_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_WL_GPIO_SMPS_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define CYW43_USES_VSYS_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SCANVIDEO_COLOR_PIN_BASE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SCANVIDEO_SYNC_PIN_BASE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SD_DAT_PIN_INCREMENT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_AUDIO_I2S_DATA_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_AUDIO_I2S_CLOCK_PIN_BASE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_AUDIO_PWM_L_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_AUDIO_PWM_R_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_ON_FPGA is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SCANVIDEO_COLOR_PIN_COUNT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SCANVIDEO_DPI_PIXEL_RSHIFT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SCANVIDEO_DPI_PIXEL_GSHIFT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SCANVIDEO_DPI_PIXEL_BSHIFT is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SCANVIDEO_48MHZ is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_AUDIO_PWM_MONO_PIN is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_LOWEST_IRQ_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_HIGHEST_IRQ_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_SHARED_IRQ_HANDLER_LOWEST_ORDER_PRIORITY is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_EARLIEST is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_LATEST is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_TYPE_HW is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_TYPE_RUNTIME is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_RUNTIME_INIT_TYPE_PER_CORE is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_FLASH_SPI_CLKDIV is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_BOOT_STAGE2_NAME is potentially missing a PICO_CONFIG: entry
WARNING:__main__:#define PICO_BOOT_STAGE2_ASM is potentially missing a PICO_CONFIG: entry
```