### PR TITLE
Add board definition for Adafruit Feather RP2040 Adalogger

### DIFF
--- a/src/boards/include/boards/adafruit_feather_rp2040_adalogger.h
+++ b/src/boards/include/boards/adafruit_feather_rp2040_adalogger.h
@@ -59,19 +59,19 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 
 //------------- SPI -------------//
 #ifndef PICO_DEFAULT_SPI
-#define PICO_DEFAULT_SPI 0
+#define PICO_DEFAULT_SPI 1
 #endif
 
 #ifndef PICO_DEFAULT_SPI_TX_PIN
-#define PICO_DEFAULT_SPI_TX_PIN 19
+#define PICO_DEFAULT_SPI_TX_PIN 15
 #endif
 
 #ifndef PICO_DEFAULT_SPI_RX_PIN
-#define PICO_DEFAULT_SPI_RX_PIN 20
+#define PICO_DEFAULT_SPI_RX_PIN 8
 #endif
 
 #ifndef PICO_DEFAULT_SPI_SCK_PIN
-#define PICO_DEFAULT_SPI_SCK_PIN 18
+#define PICO_DEFAULT_SPI_SCK_PIN 14
 #endif
 
 //------------- SD -------------//


### PR DESCRIPTION
Fixes #2522 

Based off of the existing Adafruit Feather RP2040 header (`adafruit_feather_rp2040.h`)

The only changes made from the regular Feather RP2040 board header are:

- Change NeoPixel/WS2812 pin `PICO_DEFAULT_WS2812_PIN` from 16 to 17

- Add defs for SD card pins (see SD section in header).


### Note on SD card pin defs:

I followed the conventions used for other boards with SD card pins defined, although none of the other boards I looked at had the SD "Card Detect" pin mapped so I named its pin `PICO_SD_CARD_DETECT_PIN`.

I think this should be all that is needed to provide *minimal* support for Pico SDK on this board variant, but please do let me know if I'm missing something.