### PR TITLE
Forward declare __sev(), __wfe(), __wfi()

### DIFF
--- a/src/rp2_common/hardware_sync/include/hardware/sync.h
+++ b/src/rp2_common/hardware_sync/include/hardware/sync.h
@@ -94,6 +94,9 @@ __force_inline static void __sev(void) {
     pico_default_asm_volatile ("sev");
 #endif
 }
+#else
+// Forward declare so we don't have to #include <arm_acle.h>.
+void __sev(void);
 #endif
 
 /*! \brief Insert a WFE instruction in to the code path.
@@ -110,6 +113,9 @@ __force_inline static void __wfe(void) {
     pico_default_asm_volatile ("wfe");
 #endif
 }
+#else
+// Forward declare so we don't have to #include <arm_acle.h>.
+void __wfe(void);
 #endif
 
 /*! \brief Insert a WFI instruction in to the code path.
@@ -121,6 +127,9 @@ __force_inline static void __wfe(void) {
 __force_inline static void __wfi(void) {
     pico_default_asm_volatile("wfi");
 }
+#else
+// Forward declare so we don't have to #include <arm_acle.h>.
+void __wfi(void);
 #endif
 
 /*! \brief Insert a DMB instruction in to the code path.


### PR DESCRIPTION
If the compiler in use offers __sev(), __wfe(), or __wfi(), forward declare them to be sure they're available for use.

Recent LLVM/Clang changes are enforcing `#include <arm_acle.h>` as the way to get this builtin:
```
external/pico-sdk+/src/common/pico_sync/mutex.c:77:9: error: call to undeclared library function '__wfe' with type 'void (void)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   77 |         lock_internal_spin_unlock_with_wait(&mtx->core, save);
      |         ^
external/pico-sdk+/src/common/pico_sync/include/pico/lock_core.h:128:95: note: expanded from macro 'lock_internal_spin_unlock_with_wait'
  128 | #define lock_internal_spin_unlock_with_wait(lock, save) spin_unlock((lock)->spin_lock, save), __wfe()
      |                                                                                               ^
external/pico-sdk+/src/common/pico_sync/mutex.c:77:9: note: include the header <arm_acle.h> or explicitly provide a declaration for '__wfe'
```

Forward declaring using the same signature as `arm_acle.h` makes clang happy again.