### PR TITLE
Add support for The xPack GNU RISC-V Embedded GCC

### DIFF
--- a/cmake/preload/toolchains/pico_riscv_gcc.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc.cmake
@@ -1,6 +1,6 @@
 set(CMAKE_SYSTEM_PROCESSOR hazard3)
 
-set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf)
+set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
 
 set(PICO_COMMON_LANG_FLAGS " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32")
 

--- a/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
@@ -3,7 +3,7 @@
 
 set(CMAKE_SYSTEM_PROCESSOR hazard3)
 
-set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf)
+set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
 
 set(PICO_COMMON_LANG_FLAGS " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32")
 


### PR DESCRIPTION
Add support for The xPack GNU RISC-V Embedded GCC (https://xpack-dev-tools.github.io/riscv-none-elf-gcc-xpack) which is a part of Eclipse Embedded CDT (https://eclipse-embed-cdt.github.io).

pico-sdk was configured and built successfully by this compiler while developing STK project (https://github.com/SuperTinyKernel-RTOS/stk), so it can be included into CMake configuration safely.