### PR TITLE
remove guards that disable sdio_usb when tinyusb_host is linked in

### DIFF
--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -5,6 +5,7 @@
  */
 #include "tusb.h"
 
+#if !defined(LIB_TINYUSB_HOST) || (defined(LIB_TINYUSB_HOST) && defined(CFG_TUH_RPI_PIO_USB))
 #include "pico/bootrom.h"
 
 #if PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE && !(PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL || PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT)
@@ -184,4 +185,4 @@ void tud_cdc_line_coding_cb(__unused uint8_t itf, cdc_line_coding_t const* p_lin
     }
 }
 #endif
-
+#endif // !defined(LIB_TINYUSB_HOST) || (defined(LIB_TINYUSB_HOST) && defined(CFG_TUH_RPI_PIO_USB))

--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -7,8 +7,6 @@
 
 #include "pico/bootrom.h"
 
-#if !defined(LIB_TINYUSB_HOST)
-
 #if PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE && !(PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL || PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT)
 #warning PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE has been selected but neither PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL nor PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT have been selected.
 #endif
@@ -187,4 +185,3 @@ void tud_cdc_line_coding_cb(__unused uint8_t itf, cdc_line_coding_t const* p_lin
 }
 #endif
 
-#endif

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef LIB_TINYUSB_HOST
 #include "tusb.h"
 #include "pico/stdio_usb.h"
 
@@ -301,10 +300,4 @@ bool stdio_usb_init(void) {
     return false;
 }
 #endif // CFG_TUD_ENABLED && CFG_TUD_CDC
-#else
-#warning stdio USB was configured, but is being disabled as TinyUSB host is explicitly linked
-bool stdio_usb_init(void) {
-    return false;
-}
-#endif // !LIB_TINYUSB_HOST
 

--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -5,6 +5,8 @@
  */
 
 #include "tusb.h"
+
+#if !defined(LIB_TINYUSB_HOST) || (defined(LIB_TINYUSB_HOST) && defined(CFG_TUH_RPI_PIO_USB))
 #include "pico/stdio_usb.h"
 
 // these may not be set if the user is providing tud support (i.e. LIB_TINYUSB_DEVICE is 1 because
@@ -300,4 +302,10 @@ bool stdio_usb_init(void) {
     return false;
 }
 #endif // CFG_TUD_ENABLED && CFG_TUD_CDC
+#else
+#warning stdio USB was configured, but is being disabled as TinyUSB host is explicitly linked and is not using PIO-USB
+bool stdio_usb_init(void) {
+    return false;
+}
+#endif // !defined(LIB_TINYUSB_HOST) || (defined(LIB_TINYUSB_HOST) && defined(CFG_TUH_RPI_PIO_USB))
 


### PR DESCRIPTION
Implements #2763. 

I have a working demonstration with tinyusb_host and tinyusb_device linked in along with Pico-PIO-USB; everything is working fine (including picoloader reset).

I started off copying and pasting the sdio_usb.c code and implementing my own sdio interface, and once that worked I started looking at how to get things working with the sdk's implementation. 