### PR TITLE
Make Python `re` strings in `tools/*.py` be raw to avoid escape sequence warnings

### DIFF
--- a/tools/check_board_header.py
+++ b/tools/check_board_header.py
@@ -130,7 +130,7 @@ def read_defines_from(header_file, defines_dict):
             if m:
                 validity_stack.pop()
                 continue
-            
+
             if validity_stack[-1]:
                 # look for "#include "foo.h"
                 m = re.match(r"""^\s*#include\s+"(.+?)"\s*$""", line)
@@ -220,12 +220,12 @@ with open(board_header) as header_fh:
         line = re.sub(r"(?<=\S)\s*//.*$", "", line)
 
         # look for board-detection comment
-        if re.match("^\s*// For board detection", line):
+        if re.match(r"^\s*// For board detection", line):
             board_detection_is_next = True
             continue
 
         # check include-suggestion
-        m = re.match("^\s*// This header may be included by other board headers as \"(.+?)\"", line)
+        m = re.match(r"^\s*// This header may be included by other board headers as \"(.+?)\"", line)
         if m:
             include_suggestion = m.group(1)
             if include_suggestion == expected_include_suggestion:
@@ -300,7 +300,7 @@ with open(board_header) as header_fh:
         if m:
             validity_stack.pop()
             continue
-        
+
         if validity_stack[-1]:
             # look for "#include "foo.h"
             m = re.match(r"""^\s*#include\s+"(.+?)"\s*$""", line)
@@ -484,7 +484,7 @@ for name, define in defines.items():
                 pins[define.resolved_value] = [define]
 
     # check for invalid DEFAULT mappings
-    m = re.match("^(PICO_DEFAULT_([A-Z0-9]+))_([A-Z0-9]+)_PIN$", name)
+    m = re.match(r"^(PICO_DEFAULT_([A-Z0-9]+))_([A-Z0-9]+)_PIN$", name)
     if m:
         instance_name = m.group(1)
         interface = m.group(2)
@@ -506,7 +506,7 @@ for name, define in defines.items():
             raise Exception("{}:{}  {} is set to {} which isn't a valid pin for {} on {} {}".format(board_header, define.lineno, name, define.resolved_value, function, interface, instance_num))
 
     # check that each used DEFAULT interface includes (at least) the expected pin-functions
-    m = re.match("^PICO_DEFAULT_([A-Z0-9]+)$", name)
+    m = re.match(r"^PICO_DEFAULT_([A-Z0-9]+)$", name)
     if m:
         interface = m.group(1)
         if interface not in allowed_interfaces:

--- a/tools/extract_cmake_configs.py
+++ b/tools/extract_cmake_configs.py
@@ -139,7 +139,7 @@ for dirpath, dirnames, filenames in os.walk(scandir):
                     elif BASE_CMAKE_CONFIG_RE.search(line):
                         m = CMAKE_CONFIG_RE.match(line)
                         if not m:
-                            if re.match("^\s*#\s*# ", line):
+                            if re.match(r"^\s*#\s*# ", line):
                                 logger.info("Possible misformatted {} at {}:{} ({})".format(BASE_CMAKE_CONFIG_NAME, file_path, linenum, line))
                             else:
                                 raise Exception("Found misformatted {} at {}:{} ({})".format(BASE_CMAKE_CONFIG_NAME, file_path, linenum, line))

--- a/tools/extract_cmake_functions.py
+++ b/tools/extract_cmake_functions.py
@@ -123,7 +123,7 @@ def process_commands(description, name, group, signature):
     if any([';' in x for x in params]):
         logger.error("{}:{} has a parameter description containing ';'".format(group, name))
     # Check that all parameters are in the signature
-    signature_words = set(re.split('\W+', signature))
+    signature_words = set(re.split(r'\W+', signature))
     for param in params:
         param_name = param.split(' ', maxsplit=1)[0]
         if param_name not in signature_words:


### PR DESCRIPTION
Fixes #2529.

All `re` strings in `tools/*.py` are now raw strings, to prevent warnings like:
```
/home/halbert/repos/adafruit/pico-sdk/tools/check_board_header.py:223: SyntaxWarning: invalid escape sequence '\s'
  if re.match("^\s*// For board detection", line):
```
Also (fixed by accident due to my editor settings), some trailing whitespace was removed in the files I edited.
