### PR TITLE
Fix RP2040 crash with PICO_*_IN_RAM and NaN propagation

### DIFF
--- a/src/rp2_common/pico_double/double_aeabi_rp2040.S
+++ b/src/rp2_common/pico_double/double_aeabi_rp2040.S
@@ -44,11 +44,9 @@ PICO_RUNTIME_INIT_FUNC_RUNTIME(__aeabi_double_init, PICO_RUNTIME_INIT_AEABI_DOUB
 #endif
 .endm
 
-.section .text
-
 #if PICO_DOUBLE_PROPAGATE_NANS
-.thumb_func
-__check_nan_d1:
+double_section __check_nan_d1
+regular_func __check_nan_d1
    movs r3, #1
    lsls r3, #21
    lsls r2, r1, #1
@@ -58,8 +56,8 @@ __check_nan_d1:
 1:
    bx ip
 
-.thumb_func
-__check_nan_d2:
+double_section __check_nan_d2
+regular_func __check_nan_d2
    push {r0, r2}
    movs r2, #1
    lsls r2, #21

--- a/src/rp2_common/pico_float/float_aeabi_rp2040.S
+++ b/src/rp2_common/pico_float/float_aeabi_rp2040.S
@@ -47,11 +47,10 @@ float_section WRAPPER_FUNC_NAME(\func)
 #endif
 .endm
 
-.section .text
 
 #if PICO_FLOAT_PROPAGATE_NANS
-.thumb_func
-__check_nan_f1:
+float_section __check_nan_f1
+regular_func __check_nan_f1
    movs r3, #1
    lsls r3, #24
    lsls r2, r0, #1
@@ -61,8 +60,8 @@ __check_nan_f1:
 1:
    bx ip
 
-.thumb_func
-__check_nan_f2:
+float_section __check_nan_f2
+regular_func __check_nan_f2
    movs r3, #1
    lsls r3, #24
    lsls r2, r0, #1


### PR DESCRIPTION
  ``__check_nan<f|d><1|2>`` is hard-coded into ``.text`` instead of being wrapped with ``<double|float>_section`` like other ``__aeabi*`` functions. When those functions are moved to SRAM, this leaves ``__check_nan*`` in flash, causing GCC to emit a veneer call that clobbers ``ip`` and corrupts the saved ``lr`` in ``wrapper_func_<d|f><1|2>``.

Fixes #2771