### PR TITLE
Fix error in watchdog.h

### DIFF
--- a/src/rp2_common/hardware_watchdog/include/hardware/watchdog.h
+++ b/src/rp2_common/hardware_watchdog/include/hardware/watchdog.h
@@ -121,14 +121,14 @@ bool watchdog_caused_reboot(void);
 bool watchdog_enable_caused_reboot(void);
 
 /**
- * \brief Returns the number of microseconds before the watchdog will reboot the chip.
+ * \brief Returns the number of milliseconds before the watchdog will reboot the chip.
  * \ingroup hardware_watchdog
  *
  * \if rp2040_specicifc
  * On RP2040 this method returns the last value set instead of the remaining time due to a h/w bug.
  * \endif
  * 
- * @return The number of microseconds before the watchdog will reboot the chip.
+ * @return The number of milliseconds before the watchdog will reboot the chip.
  */
 uint32_t watchdog_get_time_remaining_ms(void);
 


### PR DESCRIPTION
Fixes #2496

As said in the issue, the documentation for `watchdog_get_time_remaining_ms` says it returns the time in microseconds, while this should be milliseconds. Function its self is fine, just a small docs error.

