### PR TITLE
Add definition of PICO_NUM_VTABLE_IRQS to host build

### DIFF
--- a/src/host/pico_platform/include/pico/platform.h
+++ b/src/host/pico_platform/include/pico/platform.h
@@ -159,6 +159,11 @@ static inline uint __get_current_exception(void) {
 
 void busy_wait_at_least_cycles(uint32_t minimum_cycles);
 
+// PICO_CONFIG: PICO_NUM_VTABLE_IRQS, Number of IRQ handlers in the vector table - can be lowered to save space if you aren't using some higher IRQs, type=int, default=NUM_IRQS, group=hardware_irq
+#ifndef PICO_NUM_VTABLE_IRQS
+#define PICO_NUM_VTABLE_IRQS NUM_IRQS
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As mentioned in #2748, PICO_NUM_VTABLE_IRQS is used but not defined in host builds, which causes compile errors in debug builds.

