### PR TITLE
Fix always-true comparison warning in pio_insn

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
@@ -148,7 +148,7 @@ static inline uint pio_encode_sideset(uint sideset_bit_count, uint value) {
  * \return the side set bits to be ORed with an instruction encoding
  */
 static inline uint pio_encode_sideset_opt(uint sideset_bit_count, uint value) {
-    valid_params_if(PIO_INSTRUCTIONS, sideset_bit_count >= 0 && sideset_bit_count <= 4);
+    valid_params_if(PIO_INSTRUCTIONS, sideset_bit_count <= 4);
     valid_params_if(PIO_INSTRUCTIONS, value <= ((1u << sideset_bit_count) - 1));
     return 0x1000u | value << (12u - sideset_bit_count);
 }


### PR DESCRIPTION
The sideset_bit_count in pio_encode_sideset_opt is unsigned, so  "sideset_bit_count >= 0" will always be true.  GCC with pedantic warnings will complain when this happens.

Remove the unneeded >=0 portion of the parameter validity check.

Fixes #2607