### PR TITLE
i2c abort change

### DIFF
--- a/src/rp2_common/hardware_i2c/i2c.c
+++ b/src/rp2_common/hardware_i2c/i2c.c
@@ -298,7 +298,7 @@ static int i2c_read_blocking_internal(i2c_inst_t *i2c, uint8_t addr, uint8_t *ds
 
         do {
             abort_reason = i2c->hw->tx_abrt_source;
-            if (i2c->hw->raw_intr_stat & I2C_IC_RAW_INTR_STAT_TX_ABRT_BITS) {
+            if (abort_reason) {
                 abort = true;
                 i2c->hw->clr_tx_abrt;
             }


### PR DESCRIPTION
Elsewhere we just read to clear clr_tx_abrt if the abort reason is set.

Speculative fix for #1471
