### PR TITLE
Remove unnecessary check in pio_encode_sideset_opt

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
@@ -148,7 +148,7 @@ static inline uint pio_encode_sideset(uint sideset_bit_count, uint value) {
  * \return the side set bits to be ORed with an instruction encoding
  */
 static inline uint pio_encode_sideset_opt(uint sideset_bit_count, uint value) {
-    valid_params_if(PIO_INSTRUCTIONS, sideset_bit_count >= 0 && sideset_bit_count <= 4);
+    valid_params_if(PIO_INSTRUCTIONS, sideset_bit_count <= 4);
     valid_params_if(PIO_INSTRUCTIONS, value <= ((1u << sideset_bit_count) - 1));
     return 0x1000u | value << (12u - sideset_bit_count);
 }


### PR DESCRIPTION
When compiling with `-O3 -Wall -Wextra` a warning is emitted about a comparison always being true. `sideset_bit_count` is unsigned so it can't be negative. Just remove the comparison to fix the warning.

```
pico-sdk/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h: In function 'uint pio_encode_sideset_opt(uint, uint)':
pico-sdk/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h:151:57: error: comparison of unsigned expression in '>= 0' is always true [-Werror=type-limits]
  151 |     valid_params_if(PIO_INSTRUCTIONS, sideset_bit_count >= 0 && sideset_bit_count <= 4);
      |                                       ~~~~~~~~~~~~~~~~~~^~~~
```