### PR TITLE
docs: fix powman_timer_enable_alarm_at_ms documentation

### DIFF
--- a/src/rp2_common/hardware_powman/include/hardware/powman.h
+++ b/src/rp2_common/hardware_powman/include/hardware/powman.h
@@ -84,7 +84,7 @@ void powman_timer_set_ms(uint64_t time_ms);
 /*! \brief Set an alarm at an absolute time in ms
  *  \ingroup hardware_powman
  *
- * Note, the timer is stopped and then restarted as part of this function. This only controls the alarm
+ * Note, the alarm is disabled and then re-enabled as part of this function. This only controls the alarm;
  * if you want to use the alarm to wake up powman then you should use \ref powman_enable_alarm_wakeup_at_ms
  *
  * \param alarm_time_ms time at which the alarm will fire


### PR DESCRIPTION
## Summary
The documentation for `powman_timer_enable_alarm_at_ms` incorrectly stated that "the timer is stopped and then restarted" but the actual code behavior shows that the **alarm** is disabled and then re-enabled.

## Change
```diff
- * Note, the timer is stopped and then restarted as part of this function. This only controls the alarm
+ * Note, the alarm is disabled and then re-enabled as part of this function. This only controls the alarm;
```

Looking at the implementation in `powman.c`:
- Line 228: `powman_clear_bits(&powman_hw->timer, POWMAN_TIMER_ALARM_ENAB_BITS);` - disables alarm
- Line 236: `powman_set_bits(&powman_hw->timer, POWMAN_TIMER_ALARM_ENAB_BITS);` - enables alarm

The timer itself is not stopped/restarted, only the alarm enable bit is toggled.

Fixes #2716