### PR TITLE
Fix uninit r2 in divmod_u32u32_unsafe and divmod_s32s32_unsafe

### DIFF
--- a/src/rp2_common/pico_divider/divider_hardware.S
+++ b/src/rp2_common/pico_divider/divider_hardware.S
@@ -111,6 +111,7 @@ regular_func divmod_s32s32
     lsrs r3, #SIO_DIV_CSR_DIRTY_SHIFT_FOR_CARRY
     bcs divmod_s32s32_savestate
 regular_func divmod_s32s32_unsafe
+    ldr r2, =SIO_BASE
 #else
 // to avoid too much source code spaghetti with restoring interrupts, we make this the same as the other funcs
 // in the PICO_DIVIDER_DISABLE_INTERRUPTS case; i.e. it is not a faster function; this seems reasonable as there
@@ -173,6 +174,7 @@ wrapper_func __aeabi_uidivmod
     lsrs r3, #SIO_DIV_CSR_DIRTY_SHIFT_FOR_CARRY
     bcs divmod_u32u32_savestate
 regular_func divmod_u32u32_unsafe
+    ldr r2, =SIO_BASE
 #else
 // to avoid too much source code spaghetti with restoring interrupts, we make this the same as the other funcs
 // in the PICO_DIVIDER_DISABLE_INTERRUPTS case; i.e. it is not a faster function; this seems reasonable as there


### PR DESCRIPTION
When the ``divmod_s32s32_unsafe`` and ``divmod_u32u32_unsafe``
is called without enabled ``PICO_DIVIDER_DISABLE_INTERRUPTS``,
``ldr r2, =SIO_BASE`` will be bypassed. Later access to ``SIO_DIV``
will crash.

Fixes #2773