### PR TITLE
Add WeAct RP2350B Core board support.

### DIFF
--- a/src/boards/include/boards/weact_studio_rp2350b_core.h
+++ b/src/boards/include/boards/weact_studio_rp2350b_core.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/weact_studio_rp2350b_core.h"
+
+// pico_cmake_set PICO_PLATFORM=rp2350
+
+#ifndef _BOARDS_WEACT_STUDIO_RP2350B_CORE_H
+#define _BOARDS_WEACT_STUDIO_RP2350B_CORE_H
+
+// For board detection
+#define WEACT_STUDIO_RP2350B_CORE
+
+// --- BOARD SPECIFIC ---
+#define WEACT_STUDIO_RP2350B_USER_SW_PIN 23
+#define WEACT_STUDIO_RP2350B_PSRAM_CS_PIN 0
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 12
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 13
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 8
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 9
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (16 * 1024 * 1024)
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+// --- RP2350 VARIANT ---
+#define PICO_RP2350B 1
+
+// pico_cmake_set_default PICO_RP2350_A2_SUPPORTED = 1
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+#endif


### PR DESCRIPTION

I was testing this inexpensive RP2350B "breakout" board "WeAct RP2350B Core board":
https://github.com/WeActStudio/WeActStudio.RP2350BCoreBoard/tree/main/HDK

I noticed that there was no existing board definition for it, so I created one based on MicroPython support for it:
https://github.com/micropython/micropython/blob/master/ports/rp2/boards/WEACTSTUDIO_RP2350B_CORE/weactstudio_rp2350b_core.h

 