### PR TITLE
Set picotest_error_code in PICOTEST_CHECK_AND_ABORT

### DIFF
--- a/test/pico_test/include/pico/test.h
+++ b/test/pico_test/include/pico/test.h
@@ -39,11 +39,13 @@ but not sure that is implemented yet.
 
 #define PICOTEST_CHECK_AND_ABORT(COND, MESSAGE) if (!(COND)) {                                     \
                                         printf("Module %s: %s\n", picotest_module, MESSAGE);       \
+                                        picotest_error_code = -1;                                   \
                                         return -1;                                                  \
                                     }
 
 #define PICOTEST_CHECK_CHANNEL_AND_ABORT(CHANNEL, COND, MESSAGE) if (!(COND)) {                    \
                                         printf("Module %s, channel %d: %s\n", picotest_module, CHANNEL, MESSAGE);  \
+                                        picotest_error_code = -1;                                   \
                                         return -1;                                                  \
                                     }
 


### PR DESCRIPTION
Fixes #2721
