### PR TITLE
Fix race in gpio_set_irq_enabled_with_callback

### DIFF
--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -196,9 +196,11 @@ void gpio_set_irq_enabled(uint gpio, uint32_t events, bool enabled) {
 }
 
 void gpio_set_irq_enabled_with_callback(uint gpio, uint32_t events, bool enabled, gpio_irq_callback_t callback) {
-    // first set callback, then enable the interrupt
-    gpio_set_irq_callback(callback);
+    // when enabling, first set callback, then enable the interrupt
+    // when disabling, first disable the interrupt, then clear callback
+    if (enabled) gpio_set_irq_callback(callback);
     gpio_set_irq_enabled(gpio, events, enabled);
+    if (!enabled) gpio_set_irq_callback(callback);
     if (enabled) irq_set_enabled(IO_IRQ_BANK0, true);
 }
 


### PR DESCRIPTION
When disabling, if you get an interrupt after `gpio_set_irq_callback` before `gpio_set_irq_enabled` then you get an `unhandled_user_irq`

Fix is to change where you `gpio_set_irq_callback` depending on whether you're enabling or disabling