### PR TITLE
Host GPIO improvements

### DIFF
--- a/src/host/hardware_gpio/BUILD.bazel
+++ b/src/host/hardware_gpio/BUILD.bazel
@@ -8,6 +8,7 @@ cc_library(
     target_compatible_with = ["//bazel/constraint:host"],
     deps = [
         "//src/common/pico_binary_info:LIB_PICO_BINARY_INFO",
+        "//src/host/hardware_irq",
         "//src/host/pico_platform",
     ],
 )

--- a/src/host/hardware_gpio/CMakeLists.txt
+++ b/src/host/hardware_gpio/CMakeLists.txt
@@ -1,1 +1,2 @@
 pico_simple_hardware_target(gpio)
+target_link_libraries(hardware_gpio INTERFACE hardware_irq)

--- a/src/host/hardware_gpio/gpio.c
+++ b/src/host/hardware_gpio/gpio.c
@@ -6,9 +6,14 @@
 
 #include "hardware/gpio.h"
 
-PICO_WEAK_FUNCTION_DEF(gpio_set_function)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function)(__unused uint gpio, __unused enum gpio_function fn) {
+PICO_WEAK_FUNCTION_DEF(check_gpio_param)
+void PICO_WEAK_FUNCTION_IMPL_NAME(check_gpio_param)(__unused uint gpio) {
 
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_function)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function)(uint gpio, __unused enum gpio_function fn) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_function_masked)
@@ -22,98 +27,104 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function_masked64)(__unused uint64_t 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get_function)
-gpio_function_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_function)(__unused uint gpio) {
+gpio_function_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_function)(uint gpio) {
+    check_gpio_param(gpio);
     return GPIO_FUNC_NULL;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_pull_up)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_up)(__unused uint gpio) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_up)(uint gpio) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_is_pulled_up)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_pulled_up)(__unused uint gpio) {
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_pulled_up)(uint gpio) {
+    check_gpio_param(gpio);
     return 0;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_pull_down)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_down)(__unused uint gpio) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_down)(uint gpio) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_is_pulled_down)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_pulled_down)(__unused uint gpio) {
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_pulled_down)(uint gpio) {
+    check_gpio_param(gpio);
     return 0;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_disable_pulls)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_disable_pulls)(__unused uint gpio) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_disable_pulls)(uint gpio) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_pulls)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_pulls)(__unused uint gpio, __unused bool up, __unused bool down) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_pulls)(uint gpio, __unused bool up, __unused bool down) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_irqover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irqover)(__unused uint gpio, __unused uint value) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irqover)(uint gpio, __unused uint value) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_outover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_outover)(__unused uint gpio, __unused uint value) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_outover)(uint gpio, __unused uint value) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_inover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_inover)(__unused uint gpio, __unused uint value) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_inover)(uint gpio, __unused uint value) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_oeover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_oeover)(__unused uint gpio, __unused uint value) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_oeover)(uint gpio, __unused uint value) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_input_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_enabled)(__unused uint gpio, __unused bool enabled){
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_enabled)(uint gpio, __unused bool enabled){
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_input_hysteresis_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_hysteresis_enabled)(__unused uint gpio, __unused bool enabled){
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_hysteresis_enabled)(uint gpio, __unused bool enabled){
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_is_input_hysteresis_enabled)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_input_hysteresis_enabled)(__unused uint gpio){
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_input_hysteresis_enabled)(uint gpio){
+    check_gpio_param(gpio);
     return true;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_slew_rate)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_slew_rate)(__unused uint gpio, __unused enum gpio_slew_rate slew){
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_slew_rate)(uint gpio, __unused enum gpio_slew_rate slew){
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get_slew_rate)
-enum gpio_slew_rate PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_slew_rate)(__unused uint gpio){
+enum gpio_slew_rate PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_slew_rate)(uint gpio){
+    check_gpio_param(gpio);
     return GPIO_SLEW_RATE_FAST;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_drive_strength)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_drive_strength)(__unused uint gpio, __unused enum gpio_drive_strength drive){
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_drive_strength)(uint gpio, __unused enum gpio_drive_strength drive){
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get_drive_strength)
-enum gpio_drive_strength PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_drive_strength)(__unused uint gpio){
+enum gpio_drive_strength PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_drive_strength)(uint gpio){
+    check_gpio_param(gpio);
     return GPIO_DRIVE_STRENGTH_4MA;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_irq_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled)(__unused uint gpio, __unused uint32_t events, __unused bool enable) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled)(uint gpio, __unused uint32_t events, __unused bool enable) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_irq_callback)
