### PR TITLE
async_context_threadsafe_background: fix incorrect mutex assertion in cross-core execute_sync()

### DIFF
--- a/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
+++ b/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
@@ -138,8 +138,9 @@ static void lock_release(async_context_threadsafe_background_t *self) {
 uint32_t async_context_threadsafe_background_execute_sync(async_context_t *self_base, uint32_t (*func)(void *param), void *param) {
     async_context_threadsafe_background_t *self = (async_context_threadsafe_background_t*)self_base;
 #if ASYNC_CONTEXT_THREADSAFE_BACKGROUND_MULTI_CORE
-    if (self_base->core_num != get_core_num()) {
-        hard_assert(!recursive_mutex_enter_count(&self->lock_mutex));
+	const uint calling_core = get_core_num();
+	if (self_base->core_num != calling_core) {
+	    hard_assert(self->lock_mutex.owner != calling_core);
         sync_func_call_t call = {0};
         call.worker.do_work = handle_sync_func_call;
         call.func = func;


### PR DESCRIPTION
… cross-core execute_sync()

In multicore configurations, `async_context_threadsafe_background_execute_sync()` contained an overly strict assertion used during cross-core calls:

```c
hard_assert(!recursive_mutex_enter_count(&self->lock_mutex));
```

This check fails whenever the `lock_mutex` is held — regardless of *who* owns it — even in valid situations where the async core is processing background work.

The assertion does **not check ownership**, only that the `enter_count` is zero, which leads to false-positive failures on valid cross-core calls.

This patch replaces the enter-count check with a core-aware assertion:

```c
hard_assert(self->lock_mutex.owner != calling_core);
```

This ensures the current core does not recursively hold the mutex, preventing deadlocks while allowing valid usage where the *other* core owns the lock.

The patch ensures that both `get_core_num()` and `hard_assert()` remain inlined as in the original implementation, preserving the performance characteristics under `-Os` and `RelWithDebInfo` builds.

Fixes #2527