### PR TITLE
Use platform/generator agnostic CMake commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       ```sh
       $ cmake --build build --target hello_world
       ```
-> The directory-name supplied to the `--build` flag needs to match the directory-name that was passed to the `-B` flag in the earlier cmake command.
+      > The directory-name supplied to the `--build` flag needs to match the directory-name that was passed to the `-B` flag in the earlier cmake command.
 
 1. You now have `hello_world.elf` to load via a debugger, or `hello_world.uf2` that can be installed and run on your Raspberry Pi Pico-series device via drag and drop.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       ```
       $ cmake -S . -B build
       ```
-      > The cmake -S flag indicates the source directory, and -B tells cmake where to put the output files.
+      > The cmake -S flag indicates the source directory, and the -B flag tells cmake the name of the output-directory to create. This doesn't have to be named "build", you can call it whatever you want.
    
    When building for a board other than the Raspberry Pi Pico, you should pass `-DPICO_BOARD=board_name` to the `cmake` command above, e.g. `cmake -S . -B build -DPICO_BOARD=pico2` or `cmake -S . -B build -DPICO_BOARD=pico_w` to configure the SDK and build options accordingly for that particular board.
 
@@ -194,6 +194,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       ```sh
       $ cmake --build build --target hello_world
       ```
+> The directory-name supplied to the `--build` flag needs to match the directory-name that was passed to the `-B` flag in the earlier cmake command.
 
 1. You now have `hello_world.elf` to load via a debugger, or `hello_world.uf2` that can be installed and run on your Raspberry Pi Pico-series device via drag and drop.
 

--- a/README.md
+++ b/README.md
@@ -178,9 +178,10 @@ instructions for other platforms, and just in general, we recommend you see [Ras
       For example, if not using an IDE:
       ```
       $ cmake -S . -B build
-      ```   
+      ```
+      > The cmake -S flag indicates the source directory, and -B tells cmake where to put the output files.
    
-   When building for a board other than the Raspberry Pi Pico, you should pass `-DPICO_BOARD=board_name` to the `cmake` command above, e.g. `cmake -DPICO_BOARD=pico2 ..` or `cmake -DPICO_BOARD=pico_w ..` to configure the SDK and build options accordingly for that particular board.
+   When building for a board other than the Raspberry Pi Pico, you should pass `-DPICO_BOARD=board_name` to the `cmake` command above, e.g. `cmake -S . -B build -DPICO_BOARD=pico2` or `cmake -S . -B build -DPICO_BOARD=pico_w` to configure the SDK and build options accordingly for that particular board.
 
    Specifying `PICO_BOARD=<boardname>` sets up various compiler defines (e.g. default pin numbers for UART and other hardware) and in certain 
    cases also enables the use of additional libraries (e.g. wireless support when building for `PICO_BOARD=pico_w`) which cannot

--- a/README.md
+++ b/README.md
@@ -177,9 +177,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
 1. Setup a CMake build directory.
       For example, if not using an IDE:
       ```
-      $ mkdir build
-      $ cd build
-      $ cmake ..
+      $ cmake -S . -B build
       ```   
    
    When building for a board other than the Raspberry Pi Pico, you should pass `-DPICO_BOARD=board_name` to the `cmake` command above, e.g. `cmake -DPICO_BOARD=pico2 ..` or `cmake -DPICO_BOARD=pico_w ..` to configure the SDK and build options accordingly for that particular board.
@@ -193,7 +191,7 @@ instructions for other platforms, and just in general, we recommend you see [Ras
 
 1. Make your target from the build directory you created.
       ```sh
-      $ make hello_world
+      $ cmake --build build --target hello_world
       ```
 
 1. You now have `hello_world.elf` to load via a debugger, or `hello_world.uf2` that can be installed and run on your Raspberry Pi Pico-series device via drag and drop.


### PR DESCRIPTION
Change the README to use platform/generator agnostic commands to create and build the CMake project

This means the generic commands work with Ninja or Makefiles, and avoids the need to `cd` into build directories