### PR TITLE
Fix powman powman_configure_wakeup_state and powman_get_power_state

### DIFF
--- a/src/rp2_common/hardware_powman/powman.c
+++ b/src/rp2_common/hardware_powman/powman.c
@@ -125,7 +125,7 @@ void powman_timer_disable_gpio_1hz_sync(void) {
 }
 
 powman_power_state powman_get_power_state(void) {
-    uint32_t state_reg = powman_hw->state & POWMAN_STATE_CURRENT_BITS;
+    uint32_t state_reg = ~powman_hw->state & POWMAN_STATE_CURRENT_BITS;
     // todo we should have hardware/regs/powman.h values for these
     static_assert(POWMAN_POWER_DOMAIN_SRAM_BANK1 == 0, "");
     static_assert(POWMAN_POWER_DOMAIN_SRAM_BANK0 == 1, "");


### PR DESCRIPTION
This PR resolves issues #2506 and #2511:

To conform with SDK usage, `powman_get_power_state` now returns the complemented contents of field `POWMAN_STATE_CURRENT_BITS` of the `POWMAN` `STATE` register (#2506).

Corrects operation of `powman_configure_wakeup_state` (#2511):

- Validates that sleep state is one of the `P1.x` states, and that the wake-up state is one of the `P0.x` states.
- Correctly validates power manager state transitions while taking into account the current state, the sleep state, and the wake-up state. Validation conforms to section 6.2.3 of the RP2350 datasheet.
- Sets the `SEQ_CFG` register bits `HW_PWRUP_SRAM0` and `HW_PWRUP_SRAM1` while taking into account both the sleep state and the wake-up state.