@@ -122,23 +133,24 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_callback)(__unused gpio_irq_callb
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_irq_enabled_with_callback)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled_with_callback)(__unused uint gpio, __unused uint32_t event_mask, __unused bool enabled, __unused gpio_irq_callback_t callback) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled_with_callback)(uint gpio, __unused uint32_t event_mask, __unused bool enabled, __unused gpio_irq_callback_t callback) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dormant_irq_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dormant_irq_enabled)(__unused uint gpio, __unused uint32_t event_mask, __unused bool enabled) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dormant_irq_enabled)(uint gpio, __unused uint32_t event_mask, __unused bool enabled) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get_irq_event_mask)
-uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_irq_event_mask)(__unused uint gpio) {
+uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_irq_event_mask)(uint gpio) {
+    check_gpio_param(gpio);
     return 0;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_acknowledge_irq)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_acknowledge_irq)(__unused uint gpio, __unused uint32_t events) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_acknowledge_irq)(uint gpio, __unused uint32_t events) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_with_order_priority_masked)
@@ -152,8 +164,8 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_with_order_priority_m
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_with_order_priority)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_with_order_priority)(__unused uint gpio, __unused irq_handler_t handler, __unused uint8_t order_priority) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_with_order_priority)(uint gpio, __unused irq_handler_t handler, __unused uint8_t order_priority) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_masked)
@@ -167,8 +179,8 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_masked64)(__unused ui
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler)(__unused uint gpio, __unused irq_handler_t handler) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler)(uint gpio, __unused irq_handler_t handler) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_remove_raw_irq_handler_masked)
@@ -182,18 +194,18 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_remove_raw_irq_handler_masked64)(__unused
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_remove_raw_irq_handler)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_remove_raw_irq_handler)(__unused uint gpio, __unused irq_handler_t handler) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_remove_raw_irq_handler)(uint gpio, __unused irq_handler_t handler) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_init)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init)(__unused uint gpio) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init)(uint gpio) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_deinit)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_deinit)(__unused uint gpio) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_deinit)(uint gpio) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_init_mask)
@@ -202,7 +214,8 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(__unused uint gpio_mask) {
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get)(__unused uint gpio) {
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get)(uint gpio) {
+    check_gpio_param(gpio);
     return 0;
 }
 
@@ -287,12 +300,13 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_all64)(__unused uint64_t value) {
 
 }
 PICO_WEAK_FUNCTION_DEF(gpio_put)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put)(__unused uint gpio, __unused int value) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put)(uint gpio, __unused int value) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir_out_masked)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_out_level)(__unused uint gpio) {
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_out_level)(uint gpio) {
+    check_gpio_param(gpio);
     return 0;
 }
 
@@ -336,12 +350,13 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_all_bits64)(__unused uint64_t val
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir)(__unused uint gpio, __unused bool out) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir)(uint gpio, __unused bool out) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_is_dir_out)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_dir_out)(__unused uint gpio) {
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_dir_out)(uint gpio) {
+    check_gpio_param(gpio);
     return 0;
 }
 
@@ -351,8 +366,8 @@ uint PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_dir)(uint gpio) {
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_assign_to_ns)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_assign_to_ns)(__unused uint gpio, __unused bool ns) {
-
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_assign_to_ns)(uint gpio, __unused bool ns) {
+    check_gpio_param(gpio);
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_debug_pins_init)

--- a/src/host/hardware_gpio/gpio.c
+++ b/src/host/hardware_gpio/gpio.c
@@ -11,14 +11,39 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function)(__unused uint gpio, __unuse
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_set_function_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function_masked)(__unused uint32_t gpio_mask, __unused gpio_function_t fn) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_function_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function_masked64)(__unused uint64_t gpio_mask, __unused gpio_function_t fn) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_get_function)
+gpio_function_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_function)(__unused uint gpio) {
+    return GPIO_FUNC_NULL;
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_pull_up)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_up)(__unused uint gpio) {
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_is_pulled_up)
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_pulled_up)(__unused uint gpio) {
+    return 0;
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_pull_down)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_down)(__unused uint gpio) {
 
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_is_pulled_down)
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_pulled_down)(__unused uint gpio) {
+    return 0;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_disable_pulls)
@@ -48,6 +73,11 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_inover)(__unused uint gpio, __unused 
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_oeover)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_oeover)(__unused uint gpio, __unused uint value) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_input_enabled)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_enabled)(__unused uint gpio, __unused bool enabled){
 
 }
 
