### PR TITLE
Fix incorrect Bazel dependency in host/hardware_irq

### DIFF
--- a/src/common/pico_base_headers/BUILD.bazel
+++ b/src/common/pico_base_headers/BUILD.bazel
@@ -92,6 +92,7 @@ cc_library(
     includes = ["include"],
     visibility = [
         "//src/common:__subpackages__",
+        "//src/host/hardware_irq:__pkg__",
         "//src/host/hardware_sync:__pkg__",
         "//src/host/hardware_timer:__pkg__",
         "//src/host/pico_platform:__pkg__",

--- a/src/host/hardware_irq/BUILD.bazel
+++ b/src/host/hardware_irq/BUILD.bazel
@@ -8,7 +8,7 @@ cc_library(
     tags = ["manual"],  # TODO: No hardware/regs/intctrl.h for host yet.
     target_compatible_with = ["//bazel/constraint:host"],
     deps = [
-        "//src/host/hardware_claim",
+        "//src/common/hardware_claim",
         "//src/host/pico_platform",
     ],
 )


### PR DESCRIPTION
Bazel configuration adds a dependency on hardware_claim in 'host' but it doesn't exist there.  It's in 'common'.

Fixes #2738
