### PR TITLE
pico_status_led doxygen typo

### DIFF
--- a/src/rp2_common/pico_status_led/include/pico/status_led.h
+++ b/src/rp2_common/pico_status_led/include/pico/status_led.h
@@ -109,7 +109,7 @@ bool status_led_init(void);
  *
  * \param context An \ref async_context used to communicate with the status LED (e.g. on Pico W or Pico 2 W)
  * \return Returns true if the LED was initialized successfully, otherwise false on failure
- * \sa status_led_init_with_context
+ * \sa status_led_init
  */
 bool status_led_init_with_context(struct async_context *context);
 


### PR DESCRIPTION
Doesn't make sense for a function's doxygen-comment to link to itself :wink: 
https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#group_pico_status_led_1ga1d39f6237f4c2eb0b7d89938f379bd41