### PR TITLE
Update the localtime_r declaration for LLVM libc

### DIFF
--- a/src/rp2_common/pico_clib_interface/include/llvm_libc/time.h
+++ b/src/rp2_common/pico_clib_interface/include/llvm_libc/time.h
@@ -14,7 +14,7 @@
 
 __BEGIN_C_DECLS
 
-struct tm* localtime_r(const time_t* timer, struct tm* buf);
+struct tm* localtime_r(const time_t* timer, struct tm* buf) __NOEXCEPT;
 
 __END_C_DECLS
 


### PR DESCRIPTION
This is to match upstream declaration and avoid conflicting declaration error. This declaration will be removed after the next Clang update since LLVM libc now implements localtime_r but we keep the declaration for now to allow soft transition for SDK users.
