### PR TITLE
Improve compatibility with ARM ACLE

### DIFF
--- a/src/host/hardware_sync/include/hardware/sync.h
+++ b/src/host/hardware_sync/include/hardware/sync.h
@@ -109,8 +109,6 @@ extern "C" {
 
 void __sev();
 
-void __wev();
-
 void __wfi();
 
 void __wfe();

--- a/src/host/hardware_sync/sync_core0_only.c
+++ b/src/host/hardware_sync/sync_core0_only.c
@@ -93,23 +93,44 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(spin_unlock)(spin_lock_t *lock, uint32_t saved
     spin_unlock_unsafe(lock);
 }
 
-PICO_WEAK_FUNCTION_DEF(__sev)
+// These are defined on ARM hosts, but don't do what we want for the host
+// since this is a simulated build.
+
+#if PICO_C_COMPILER_IS_GNU || !__has_builtin(__sev)
+#define __sev_c __sev
+#else
+#pragma redefine_extname __sev_c __sev
+#endif
+
+#if PICO_C_COMPILER_IS_GNU || !__has_builtin(__wfi)
+#define __wfi_c __wfi
+#else
+#pragma redefine_extname __wfi_c __wfi
+#endif
+
+#if PICO_C_COMPILER_IS_GNU || !__has_builtin(__wfe)
+#define __wfe_c __wfe
+#else
+#pragma redefine_extname __wfe_c __wfe
+#endif
+
+PICO_WEAK_FUNCTION_DEF(__sev_c)
 
 volatile bool event_fired;
 
-void PICO_WEAK_FUNCTION_IMPL_NAME(__sev)() {
+void PICO_WEAK_FUNCTION_IMPL_NAME(__sev_c)() {
     event_fired = true;
 }
 
-PICO_WEAK_FUNCTION_DEF(__wfi)
+PICO_WEAK_FUNCTION_DEF(__wfi_c)
 
-void PICO_WEAK_FUNCTION_IMPL_NAME(__wfi)() {
+void PICO_WEAK_FUNCTION_IMPL_NAME(__wfi_c)() {
     panic("Can't wait on irq for host core0 only implementation");
 }
 
-PICO_WEAK_FUNCTION_DEF(__wfe)
+PICO_WEAK_FUNCTION_DEF(__wfe_c)
 
-void PICO_WEAK_FUNCTION_IMPL_NAME(__wfe)() {
+void PICO_WEAK_FUNCTION_IMPL_NAME(__wfe_c)() {
     while (!event_fired) tight_loop_contents();
 }
 

--- a/src/rp2_common/hardware_exception/exception.c
+++ b/src/rp2_common/hardware_exception/exception.c
@@ -35,7 +35,7 @@ static inline exception_handler_t *get_exception_table(void) {
 static void set_raw_exception_handler_and_restore_interrupts(enum exception_number num, exception_handler_t handler, uint32_t save) {
     // update vtable (vtable_handler may be same or updated depending on cases, but we do it anyway for compactness)
     get_exception_table()[num] = handler;
-    __dmb();
+    __DMB();
     restore_interrupts_from_disabled(save);
 }
 #endif

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -132,7 +132,7 @@ void irq_set_pending(uint num) {
 static void set_raw_irq_handler_and_unlock(uint num, irq_handler_t handler, uint32_t save) {
     // update vtable (vtable_handler may be same or updated depending on cases, but we do it anyway for compactness)
     get_vtable()[VTABLE_FIRST_IRQ + num] = handler;
-    __dmb();
+    __DMB();
     spin_unlock(spin_lock_instance(PICO_SPINLOCK_ID_IRQ), save);
 }
 #endif
@@ -498,7 +498,7 @@ void irq_remove_handler(uint num, irq_handler_t handler) {
             // Note that a irq handler chain is local to our own core, so we don't need to worry about the other core
             bool was_enabled = irq_is_enabled(num);
             irq_set_enabled(num, false);
-            __dmb();
+            __DMB();
 
             // It is possible we are being called while an IRQ for this chain is already in progress.
             // The issue we have here is that we must not free a slot that is currently being executed, because

--- a/src/rp2_common/hardware_xip_cache/xip_cache.c
+++ b/src/rp2_common/hardware_xip_cache/xip_cache.c
@@ -18,7 +18,7 @@ typedef enum {
 #endif
 
 // Used to ensure subsequent accesses observe the new state of the maintained cache lines
-#define __post_maintenance_barrier() do {__dsb(); __isb();} while (0)
+#define __post_maintenance_barrier() do {__DSB(); __ISB();} while (0)
 
 // All functions in this file are marked non-flash, even though they themselves may be executed
 // safely from flash, because they are likely to be called during a flash programming operation


### PR DESCRIPTION
The sync.h header includes some definitions of some ARM ACLE intrinsics that can collide in breaking ways. This change improves compatibility in several ways:

* If <arm_acle.h> exists, use that. This catches cases where builtins are not properly caught by __has_builtin().
* Fix function signatures for __dmb(), __dsb(), and __isb(), which should take a unsigned int as an argument according to the ARM ACLE.
* Use __DMB(), __DSB(), and __ISB() throughout the code. This allows callsites to use the intrinsics without having to pass an argument, and matches well-established CMSIS patterns.
* Provide a workaround for ARM host builds.
