### PR TITLE
Clang 20.1.0

### DIFF
--- a/cmake/preload/toolchains/pico_arm_cortex_m33_clang.cmake
+++ b/cmake/preload/toolchains/pico_arm_cortex_m33_clang.cmake
@@ -1,7 +1,7 @@
 set(CMAKE_SYSTEM_PROCESSOR cortex-m33)
 
 # these are all the directories under LLVM embedded toolchain for ARM (newlib or pibolibc) and under llvm_libc
-set(PICO_CLANG_RUNTIMES armv8m.main_soft_nofp armv8m.main-unknown-none-eabi)
+set(PICO_CLANG_RUNTIMES armv8m.main_soft_nofp armv8m.main_soft_nofp_unaligned armv8m.main-unknown-none-eabi)
 
 set(PICO_COMMON_LANG_FLAGS "-mcpu=cortex-m33 --target=armv8m.main-none-eabi -mfloat-abi=softfp -march=armv8m.main+fp+dsp")
 set(PICO_DISASM_OBJDUMP_ARGS --mcpu=cortex-m33 --arch=armv8m.main+fp+dsp)


### PR DESCRIPTION
It seems that
* [LLVM Embedded Toollchain for Arm](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm) has become [Arm Toolchain for Embedded](https://github.com/arm/arm-toolchain/blob/arm-software/arm-software/embedded/README.md)
* For unaligned-access safe targets, the defaut/only runtime now specifies `_unaligned` in the name

This PR adds the armv8m runtime `_unaligned` variant to our whitelist of runtimes to look for

fixes #2534