@@ -86,13 +116,88 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled)(__unused uint gpio, __un
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_set_irq_callback)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_callback)(__unused gpio_irq_callback_t callback) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_irq_enabled_with_callback)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled_with_callback)(__unused uint gpio, __unused uint32_t event_mask, __unused bool enabled, __unused gpio_irq_callback_t callback) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_dormant_irq_enabled)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dormant_irq_enabled)(__unused uint gpio, __unused uint32_t event_mask, __unused bool enabled) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_get_irq_event_mask)
+uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_irq_event_mask)(__unused uint gpio) {
+    return 0;
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_acknowledge_irq)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_acknowledge_irq)(__unused uint gpio, __unused uint32_t events) {
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_with_order_priority_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_with_order_priority_masked)(__unused uint32_t gpio_mask, __unused irq_handler_t handler, __unused uint8_t order_priority) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_with_order_priority_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_with_order_priority_masked64)(__unused uint64_t gpio_mask, __unused irq_handler_t handler, __unused uint8_t order_priority) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_with_order_priority)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_with_order_priority)(__unused uint gpio, __unused irq_handler_t handler, __unused uint8_t order_priority) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_masked)(__unused uint32_t gpio_mask, __unused irq_handler_t handler) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler_masked64)(__unused uint64_t gpio_mask, __unused irq_handler_t handler) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_add_raw_irq_handler)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_add_raw_irq_handler)(__unused uint gpio, __unused irq_handler_t handler) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_remove_raw_irq_handler_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_remove_raw_irq_handler_masked)(__unused uint32_t gpio_mask, __unused irq_handler_t handler) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_remove_raw_irq_handler_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_remove_raw_irq_handler_masked64)(__unused uint64_t gpio_mask, __unused irq_handler_t handler) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_remove_raw_irq_handler)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_remove_raw_irq_handler)(__unused uint gpio, __unused irq_handler_t handler) {
+
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_init)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init)(__unused uint gpio) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_deinit)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_deinit)(__unused uint gpio) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_init_mask)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(__unused uint gpio_mask) {
 
 }
 
@@ -102,7 +207,12 @@ bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get)(__unused uint gpio) {
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get_all)
-uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_all)() {
+uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_all)(void) {
+    return 0;
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_get_all46)
+uint64_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_all64)(void) {
     return 0;
 }
 
@@ -111,8 +221,29 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_mask)(__unused uint32_t mask) {
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_set_mask64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_mask64)(__unused uint64_t mask) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_mask_n)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_mask_n)(__unused uint n, __unused uint32_t mask) {
+
+}
+
+
 PICO_WEAK_FUNCTION_DEF(gpio_clr_mask)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_clr_mask)(__unused uint32_t mask) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_clr_mask64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_clr_mask64)(__unused uint64_t mask) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_clr_mask_n)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_clr_mask_n)(__unused uint n, __unused uint32_t mask) {
 
 }
 
@@ -121,8 +252,28 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_xor_mask)(__unused uint32_t mask) {
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_xor_mask64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_xor_mask64)(__unused uint64_t mask) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_xor_mask_n)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_xor_mask_n)(__unused uint n, __unused uint32_t mask) {
+
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_put_masked)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_masked)(__unused uint32_t mask, __unused uint32_t value) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_put_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_masked64)(__unused uint64_t mask, __unused uint64_t value) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_put_mask_n)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_mask_n)(__unused uint n, __unused uint32_t mask) {
 
 }
 
@@ -131,13 +282,27 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_all)(__unused uint32_t value) {
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_put_all64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_all64)(__unused uint64_t value) {
+
+}
 PICO_WEAK_FUNCTION_DEF(gpio_put)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put)(__unused uint gpio, __unused int value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir_out_masked)
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_out_level)(__unused uint gpio) {
+    return 0;
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_out_masked)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_out_masked)(__unused uint32_t mask) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_out_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_out_masked64)(__unused uint64_t mask) {
 
 }
 
@@ -146,8 +311,17 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_in_masked)(__unused uint32_t mask
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_in_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_in_masked64)(__unused uint64_t mask) {
+
+}
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir_masked)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_masked)(__unused uint32_t mask, __unused uint32_t value) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_masked64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_masked64)(__unused uint64_t mask, __unused uint64_t value) {
 
 }
 
@@ -156,22 +330,32 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_all_bits)(__unused uint32_t value
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_all_bits64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_all_bits64)(__unused uint64_t value) {
+
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir)(__unused uint gpio, __unused bool out) {
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_is_dir_out)
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_dir_out)(__unused uint gpio) {
+    return 0;
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_get_dir)
+uint PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_dir)(uint gpio) {
+    return gpio_is_dir_out(gpio); // note GPIO_OUT is 1/true and GPIO_IN is 0/false anyway
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_assign_to_ns)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_assign_to_ns)(__unused uint gpio, __unused bool ns) {
+
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_debug_pins_init)
 void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_debug_pins_init)() {
-
-}
-
-PICO_WEAK_FUNCTION_DEF(gpio_set_input_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_enabled)(__unused uint gpio, __unused bool enable) {
-
-}
-
-PICO_WEAK_FUNCTION_DEF(gpio_init_mask)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(__unused uint gpio_mask) {
 
 }

