### PR TITLE
Add PR branch check action

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,28 @@
+name: Make sure PRs target the develop branch
+
+on:
+  pull_request_target:
+
+# By default, pull_request_target gets write permissions to the repo - this prevents that
+permissions:
+  pull-requests: write
+
+jobs:
+  check-branch:
+    if: github.event.pull_request.base.ref == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Please do not submit against `master`, use `develop` instead'
+            })
+      - name: Throw error
+        run: |
+          echo "::error title=wrong-branch::Please do not submit against 'master', use 'develop' instead"
+          exit 1


### PR DESCRIPTION
This adds a GitHub action to throw an error if you raise a PR targeting the `master` branch, and adds a comment to the PR. See [here](https://github.com/will-v-pi/release-playground/pull/2#issuecomment-2988656037) for an example of the comment.

Note that this action will only be run once it has been merged into `master`

Once this is merged, I'll merge identical actions into `picotool` and `pico-examples`