### PR TITLE
Add POWMAN_PASSWORD_BITS to pico_bootsel_via_double_reset.

### DIFF
--- a/src/rp2_common/pico_bootsel_via_double_reset/pico_bootsel_via_double_reset.c
+++ b/src/rp2_common/pico_bootsel_via_double_reset/pico_bootsel_via_double_reset.c
@@ -97,11 +97,11 @@ static inline bool double_tap_flag_is_set(void) {
 }
 
 static inline void set_double_tap_flag(void) {
-    hw_set_bits(&powman_hw->chip_reset, POWMAN_CHIP_RESET_DOUBLE_TAP_BITS);
+    hw_set_bits(&powman_hw->chip_reset, POWMAN_CHIP_RESET_DOUBLE_TAP_BITS | POWMAN_PASSWORD_BITS);
 }
 
 static inline void clear_double_tap_flag(void) {
-    hw_clear_bits(&powman_hw->chip_reset, POWMAN_CHIP_RESET_DOUBLE_TAP_BITS);
+    hw_clear_bits(&powman_hw->chip_reset, POWMAN_CHIP_RESET_DOUBLE_TAP_BITS | POWMAN_PASSWORD_BITS);
 }
 
 #endif


### PR DESCRIPTION
Fix pico_bootsel_via_double_reset for RP2350.

Was borrowing this code for a USB MSC user boot toggle. Found it didn't work, delved into the bootloader and found:

https://github.com/raspberrypi/pico-bootrom-rp2350/blob/fd6104450fa8f55c11c0c9b54dbc69a27537130f/src/main/arm/varm_boot_path.c#L774