### PR TITLE
Don't include the picobin end block when sealing

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -671,16 +671,18 @@ function(picotool_postprocess_binary TARGET)
             uf2_package_addr OR
             extra_process_args
         )
-        add_custom_command(TARGET ${TARGET} POST_BUILD
-            DEPENDS ${picotool_sigfile}
-            COMMAND picotool
-            ARGS seal
-                --quiet
-                $<TARGET_FILE:${TARGET}> $<TARGET_FILE:${TARGET}>
-                ${picotool_sigfile} ${otp_file}
-                ${picotool_args}
-            COMMAND_EXPAND_LISTS
-            VERBATIM)
+            # We don't need the extra end block, as picotool seal will add one
+            target_compile_definitions(${TARGET} PRIVATE PICO_CRT0_INCLUDE_PICOBIN_END_BLOCK=0)
+            add_custom_command(TARGET ${TARGET} POST_BUILD
+                DEPENDS ${picotool_sigfile}
+                COMMAND picotool
+                ARGS seal
+                    --quiet
+                    $<TARGET_FILE:${TARGET}> $<TARGET_FILE:${TARGET}>
+                    ${picotool_sigfile} ${otp_file}
+                    ${picotool_args}
+                COMMAND_EXPAND_LISTS
+                VERBATIM)
         endif()
         # Encryption
         if (picotool_aesfile AND picotool_ivfile)


### PR DESCRIPTION
Don't include the picobin end block when sealing, as picotool will add a new end block anyway, so the extra ignored block is uneccessary. This saves 5 words of space in sealed binaries.

This will need rebasing once #2489 is merged to remove the `DEPENDS`