### PR TITLE
Provide an easy way to disable cyw43 logging

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/include/cyw43_configport.h
+++ b/src/rp2_common/pico_cyw43_driver/include/cyw43_configport.h
@@ -198,6 +198,15 @@ void cyw43_post_poll_hook(void);
 #define cyw43_free free
 #endif
 
+// PICO_CONFIG: PICO_CYW43_LOGGING_ENABLED, Enable/disable CYW43_PRINTF used for logging in cyw43 components. Has no effect if CYW43_PRINTF is defined by the user, default=1, type=bool, group=pico_cyw43_driver
+#ifndef PICO_CYW43_LOGGING_ENABLED
+#define PICO_CYW43_LOGGING_ENABLED 1
+#endif
+
+#if !defined CYW43_PRINTF && !PICO_CYW43_LOGGING_ENABLED
+#define CYW43_PRINTF(...) (void)0
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
All cyw43 logging uses CYW43_PRINTF by default. To disable logging you have to define this to do nothing. There's no simple way to achieve this. Make it easier by adding PICO_CYW43_LOGGING_ENABLED which can be set to zero to disable CYW43_PRINTF.

Fixes #2523
