### PR TITLE
Call enable_interrupts when initialising IRQs

### DIFF
--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -680,8 +680,10 @@ __weak void runtime_init_per_core_irq_priorities(void) {
     }
 #endif
 #endif
-    // enable interrupts that might be disabled by a previous bootloader stage
+#if !PICO_RP2040
+    // enable interrupts that might be disabled by a previous bootloader stage (guarded for RP2040 as there is no bootrom chain_image call there)
     enable_interrupts();
+#endif
 }
 
 static uint get_user_irq_claim_index(uint irq_num) {

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -666,8 +666,6 @@ void irq_add_tail_to_free_list(struct irq_handler_chain_slot *slot) {
 #endif
 
 __weak void runtime_init_per_core_irq_priorities(void) {
-    // enable interrupts that might be disabled by a previous bootloader stage
-    enable_interrupts();
 #if PICO_DEFAULT_IRQ_PRIORITY != 0
 #ifndef __riscv
     // static_assert(!(NUM_IRQS & 3), ""); // this isn't really required - the reg is still 32 bit
@@ -682,6 +680,8 @@ __weak void runtime_init_per_core_irq_priorities(void) {
     }
 #endif
 #endif
+    // enable interrupts that might be disabled by a previous bootloader stage
+    enable_interrupts();
 }
 
 static uint get_user_irq_claim_index(uint irq_num) {

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -666,6 +666,8 @@ void irq_add_tail_to_free_list(struct irq_handler_chain_slot *slot) {
 #endif
 
 __weak void runtime_init_per_core_irq_priorities(void) {
+    // enable interrupts that might be disabled by a previous bootloader stage
+    enable_interrupts();
 #if PICO_DEFAULT_IRQ_PRIORITY != 0
 #ifndef __riscv
     // static_assert(!(NUM_IRQS & 3), ""); // this isn't really required - the reg is still 32 bit


### PR DESCRIPTION
Interrupts are often disabled when calling `chain_image` to avoid them firing during the chain, so they need to be re-enabled by the binary that has been chained into

Fixes raspberrypi/pico-examples#584, supercedes raspberrypi/pico-examples#588