### PR TITLE
Add UUGear Witty Pi 5 HAT+ board header file

### DIFF
--- a/src/boards/include/boards/uugear_wittypi5_hat_plus.h
+++ b/src/boards/include/boards/uugear_wittypi5_hat_plus.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Dun Cat B.V.(UUGear)
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/uugear_wittypi5_hat_plus.h"
+
+// pico_cmake_set PICO_PLATFORM=rp2350
+
+#ifndef _BOARDS_UUGEAR_WITTYPI5_HAT_PLUS_H
+#define _BOARDS_UUGEAR_WITTYPI5_HAT_PLUS_H
+
+// For board detection
+#define UUGEAR_WITTYPI5_HAT_PLUS
+
+// --- RP2350 VARIANT ---
+#define PICO_RP2350A 1
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 22
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (16 * 1024 * 1024)
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+// pico_cmake_set_default PICO_RP2350_A2_SUPPORTED = 1
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+// Sometimes the xosc may take longer to stabilize
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+#endif
+
+#endif


### PR DESCRIPTION
This PR introduces support for the UUGear [Witty Pi 5 HAT+](https://www.uugear.com/product/witty-pi-5/) board. 

Witty Pi 5 HAT+ uses RP2350A as the MCU, turning the Raspberry Pi into a device controlled by time, voltage, and temperature, while also simulating a USB flash drive and a USB serial port device.

Fixes #2517 