### PR TITLE
Update instructions.h

### DIFF
--- a/src/rp2_common/hardware_hazard3/include/hardware/hazard3/instructions.h
+++ b/src/rp2_common/hardware_hazard3/include/hardware/hazard3/instructions.h
@@ -128,7 +128,7 @@ extern "C" {
     __h3_bextmi_rd; \
 })
 #else
-#define __hazard3_bextm(nbits, rs1, rs2) (((rs1) >> ((shamt) & 0x1f)) & (0xffu >> (7 - (((nbits) - 1) & 0x7))))
+#define __hazard3_bextmi(nbits, rs1, rs2) (((rs1) >> ((shamt) & 0x1f)) & (0xffu >> (7 - (((nbits) - 1) & 0x7))))
 #endif
 
 #ifdef __hazard3_extension_xh3power


### PR DESCRIPTION
Fix copy-paste-error. With RP2350's Hazard3 should never show up, but anyway.
In line 122 the macro is conditionally defined using ASM (when __hazard3_extension_xh3bextm), so line 131 should also define this -- and not redefine line 117.