### PR TITLE
Fix missing #include<cstdint> in pio_types.h and output_format.h

### DIFF
--- a/tools/pioasm/output_format.h
+++ b/tools/pioasm/output_format.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <string>
 #include <memory>
+#include <cstdint>
 
 #include "pio_enums.h"
 

--- a/tools/pioasm/pio_types.h
+++ b/tools/pioasm/pio_types.h
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 #include "location.h"
 #include "pio_enums.h"


### PR DESCRIPTION
This fixes a build error when using pioasm due to uint8_t not being recognized unless <cstdint> is included.
Confirmed on latest Arch Linux in a headless tty build environment without VSCode.