### PR TITLE
Make private async_context_*_execute_sync static

### DIFF
--- a/src/rp2_common/pico_async_context/async_context_freertos.c
+++ b/src/rp2_common/pico_async_context/async_context_freertos.c
@@ -226,7 +226,7 @@ static void handle_sync_func_call(async_context_t *context, async_when_pending_w
     xSemaphoreGive(call->sem);
 }
 
-uint32_t async_context_freertos_execute_sync(async_context_t *self_base, uint32_t (*func)(void *param), void *param) {
+static uint32_t async_context_freertos_execute_sync(async_context_t *self_base, uint32_t (*func)(void *param), void *param) {
     async_context_freertos_t *self = (async_context_freertos_t*)self_base;
     hard_assert(xSemaphoreGetMutexHolder(self->lock_mutex) != xTaskGetCurrentTaskHandle());
     sync_func_call_t call = {0};

--- a/src/rp2_common/pico_async_context/async_context_poll.c
+++ b/src/rp2_common/pico_async_context/async_context_poll.c
@@ -51,7 +51,7 @@ static void async_context_poll_lock_check(async_context_t *self_base) {
     }
 }
 
-uint32_t async_context_poll_execute_sync(__unused async_context_t *context, uint32_t (*func)(void *param), void *param) {
+static uint32_t async_context_poll_execute_sync(__unused async_context_t *context, uint32_t (*func)(void *param), void *param) {
     return func(param);
 }
 

--- a/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
+++ b/src/rp2_common/pico_async_context/async_context_threadsafe_background.c
@@ -135,7 +135,7 @@ static void lock_release(async_context_threadsafe_background_t *self) {
 #endif
 }
 
-uint32_t async_context_threadsafe_background_execute_sync(async_context_t *self_base, uint32_t (*func)(void *param), void *param) {
+static uint32_t async_context_threadsafe_background_execute_sync(async_context_t *self_base, uint32_t (*func)(void *param), void *param) {
     async_context_threadsafe_background_t *self = (async_context_threadsafe_background_t*)self_base;
 #if ASYNC_CONTEXT_THREADSAFE_BACKGROUND_MULTI_CORE
     if (self_base->core_num != get_core_num()) {


### PR DESCRIPTION
Fixes #2678

The FreeRTOS, Poll, and Threadsafe async_context implementations have execute_sync functions that's set as a member of their async_context_type_t struct for use by the user-visible async_context API.  These implementation functions should not be accessible by user code which chouls only use async_context_execute_sync and not the low-lever async_context_{freertos,poll,threadsafe}_execute_sync implementation.

Make these private functions static like the other low-level functions in the async_context_type_t struct.
