### PR TITLE
Fix use-after-return race in handle_sync_func_call()

### DIFF
--- a/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
+++ b/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
@@ -98,8 +98,8 @@ typedef struct sync_func_call{
 static void handle_sync_func_call(async_context_t *context, async_when_pending_worker_t *worker) {
     sync_func_call_t *call = (sync_func_call_t *)worker;
     call->rc = call->func(call->param);
-    sem_release(&call->sem);
     async_context_remove_when_pending_worker(context, worker);
+    sem_release(&call->sem);
 }
 #endif
 


### PR DESCRIPTION
# Description

This PR corrects the call order in handle_sync_func_call() to avoid a potential use-after-return bug.

Previously, sem_release(&call->sem) was called before removing the worker from the pending list. This allows a waiting thread to proceed and potentially free the sync_func_call_t structure, while it was still linked and accessed within async_context_remove_when_pending_worker().

# Fix
Reordered the function calls so that the worker is unlinked before releasing the semaphore:

```c
async_context_remove_when_pending_worker(context, worker);
sem_release(&call->sem);
```

This ensures safe memory access and resolves rare race conditions observed under high-frequency stress testing (~185 execute_sync() calls/sec sustained for 6+ hours without fault).

Fixes raspberrypi/pico-sdk#2433

