### PR TITLE
[Bazel] Add bzl_library targets

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.9")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "rules_python", version = "0.36.0")
 bazel_dep(name = "picotool", version = "2.2.0")

--- a/bazel/toolchain/BUILD.bazel
+++ b/bazel/toolchain/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:args_list.bzl", "cc_args_list")
 load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
@@ -331,3 +332,20 @@ _HOST_CPU_CONSTRAINTS = {
     }),
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 ) for host_os, host_cpu in HOSTS]
+
+bzl_library(
+    name = "configurable_feature",
+    srcs = ["configurable_feature.bzl"],
+    deps = [
+        "@rules_cc//cc/toolchains:toolchain_rules",
+    ],
+)
+
+bzl_library(
+    name = "objcopy",
+    srcs = ["objcopy.bzl"],
+    deps = [
+        "@bazel_tools//tools/build_defs/cc:action_names",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
+    ]
+)


### PR DESCRIPTION
Add some `bzl_library` targets for `.bzl` files. This enables [stardoc to do its thing](https://blog.aspect.build/stardocs-on-bcr) and is helpful in its own right for validating rule & macro dependencies.

Notes:
- Open question: should this PR add bzl_library targets for all `.bzl` files? I added the ones I personally depend on, but adding it for more files requires bumping the `rules_cc` version; might be poking the bear?
- I haven't filed an issue yet, will do as desired

