### PR TITLE
add default implementation of `_get_entropy()` that returns -1 to avoid linker warning

### DIFF
--- a/src/rp2_common/pico_clib_interface/newlib_interface.c
+++ b/src/rp2_common/pico_clib_interface/newlib_interface.c
@@ -152,6 +152,11 @@ int __attribute__((weak)) _isatty(int fd) {
     return fd == STDIO_HANDLE_STDIN || fd == STDIO_HANDLE_STDOUT || fd == STDIO_HANDLE_STDERR;
 }
 
+int __attribute__((weak)) _getentropy (__unused void *buffer, __unused size_t length) {
+    // note we don't hook this up as it isn't clear if/where it is used, and we don't particularly
+    // want to pull in pico_rand. the user can supply their own strong implementation if they need it!
+    return -1;
+}
 // exit is not useful... no desire to pull in __call_exitprocs
 void exit(int status) {
     _exit(status);


### PR DESCRIPTION
fixes #1768 