### PR TITLE
Fix some errors from -fanalyzer.

### DIFF
--- a/src/common/pico_sync/mutex.c
+++ b/src/common/pico_sync/mutex.c
@@ -18,10 +18,10 @@ void __weak runtime_init_mutex(void) {
     static_assert(!(sizeof(recursive_mutex_t)&3), "");
     static_assert(!offsetof(mutex_t, core), "");
     static_assert(!offsetof(recursive_mutex_t, core), "");
-    extern lock_core_t __mutex_array_start;
+    extern lock_core_t __mutex_array_start[];
     extern lock_core_t __mutex_array_end;
 
-    for (lock_core_t *l = &__mutex_array_start; l < &__mutex_array_end; ) {
+    for (lock_core_t *l = &__mutex_array_start[0]; l < &__mutex_array_end; ) {
         if (l->spin_lock) {
             assert(1 == (uintptr_t)l->spin_lock); // indicator for a recursive mutex
             recursive_mutex_t *rm = (recursive_mutex_t *)l;

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -112,6 +112,7 @@ alarm_pool_t *alarm_pool_create_on_timer(alarm_pool_timer_t *timer, uint hardwar
     alarm_pool_t *pool = (alarm_pool_t *) malloc(sizeof(alarm_pool_t));
     if (pool) {
         pool->entries = (alarm_pool_entry_t *) calloc(max_timers, sizeof(alarm_pool_entry_t));
+        if (!pool->entries) panic("Failed to allocate alarm pool entries");
         ta_hardware_alarm_claim(timer, hardware_alarm_num);
         alarm_pool_post_alloc_init(pool, timer, hardware_alarm_num, max_timers);
     }
@@ -122,6 +123,7 @@ alarm_pool_t *alarm_pool_create_on_timer_with_unused_hardware_alarm(alarm_pool_t
     alarm_pool_t *pool = (alarm_pool_t *) malloc(sizeof(alarm_pool_t));
     if (pool) {
         pool->entries = (alarm_pool_entry_t *) calloc(max_timers, sizeof(alarm_pool_entry_t));
+        if (!pool->entries) panic("Failed to allocate alarm pool entries");
         alarm_pool_post_alloc_init(pool, timer, (uint) ta_hardware_alarm_claim_unused(timer, true), max_timers);
     }
     return pool;

--- a/src/common/pico_time/time.c
+++ b/src/common/pico_time/time.c
@@ -112,9 +112,13 @@ alarm_pool_t *alarm_pool_create_on_timer(alarm_pool_timer_t *timer, uint hardwar
     alarm_pool_t *pool = (alarm_pool_t *) malloc(sizeof(alarm_pool_t));
     if (pool) {
         pool->entries = (alarm_pool_entry_t *) calloc(max_timers, sizeof(alarm_pool_entry_t));
-        if (!pool->entries) panic("Failed to allocate alarm pool entries");
-        ta_hardware_alarm_claim(timer, hardware_alarm_num);
-        alarm_pool_post_alloc_init(pool, timer, hardware_alarm_num, max_timers);
+        if (pool->entries) {
+            ta_hardware_alarm_claim(timer, hardware_alarm_num);
+            alarm_pool_post_alloc_init(pool, timer, hardware_alarm_num, max_timers);
+        } else {
+            free(pool);
+            pool = NULL;
+        }
     }
     return pool;
 }
@@ -123,8 +127,12 @@ alarm_pool_t *alarm_pool_create_on_timer_with_unused_hardware_alarm(alarm_pool_t
     alarm_pool_t *pool = (alarm_pool_t *) malloc(sizeof(alarm_pool_t));
     if (pool) {
         pool->entries = (alarm_pool_entry_t *) calloc(max_timers, sizeof(alarm_pool_entry_t));
-        if (!pool->entries) panic("Failed to allocate alarm pool entries");
-        alarm_pool_post_alloc_init(pool, timer, (uint) ta_hardware_alarm_claim_unused(timer, true), max_timers);
+        if (pool->entries) {
+            alarm_pool_post_alloc_init(pool, timer, (uint) ta_hardware_alarm_claim_unused(timer, true), max_timers);
+        } else {
+            free(pool);
+            pool = NULL;
+        }
     }
     return pool;
 }

--- a/src/rp2_common/pico_multicore/multicore.c
+++ b/src/rp2_common/pico_multicore/multicore.c
@@ -367,7 +367,7 @@ static inline void clear_claimed_bit(uint8_t *bits, uint bit_index) {
 static bool multicore_doorbell_claim_under_lock(uint doorbell_num, uint core_mask, bool required) {
     static_assert(NUM_CORES == 2, "");
     uint claimed_cores_for_doorbell = (uint) (is_bit_claimed(doorbell_claimed[0], doorbell_num) |
-                                              (is_bit_claimed(doorbell_claimed[1], doorbell_num + 1u) << 1));
+                                              (is_bit_claimed(doorbell_claimed[1], doorbell_num) << 1));
     if (claimed_cores_for_doorbell & core_mask) {
         if (required) {
             panic( "Multicore doorbell %d already claimed on core mask 0x%x; requested core mask 0x%x\n",

--- a/src/rp2_common/pico_rand/rand.c
+++ b/src/rp2_common/pico_rand/rand.c
@@ -239,7 +239,7 @@ static uint64_t capture_additional_rosc_samples(uint n) {
 #endif
 
 static void initialise_rand(void) {
-    rng_128_t local_rng_state = local_rng_state;
+    rng_128_t local_rng_state = {0};
     uint which = 0;
 #if PICO_RAND_SEED_ENTROPY_SRC_RAM_HASH
     ram_hash = sdbm_hash64_sram(ram_hash);


### PR DESCRIPTION
These are from building `kitchen_sink` with `-fanalyzer` on GCC 14.3.

* Panic on failed allocation in `pico_time`
* Remove `+ 1` on claim bit for second core in `multicore_doorbell_claim()` -- besides being OOB this also seems to just be looking at the wrong bit as it doesn't match the one used in `multicore_doorbell_unclaim()`
* Use a constant initialiser for `local_rng_state` in `initialise_rand` -- this looked like it was trying to be deliberately uninitialised but this doesn't garner much entropy for a stack variable, and it's undefined behaviour

There are some remaining errors in the SHA-256 which look pessimistic to me. It would still be good to clean that up so that people can use `-fanalyzer` when building against the SDK.