--- a/src/host/hardware_gpio/gpio.c
+++ b/src/host/hardware_gpio/gpio.c
@@ -7,97 +7,97 @@
 #include "hardware/gpio.h"
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_function)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function)(uint gpio, enum gpio_function fn) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function)(__unused uint gpio, __unused enum gpio_function fn) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_pull_up)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_up)(uint gpio) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_up)(__unused uint gpio) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_pull_down)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_down)(uint gpio) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_down)(__unused uint gpio) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_disable_pulls)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_disable_pulls)(uint gpio) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_disable_pulls)(__unused uint gpio) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_pulls)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_pulls)(uint gpio, bool up, bool down) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_pulls)(__unused uint gpio, __unused bool up, __unused bool down) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_irqover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irqover)(uint gpio, uint value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irqover)(__unused uint gpio, __unused uint value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_outover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_outover)(uint gpio, uint value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_outover)(__unused uint gpio, __unused uint value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_inover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_inover)(uint gpio, uint value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_inover)(__unused uint gpio, __unused uint value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_oeover)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_oeover)(uint gpio, uint value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_oeover)(__unused uint gpio, __unused uint value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_input_hysteresis_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_hysteresis_enabled)(uint gpio, bool enabled){
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_hysteresis_enabled)(__unused uint gpio, __unused bool enabled){
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_is_input_hysteresis_enabled)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_input_hysteresis_enabled)(uint gpio){
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_input_hysteresis_enabled)(__unused uint gpio){
     return true;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_slew_rate)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_slew_rate)(uint gpio, enum gpio_slew_rate slew){
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_slew_rate)(__unused uint gpio, __unused enum gpio_slew_rate slew){
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get_slew_rate)
-enum gpio_slew_rate PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_slew_rate)(uint gpio){
+enum gpio_slew_rate PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_slew_rate)(__unused uint gpio){
     return GPIO_SLEW_RATE_FAST;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_drive_strength)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_drive_strength)(uint gpio, enum gpio_drive_strength drive){
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_drive_strength)(__unused uint gpio, __unused enum gpio_drive_strength drive){
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get_drive_strength)
-enum gpio_drive_strength PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_drive_strength)(uint gpio){
+enum gpio_drive_strength PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_drive_strength)(__unused uint gpio){
     return GPIO_DRIVE_STRENGTH_4MA;
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_irq_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled)(uint gpio, uint32_t events, bool enable) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled)(__unused uint gpio, __unused uint32_t events, __unused bool enable) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_acknowledge_irq)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_acknowledge_irq)(uint gpio, uint32_t events) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_acknowledge_irq)(__unused uint gpio, __unused uint32_t events) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_init)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init)(uint gpio) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init)(__unused uint gpio) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get)
-bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get)(uint gpio) {
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get)(__unused uint gpio) {
     return 0;
 }
 
@@ -107,57 +107,57 @@ uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_all)() {
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_mask)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_mask)(uint32_t mask) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_mask)(__unused uint32_t mask) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_clr_mask)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_clr_mask)(uint32_t mask) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_clr_mask)(__unused uint32_t mask) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_xor_mask)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_xor_mask)(uint32_t mask) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_xor_mask)(__unused uint32_t mask) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_put_masked)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_masked)(uint32_t mask, uint32_t value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_masked)(__unused uint32_t mask, __unused uint32_t value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_put_all)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_all)(uint32_t value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_all)(__unused uint32_t value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_put)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put)(uint gpio, int value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put)(__unused uint gpio, __unused int value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir_out_masked)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_out_masked)(uint32_t mask) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_out_masked)(__unused uint32_t mask) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir_in_masked)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_in_masked)(uint32_t mask) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_in_masked)(__unused uint32_t mask) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir_masked)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_masked)(uint32_t mask, uint32_t value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_masked)(__unused uint32_t mask, __unused uint32_t value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir_all_bits)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_all_bits)(uint32_t value) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_all_bits)(__unused uint32_t value) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_dir)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir)(uint gpio, bool out) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir)(__unused uint gpio, __unused bool out) {
 
 }
 
@@ -167,11 +167,11 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_debug_pins_init)() {
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_set_input_enabled)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_enabled)(uint gpio, bool enable) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_enabled)(__unused uint gpio, __unused bool enable) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_init_mask)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(uint gpio_mask) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(__unused uint gpio_mask) {
 
 }

--- a/src/host/hardware_gpio/gpio.c
+++ b/src/host/hardware_gpio/gpio.c
@@ -6,142 +6,172 @@
 
 #include "hardware/gpio.h"
 
-// todo weak or replace? probably weak
-void gpio_set_function(uint gpio, enum gpio_function fn) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_function)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_function)(uint gpio, enum gpio_function fn) {
 
 }
 
-void gpio_pull_up(uint gpio) {
+PICO_WEAK_FUNCTION_DEF(gpio_pull_up)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_up)(uint gpio) {
 
 }
 
-void gpio_pull_down(uint gpio) {
+PICO_WEAK_FUNCTION_DEF(gpio_pull_down)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_pull_down)(uint gpio) {
 
 }
 
