### PR TITLE
More robust clobbering of ARM builtins on host

### DIFF
--- a/src/host/hardware_sync/include/hardware/sync.h
+++ b/src/host/hardware_sync/include/hardware/sync.h
@@ -109,8 +109,6 @@ extern "C" {
 
 void __sev();
 
-void __wev();
-
 void __wfi();
 
 void __wfe();

--- a/src/host/hardware_sync/sync_core0_only.c
+++ b/src/host/hardware_sync/sync_core0_only.c
@@ -93,23 +93,44 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(spin_unlock)(spin_lock_t *lock, uint32_t saved
     spin_unlock_unsafe(lock);
 }
 
-PICO_WEAK_FUNCTION_DEF(__sev)
+// These are defined on ARM hosts, but don't do what we want for the host
+// since this is a simulated build.
+
+#if PICO_C_COMPILER_IS_GNU || !__has_builtin(__sev)
+#define __sev_c __sev
+#else
+#pragma redefine_extname __sev_c __sev
+#endif
+
+#if PICO_C_COMPILER_IS_GNU || !__has_builtin(__wfi)
+#define __wfi_c __wfi
+#else
+#pragma redefine_extname __wfi_c __wfi
+#endif
+
+#if PICO_C_COMPILER_IS_GNU || !__has_builtin(__wfe)
+#define __wfe_c __wfe
+#else
+#pragma redefine_extname __wfe_c __wfe
+#endif
+
+PICO_WEAK_FUNCTION_DEF(__sev_c)
 
 volatile bool event_fired;
 
-void PICO_WEAK_FUNCTION_IMPL_NAME(__sev)() {
+void PICO_WEAK_FUNCTION_IMPL_NAME(__sev_c)() {
     event_fired = true;
 }
 
-PICO_WEAK_FUNCTION_DEF(__wfi)
+PICO_WEAK_FUNCTION_DEF(__wfi_c)
 
-void PICO_WEAK_FUNCTION_IMPL_NAME(__wfi)() {
+void PICO_WEAK_FUNCTION_IMPL_NAME(__wfi_c)() {
     panic("Can't wait on irq for host core0 only implementation");
 }
 
-PICO_WEAK_FUNCTION_DEF(__wfe)
+PICO_WEAK_FUNCTION_DEF(__wfe_c)
 
-void PICO_WEAK_FUNCTION_IMPL_NAME(__wfe)() {
+void PICO_WEAK_FUNCTION_IMPL_NAME(__wfe_c)() {
     while (!event_fired) tight_loop_contents();
 }
 


### PR DESCRIPTION
Since ARM hosts have builtins listed in hardware/sync.h, these builtins should be clobbered. Newer versions of LLVM/Clang emit an error when clobbering these builtins, so this switches the overrides to use the same patterns as pico_atomic to clobber the builtins.

This works around this compiler error on ARM hosts:
```
external/pico-sdk+/src/host/hardware_sync/sync_core0_only.c:91:35: error: definition of builtin function '__sev'
   91 | void PICO_WEAK_FUNCTION_IMPL_NAME(__sev)() {
      |                                   ^
```