### PR TITLE
Clean extra output files

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -556,6 +556,7 @@ function(pico_add_uf2_output TARGET)
     else()
         set(output_path "")
     endif()
+    pico_get_output_name(${TARGET} output_name)
 
     get_target_property(${TARGET}_uf2_package_addr ${TARGET} PICOTOOL_UF2_PACKAGE_ADDR)
     if (${TARGET}_uf2_package_addr)
@@ -594,7 +595,8 @@ function(pico_add_uf2_output TARGET)
                 --family ${picotool_family}
                 ${extra_uf2_args}
             COMMAND_EXPAND_LISTS
-            VERBATIM)
+            VERBATIM
+            BYPRODUCTS "${output_path}${output_name}.uf2")
     endif()
 endfunction()
 

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -50,6 +50,7 @@ allowed_missing_functions = set([
     "pico_init_picotool",
     "pico_add_platform_library",
     "pico_get_runtime_output_directory",
+    "pico_get_output_name",
     "pico_set_printf_implementation",
     "pico_expand_pico_platform",
 ])


### PR DESCRIPTION
Add bin/uf2/dis/hex output files as byproducts, so they get cleaned up when using `make clean` (or similar)

This is only best-effort, because `BYPRODUCTS` doesn't support generator expressions (https://gitlab.kitware.com/cmake/cmake/-/issues/12877), so everything must be evaluated at the time `pico_add_extra_outputs` is called. This shouldn't have any ill effects, other than not cleaning up the extra output files if `OUTPUT_NAME` is set after calling `pico_add_extra_outputs`.