### PR TITLE
Add missing pio_encode_wait_jmppin function to pio_instructions.h

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
@@ -310,6 +310,23 @@ static inline uint pio_encode_wait_irq(bool polarity, bool relative, uint irq) {
     return _pio_encode_instr_and_args(pio_instr_bits_wait, 2u | (polarity ? 4u : 0u), _pio_encode_irq(relative, irq));
 }
 
+#if PICO_PIO_VERSION > 0
+/*! \brief Encode a WAIT for jmppin instruction
+ *  \ingroup pio_instructions
+ *
+ * This is the equivalent of `WAIT <polarity> JMPPIN + <offset>`
+ *
+ * \param polarity true for `WAIT 1`, false for `WAIT 0`
+ * \param offset The pin offset 0-3 relative to the executing SM's jmp pin mapping
+ * \return The instruction encoding with 0 delay and no side set value
+ * \see pio_encode_delay, pio_encode_sideset, pio_encode_sideset_opt
+ */
+static inline uint pio_encode_wait_jmppin(bool polarity, uint offset) {
+    valid_params_if(PIO_INSTRUCTIONS, offset <= 4);
+    return _pio_encode_instr_and_args(pio_instr_bits_wait, 3u | (polarity ? 4u : 0u), offset);
+}
+#endif
+
 /*! \brief Encode an IN instruction
  *  \ingroup pio_instructions
  *


### PR DESCRIPTION
I noticed that this function was missing whilst looking at #2754 