### PR TITLE
Enable TLS1.3

### DIFF
--- a/src/rp2_common/pico_mbedtls/CMakeLists.txt
+++ b/src/rp2_common/pico_mbedtls/CMakeLists.txt
@@ -114,6 +114,11 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
                 bignum_core.c
                 rsa_alt_helpers.c
                 pk_ecc.c
+                psa_crypto_driver_wrappers_no_static.c
+                psa_crypto_ffdh.c
+                psa_crypto_pake.c
+                psa_util.c
+                sha3.c
             )
         endif()
         list(TRANSFORM src_crypto PREPEND ${PICO_MBEDTLS_PATH}/library/)
@@ -169,6 +174,9 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
             list(APPEND src_tls
                 ssl_client.c
                 ssl_debug_helpers_generated.c
+                ssl_tls13_client.c
+                ssl_tls13_generic.c
+                ssl_tls13_server.c
                 ssl_tls12_client.c
                 ssl_tls12_server.c
             )


### PR DESCRIPTION

Fixes #2710 

Added these files to get TLS1.3 actually working: handshake/session handling + data transfer, and the crypto the PSA bits TLS1.3 needs.

**TLS1.3 flow**
- ssl_tls13_client.c — client-side TLS1.3 handshake & state machine (connect, key schedule, etc).
- ssl_tls13_server.c — server-side TLS1.3 handshake & state machine (accept, resume, keys).
- ssl_tls13_generic.c — shared TLS1.3 code used by client+server (common handshake steps, key derivation, cipher handling).




**Needed crypto stuffc for TLS1.3**
- psa_crypto_driver_wrappers_no_static.c — PSA driver wrapper glue so mbedtls can call platform crypto implementations without static binding.
- psa_crypto_ffdh.c — finite-field Diffie-Hellman PSA glue (for any non-ECC FFDH needs).
- psa_crypto_pake.c — PAKE support via PSA (if you need password-authenticated key exchange helpers).
- psa_util.c — helper utils for PSA integration (common conversions, checks).
- sha3.c — SHA-3 family implementation — some profiles / ciphersuites or future proofing.