-void gpio_disable_pulls(uint gpio) {
+PICO_WEAK_FUNCTION_DEF(gpio_disable_pulls)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_disable_pulls)(uint gpio) {
 
 }
 
-void gpio_set_pulls(uint gpio, bool up, bool down) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_pulls)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_pulls)(uint gpio, bool up, bool down) {
 
 }
 
-void gpio_set_irqover(uint gpio, uint value) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_irqover)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irqover)(uint gpio, uint value) {
 
 }
 
-void gpio_set_outover(uint gpio, uint value) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_outover)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_outover)(uint gpio, uint value) {
 
 }
 
-void gpio_set_inover(uint gpio, uint value) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_inover)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_inover)(uint gpio, uint value) {
 
 }
 
-void gpio_set_oeover(uint gpio, uint value) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_oeover)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_oeover)(uint gpio, uint value) {
 
 }
 
-void gpio_set_input_hysteresis_enabled(uint gpio, bool enabled){
+PICO_WEAK_FUNCTION_DEF(gpio_set_input_hysteresis_enabled)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_hysteresis_enabled)(uint gpio, bool enabled){
 
 }
 
-bool gpio_is_input_hysteresis_enabled(uint gpio){
+PICO_WEAK_FUNCTION_DEF(gpio_is_input_hysteresis_enabled)
+bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_is_input_hysteresis_enabled)(uint gpio){
     return true;
 }
 
-void gpio_set_slew_rate(uint gpio, enum gpio_slew_rate slew){
+PICO_WEAK_FUNCTION_DEF(gpio_set_slew_rate)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_slew_rate)(uint gpio, enum gpio_slew_rate slew){
 
 }
 
-enum gpio_slew_rate gpio_get_slew_rate(uint gpio){
+PICO_WEAK_FUNCTION_DEF(gpio_get_slew_rate)
+enum gpio_slew_rate PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_slew_rate)(uint gpio){
     return GPIO_SLEW_RATE_FAST;
 }
 
-void gpio_set_drive_strength(uint gpio, enum gpio_drive_strength drive){
+PICO_WEAK_FUNCTION_DEF(gpio_set_drive_strength)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_drive_strength)(uint gpio, enum gpio_drive_strength drive){
 
 }
 
-enum gpio_drive_strength gpio_get_drive_strength(uint gpio){
+PICO_WEAK_FUNCTION_DEF(gpio_get_drive_strength)
+enum gpio_drive_strength PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_drive_strength)(uint gpio){
     return GPIO_DRIVE_STRENGTH_4MA;
 }
 
-
-void gpio_set_irq_enabled(uint gpio, uint32_t events, bool enable) {
-
-}
-
-void gpio_acknowledge_irq(uint gpio, uint32_t events) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_irq_enabled)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_irq_enabled)(uint gpio, uint32_t events, bool enable) {
 
 }
 
-void gpio_init(uint gpio) {
+PICO_WEAK_FUNCTION_DEF(gpio_acknowledge_irq)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_acknowledge_irq)(uint gpio, uint32_t events) {
+
+}
+
+PICO_WEAK_FUNCTION_DEF(gpio_init)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init)(uint gpio) {
 
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_get)
-
 bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get)(uint gpio) {
     return 0;
 }
 
-uint32_t gpio_get_all() {
+PICO_WEAK_FUNCTION_DEF(gpio_get_all)
+uint32_t PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get_all)() {
     return 0;
 }
 
-void gpio_set_mask(uint32_t mask) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_mask)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_mask)(uint32_t mask) {
 
 }
 
-void gpio_clr_mask(uint32_t mask) {
+PICO_WEAK_FUNCTION_DEF(gpio_clr_mask)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_clr_mask)(uint32_t mask) {
 
 }
 
-void gpio_xor_mask(uint32_t mask) {
+PICO_WEAK_FUNCTION_DEF(gpio_xor_mask)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_xor_mask)(uint32_t mask) {
 
 }
 
-void gpio_put_masked(uint32_t mask, uint32_t value) {
+PICO_WEAK_FUNCTION_DEF(gpio_put_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_masked)(uint32_t mask, uint32_t value) {
 
 }
 
-void gpio_put_all(uint32_t value) {
+PICO_WEAK_FUNCTION_DEF(gpio_put_all)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put_all)(uint32_t value) {
 
 }
 
-void gpio_put(uint gpio, int value) {
+PICO_WEAK_FUNCTION_DEF(gpio_put)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_put)(uint gpio, int value) {
 
 }
 
-void gpio_set_dir_out_masked(uint32_t mask) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_out_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_out_masked)(uint32_t mask) {
 
 }
 
-void gpio_set_dir_in_masked(uint32_t mask) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_in_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_in_masked)(uint32_t mask) {
 
 }
 
-void gpio_set_dir_masked(uint32_t mask, uint32_t value) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_masked)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_masked)(uint32_t mask, uint32_t value) {
 
 }
 
