### PR TITLE
Remove DEPENDS argument from add_custom_command(TARGET...) functions

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -660,7 +660,6 @@ function(picotool_postprocess_binary TARGET)
         # Embed PT
         if (picotool_embed_pt)
             add_custom_command(TARGET ${TARGET} POST_BUILD
-                DEPENDS ${picotool_embed_pt}
                 COMMAND picotool partition create --quiet ${picotool_embed_pt} $<TARGET_FILE:${TARGET}> $<TARGET_FILE:${TARGET}>
                 VERBATIM)
         endif()
@@ -672,7 +671,6 @@ function(picotool_postprocess_binary TARGET)
             extra_process_args
         )
         add_custom_command(TARGET ${TARGET} POST_BUILD
-            DEPENDS ${picotool_sigfile}
             COMMAND picotool
             ARGS seal
                 --quiet
@@ -700,7 +698,6 @@ function(picotool_postprocess_binary TARGET)
             endif()
 
             add_custom_command(TARGET ${TARGET} POST_BUILD
-                DEPENDS ${picotool_enc_sigfile} ${picotool_aesfile} ${picotool_ivfile}
                 COMMAND picotool
                 ARGS encrypt
                     --quiet --hash --sign


### PR DESCRIPTION
This raises a warning with recent CMake versions, and isn't required due to the `pico_add_link_depend` already added for these files in #2027

Fixes raspberrypi/picotool#235