### PR TITLE
Flash functions in PICO_NO_FLASH binaries

### DIFF
--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -354,7 +354,7 @@ void __no_inline_not_in_flash_func(flash_do_cmd_cs)(const uint8_t *txbuf, uint8_
 static_assert(FLASH_UNIQUE_ID_SIZE_BYTES == FLASH_RUID_DATA_BYTES, "");
 
 void flash_get_unique_id(uint8_t *id_out) {
-#if PICO_NO_FLASH && !PICO_INCLUDE_FLASH_ID_FUNCTIONS
+#if PICO_NO_FLASH && !PICO_ALWAYS_INCLUDE_FLASH_ID_FUNCTIONS
     __unused uint8_t *ignore = id_out;
     panic_unsupported();
 #else

--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -354,7 +354,7 @@ void __no_inline_not_in_flash_func(flash_do_cmd_cs)(const uint8_t *txbuf, uint8_
 static_assert(FLASH_UNIQUE_ID_SIZE_BYTES == FLASH_RUID_DATA_BYTES, "");
 
 void flash_get_unique_id(uint8_t *id_out) {
-#if PICO_NO_FLASH
+#if PICO_NO_FLASH && !PICO_INCLUDE_FLASH_ID_FUNCTIONS
     __unused uint8_t *ignore = id_out;
     panic_unsupported();
 #else

--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -52,6 +52,11 @@
 
 // PICO_CONFIG: PICO_FLASH_SIZE_BYTES, size of primary flash in bytes, type=int, default=Usually provided via board header, group=hardware_flash
 
+// PICO_CONFIG: PICO_INCLUDE_FLASH_ID_FUNCTIONS, Force inclusion of flash unique id functionality in PICO_NO_FLASH binaries, type=bool, default=0, group=hardware_flash
+#ifndef PICO_INCLUDE_FLASH_ID_FUNCTIONS
+#define PICO_INCLUDE_FLASH_ID_FUNCTIONS 0
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -52,9 +52,9 @@
 
 // PICO_CONFIG: PICO_FLASH_SIZE_BYTES, size of primary flash in bytes, type=int, default=Usually provided via board header, group=hardware_flash
 
-// PICO_CONFIG: PICO_INCLUDE_FLASH_ID_FUNCTIONS, Force inclusion of flash unique id functionality in PICO_NO_FLASH binaries, type=bool, default=0, group=hardware_flash
-#ifndef PICO_INCLUDE_FLASH_ID_FUNCTIONS
-#define PICO_INCLUDE_FLASH_ID_FUNCTIONS 0
+// PICO_CONFIG: PICO_ALWAYS_INCLUDE_FLASH_ID_FUNCTIONS, Force inclusion of flash unique id functionality in PICO_NO_FLASH binaries, type=bool, default=0, group=hardware_flash
+#ifndef PICO_ALWAYS_INCLUDE_FLASH_ID_FUNCTIONS
+#define PICO_ALWAYS_INCLUDE_FLASH_ID_FUNCTIONS 0
 #endif
 
 #ifdef __cplusplus

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -20,7 +20,7 @@ static pico_unique_board_id_t retrieved_id;
 
 static void __attribute__((PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES)) _retrieve_unique_id_on_boot(void) {
 #if PICO_RP2040
-    #if PICO_NO_FLASH
+    #if PICO_NO_FLASH && !PICO_INCLUDE_FLASH_ID_FUNCTIONS
         // The hardware_flash call will panic() if called directly on a NO_FLASH
         // build. Since this constructor is pre-main it would be annoying to
         // debug, so just produce something well-defined and obviously wrong.

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -20,7 +20,7 @@ static pico_unique_board_id_t retrieved_id;
 
 static void __attribute__((PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES)) _retrieve_unique_id_on_boot(void) {
 #if PICO_RP2040
-    #if PICO_NO_FLASH && !PICO_INCLUDE_FLASH_ID_FUNCTIONS
+    #if PICO_NO_FLASH && !PICO_ALWAYS_INCLUDE_FLASH_ID_FUNCTIONS
         // The hardware_flash call will panic() if called directly on a NO_FLASH
         // build. Since this constructor is pre-main it would be annoying to
         // debug, so just produce something well-defined and obviously wrong.


### PR DESCRIPTION
We assume that PICO_NO_FLASH binaries means the device does not have a flash chip. But it's possible that you want a ram binary AND want to mess about with flash, e.g. something that uses the unique flash id.

Add PICO_INCLUDE_FLASH_FUNCTIONS  which forces some flash functions to be included.