-void gpio_set_dir_all_bits(uint32_t value) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir_all_bits)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir_all_bits)(uint32_t value) {
 
 }
 
-void gpio_set_dir(uint gpio, bool out) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_dir)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_dir)(uint gpio, bool out) {
 
 }
 
-void gpio_debug_pins_init() {
+PICO_WEAK_FUNCTION_DEF(gpio_debug_pins_init)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_debug_pins_init)() {
 
 }
 
-void gpio_set_input_enabled(uint gpio, bool enable) {
+PICO_WEAK_FUNCTION_DEF(gpio_set_input_enabled)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_set_input_enabled)(uint gpio, bool enable) {
 
 }
 
-void gpio_init_mask(uint gpio_mask) {
+PICO_WEAK_FUNCTION_DEF(gpio_init_mask)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(uint gpio_mask) {
 
 }

--- a/src/host/hardware_gpio/include/hardware/gpio.h
+++ b/src/host/hardware_gpio/include/hardware/gpio.h
@@ -12,9 +12,11 @@ extern "C" {
 #endif
 
 #include "pico.h"
+#include "hardware/irq.h"
 
-enum gpio_function {
+typedef enum gpio_function {
     GPIO_FUNC_XIP = 0,
+    GPIO_FUNC_XIP_CS1 = 0,
     GPIO_FUNC_SPI = 1,
     GPIO_FUNC_UART = 2,
     GPIO_FUNC_I2C = 3,
@@ -24,7 +26,32 @@ enum gpio_function {
     GPIO_FUNC_PIO1 = 7,
     GPIO_FUNC_GPCK = 8,
     GPIO_FUNC_USB = 9,
-    GPIO_FUNC_NULL = 0xf,
+    GPIO_FUNC_HSTX = 10,
+    GPIO_FUNC_PIO2 = 11,
+    GPIO_FUNC_CORESIGHT_TRACE = 12,
+    GPIO_FUNC_UART_AUX = 13,
+    GPIO_FUNC_NULL = 0x1f,
+}gpio_function_t;
+
+enum gpio_dir {
+    GPIO_OUT = 1u, ///< set GPIO to output
+    GPIO_IN = 0u,  ///< set GPIO to input
+};
+
+enum gpio_irq_level {
+    GPIO_IRQ_LEVEL_LOW = 0x1u,  ///< IRQ when the GPIO pin is a logical 0
+    GPIO_IRQ_LEVEL_HIGH = 0x2u, ///< IRQ when the GPIO pin is a logical 1
+    GPIO_IRQ_EDGE_FALL = 0x4u,  ///< IRQ when the GPIO has transitioned from a logical 1 to a logical 0
+    GPIO_IRQ_EDGE_RISE = 0x8u,  ///< IRQ when the GPIO has transitioned from a logical 0 to a logical 1
+};
+
+typedef void (*gpio_irq_callback_t)(uint gpio, uint32_t event_mask);
+
+enum gpio_override {
+    GPIO_OVERRIDE_NORMAL = 0,      ///< peripheral signal selected via \ref gpio_set_function
+    GPIO_OVERRIDE_INVERT = 1,      ///< invert peripheral signal selected via \ref gpio_set_function
+    GPIO_OVERRIDE_LOW = 2,         ///< drive low/disable output
+    GPIO_OVERRIDE_HIGH = 3,        ///< drive high/enable output
 };
 
 enum gpio_slew_rate {
@@ -39,25 +66,28 @@ enum gpio_drive_strength {
     GPIO_DRIVE_STRENGTH_12MA = 3 ///< 12 mA nominal drive strength
 };
 
-#define GPIO_OUT 1
-#define GPIO_IN 0
-
 // ----------------------------------------------------------------------------
 // Pad Controls + IO Muxing
 // ----------------------------------------------------------------------------
 // Declarations for gpio.c
 
-void gpio_set_function(uint gpio, enum gpio_function fn);
+void gpio_set_function(uint gpio, gpio_function_t fn);
+void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn);
+void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn);
 
-enum gpio_function gpio_get_function(uint gpio);
+gpio_function_t gpio_get_function(uint gpio);
+
+void gpio_set_pulls(uint gpio, bool up, bool down);
 
 void gpio_pull_up(uint gpio);
 
+bool gpio_is_pulled_up(uint gpio);
+
 void gpio_pull_down(uint gpio);
 
-void gpio_disable_pulls(uint gpio);
+bool gpio_is_pulled_down(uint gpio);
 
-void gpio_set_pulls(uint gpio, bool up, bool down);
+void gpio_disable_pulls(uint gpio);
 
 void gpio_set_irqover(uint gpio, uint value);
 
@@ -67,7 +97,7 @@ void gpio_set_inover(uint gpio, uint value);
 
 void gpio_set_oeover(uint gpio, uint value);
 
-void gpio_set_input_enabled(uint gpio, bool enable);
+void gpio_set_input_enabled(uint gpio, bool enabled);
 
 void gpio_set_input_hysteresis_enabled(uint gpio, bool enabled);
 
@@ -81,8 +111,40 @@ void gpio_set_drive_strength(uint gpio, enum gpio_drive_strength drive);
 
 enum gpio_drive_strength gpio_get_drive_strength(uint gpio);
 
+void gpio_set_irq_enabled(uint gpio, uint32_t event_mask, bool enabled);
+
+void gpio_set_irq_callback(gpio_irq_callback_t callback);
+
+void gpio_set_irq_enabled_with_callback(uint gpio, uint32_t event_mask, bool enabled, gpio_irq_callback_t callback);
+
+void gpio_set_dormant_irq_enabled(uint gpio, uint32_t event_mask, bool enabled);
+
+uint32_t gpio_get_irq_event_mask(uint gpio);
+
+void gpio_acknowledge_irq(uint gpio, uint32_t event_mask);
+
+void gpio_add_raw_irq_handler_with_order_priority_masked(uint32_t gpio_mask, irq_handler_t handler, uint8_t order_priority);
+
+void gpio_add_raw_irq_handler_with_order_priority_masked64(uint64_t gpio_mask, irq_handler_t handler, uint8_t order_priority);
+
+void gpio_add_raw_irq_handler_with_order_priority(uint gpio, irq_handler_t handler, uint8_t order_priority);
+
+void gpio_add_raw_irq_handler_masked(uint32_t gpio_mask, irq_handler_t handler);
+
+void gpio_add_raw_irq_handler_masked64(uint64_t gpio_mask, irq_handler_t handler);
+
+void gpio_add_raw_irq_handler(uint gpio, irq_handler_t handler);
+
+void gpio_remove_raw_irq_handler_masked(uint32_t gpio_mask, irq_handler_t handler);
+
+void gpio_remove_raw_irq_handler_masked64(uint64_t gpio_mask, irq_handler_t handler);
+
+void gpio_remove_raw_irq_handler(uint gpio, irq_handler_t handler);
+
 // Configure a GPIO for direct input/output from software
 void gpio_init(uint gpio);
+
+void gpio_deinit(uint gpio);
 
 void gpio_init_mask(uint gpio_mask);
 
@@ -94,7 +156,9 @@ void gpio_init_mask(uint gpio_mask);
 bool gpio_get(uint gpio);
 
 // Get raw value of all
-uint32_t gpio_get_all();
+uint32_t gpio_get_all(void);
+
+uint64_t gpio_get_all64(void);
 
 // ----------------------------------------------------------------------------
 // Output
@@ -102,11 +166,17 @@ uint32_t gpio_get_all();
 
 // Drive high every GPIO appearing in mask
 void gpio_set_mask(uint32_t mask);
+void gpio_set_mask64(uint64_t mask);
+void gpio_set_mask_n(uint n, uint32_t mask);
 
 void gpio_clr_mask(uint32_t mask);
+void gpio_clr_mask64(uint64_t mask);
+void gpio_clr_mask_n(uint n, uint32_t mask);
 
 // Toggle every GPIO appearing in mask
 void gpio_xor_mask(uint32_t mask);
+void gpio_xor_mask64(uint64_t mask);
+void gpio_xor_mask_n(uint n, uint32_t mask);
 
 
 // For each 1 bit in "mask", drive that pin to the value given by
@@ -114,13 +184,19 @@ void gpio_xor_mask(uint32_t mask);
 // Since this uses the TOGL alias, it is concurrency-safe with e.g. an IRQ
 // bashing different pins from the same core.
 void gpio_put_masked(uint32_t mask, uint32_t value);
+void gpio_put_masked64(uint64_t mask, uint64_t value);
+void gpio_put_masked_n(uint n, uint32_t mask, uint32_t value);
 
 // Drive all pins simultaneously
 void gpio_put_all(uint32_t value);
+void gpio_put_all64(uint64_t value);
 
 
 // Drive a single GPIO high/low
 void gpio_put(uint gpio, int value);
+
+// Determine whether a GPIO is currently driven high or low
+bool gpio_get_out_level(uint gpio);
 
 // ----------------------------------------------------------------------------
 // Direction
@@ -128,45 +204,76 @@ void gpio_put(uint gpio, int value);
 
 // Switch all GPIOs in "mask" to output
 void gpio_set_dir_out_masked(uint32_t mask);
+void gpio_set_dir_out_masked64(uint64_t mask);
 
 // Switch all GPIOs in "mask" to input
 void gpio_set_dir_in_masked(uint32_t mask);
+void gpio_set_dir_in_masked64(uint64_t mask);
 
 // For each 1 bit in "mask", switch that pin to the direction given by
 // corresponding bit in "value", leaving other pins unchanged.
 // E.g. gpio_set_dir_masked(0x3, 0x2); -> set pin 0 to input, pin 1 to output,
 // simultaneously.
 void gpio_set_dir_masked(uint32_t mask, uint32_t value);
+void gpio_set_dir_masked64(uint64_t mask, uint64_t value);
 
 // Set direction of all pins simultaneously.
 // For each bit in value,
 // 1 = out
 // 0 = in
 void gpio_set_dir_all_bits(uint32_t value);
+void gpio_set_dir_all_bits64(uint64_t values);
 
 // Set a single GPIO to input/output.
 // true = out
 // 0 = in
 void gpio_set_dir(uint gpio, bool out);
 
-// debugging
-#ifndef PICO_DEBUG_PIN_BASE
-#define PICO_DEBUG_PIN_BASE 19u
+// Check if a specific GPIO direction is OUT
+bool gpio_is_dir_out(uint gpio);
+
+// Get a specific GPIO direction
+// 1 = out
+// 0 = in
+uint gpio_get_dir(uint gpio);
+
+#if PICO_SECURE
+void gpio_assign_to_ns(uint gpio, bool ns);
 #endif
-
-// note these two macros may only be used once per compilation unit
-#define CU_REGISTER_DEBUG_PINS(p, ...)
-#define CU_SELECT_DEBUG_PINS(x)
-#define DEBUG_PINS_ENABLED(p) false
-
-#define DEBUG_PINS_SET(p, v) ((void)0)
-#define DEBUG_PINS_CLR(p, v) ((void)0)
-#define DEBUG_PINS_XOR(p, v) ((void)0)
-
-void gpio_debug_pins_init();
+extern void gpio_debug_pins_init(void);
 
 #ifdef __cplusplus
 }
 #endif
+
+
+// PICO_CONFIG: PICO_DEBUG_PIN_BASE, First pin to use for debug output (if enabled), min=0, max=31 on RP2350B, 29 otherwise, default=19, group=hardware_gpio
+#ifndef PICO_DEBUG_PIN_BASE
+#define PICO_DEBUG_PIN_BASE 19u
+#endif
+
+// PICO_CONFIG: PICO_DEBUG_PIN_COUNT, Number of pins to use for debug output (if enabled), min=1, max=32 on RP2350B, 30 otherwise, default=3, group=hardware_gpio
+#ifndef PICO_DEBUG_PIN_COUNT
+#define PICO_DEBUG_PIN_COUNT 3u
+#endif
+
+#ifndef __cplusplus
+// note these two macros may only be used once per and only apply per compilation unit (hence the CU_)
+#define CU_REGISTER_DEBUG_PINS(...) enum __unused DEBUG_PIN_TYPE { _none = 0, __VA_ARGS__ }; static enum DEBUG_PIN_TYPE __selected_debug_pins;
+#define CU_SELECT_DEBUG_PINS(x) static enum DEBUG_PIN_TYPE __selected_debug_pins = (x);
+#define DEBUG_PINS_ENABLED(p) (__selected_debug_pins == (p))
+#else
+#define CU_REGISTER_DEBUG_PINS(p...) \
+    enum DEBUG_PIN_TYPE { _none = 0, p }; \
+    template <enum DEBUG_PIN_TYPE> class __debug_pin_settings { \
+        public: \
+            static inline bool enabled() { return false; } \
+    };
+#define CU_SELECT_DEBUG_PINS(x) template<> inline bool __debug_pin_settings<x>::enabled() { return true; };
+#define DEBUG_PINS_ENABLED(p) (__debug_pin_settings<p>::enabled())
+#endif
+#define DEBUG_PINS_SET(p, v) if (DEBUG_PINS_ENABLED(p)) gpio_set_mask((unsigned)(v)<<PICO_DEBUG_PIN_BASE)
+#define DEBUG_PINS_CLR(p, v) if (DEBUG_PINS_ENABLED(p)) gpio_clr_mask((unsigned)(v)<<PICO_DEBUG_PIN_BASE)
+#define DEBUG_PINS_XOR(p, v) if (DEBUG_PINS_ENABLED(p)) gpio_xor_mask((unsigned)(v)<<PICO_DEBUG_PIN_BASE)
 
 #endif

--- a/src/host/hardware_gpio/include/hardware/gpio.h
+++ b/src/host/hardware_gpio/include/hardware/gpio.h
@@ -66,6 +66,8 @@ enum gpio_drive_strength {
     GPIO_DRIVE_STRENGTH_12MA = 3 ///< 12 mA nominal drive strength
 };
 
+void check_gpio_param(uint gpio);
+
 // ----------------------------------------------------------------------------
 // Pad Controls + IO Muxing
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
As stated in #2736, the host GPIO implementation is currently a little too basic and is missing quite a few functions that have been introduced in recent SDK versions.

This PR has several commits to make the implementation a bit more usable for running tests on the host.
