### PR TITLE
Add support for WeAct RP2350A core board V10

### DIFF
--- a/src/boards/include/boards/weact_studio_rp2350a_core_v10_16mb.h
+++ b/src/boards/include/boards/weact_studio_rp2350a_core_v10_16mb.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/weact_studio_rp2350a_core_v10_16mb.h"
+
+#ifndef _BOARDS_WEACT_STUDIO_RP2350A_CORE_V10_16MB_H
+#define _BOARDS_WEACT_STUDIO_RP2350A_CORE_V10_16MB_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2350)
+
+// For board detection
+#define WEACT_STUDIO_RP2350A_CORE_V10_16MB
+
+// --- BOARD SPECIFIC ---
+#define WEACT_STUDIO_USER_SW_PIN 23
+#define WEACT_STUDIO_LED1_PIN 24
+#define WEACT_STUDIO_LED2_PIN 25
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+#ifndef PICO_DEFAULT_LED1_PIN
+#define PICO_DEFAULT_LED1_PIN WEACT_STUDIO_LED1_PIN
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+// --- RP2350 VARIANT ---
+// This means RP2350B.
+#define PICO_RP2350A 1
+
+pico_board_cmake_set_default(PICO_RP2350_A2_SUPPORTED, 1)
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+#endif

--- a/src/boards/include/boards/weact_studio_rp2350a_core_v10_4mb.h
+++ b/src/boards/include/boards/weact_studio_rp2350a_core_v10_4mb.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/weact_studio_rp2350a_core_v10_4mb.h"
+
+#ifndef _BOARDS_WEACT_STUDIO_RP2350A_CORE_V10_4MB_H
+#define _BOARDS_WEACT_STUDIO_RP2350A_CORE_V10_4MB_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2350)
+
+// For board detection
+#define WEACT_STUDIO_RP2350A_CORE_V10_4MB
+
+// --- BOARD SPECIFIC ---
+#define WEACT_STUDIO_USER_SW_PIN 23
+#define WEACT_STUDIO_LED1_PIN 24
+#define WEACT_STUDIO_LED2_PIN 25
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+#ifndef PICO_DEFAULT_LED1_PIN
+#define PICO_DEFAULT_LED1_PIN WEACT_STUDIO_LED1_PIN
+#endif
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (4 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+// --- RP2350 VARIANT ---
+// This means RP2350B.
+#define PICO_RP2350A 1
+
+pico_board_cmake_set_default(PICO_RP2350_A2_SUPPORTED, 1)
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+#endif


### PR DESCRIPTION
I was testing RP2350A using this breakout board for more accessible GPIO pins. Based off pico 2’s definition, with minor modifications.

[WeActStudio/WeActStudio.RP2350ACoreBoard`@main`/RP2350A_V10/HDK/V10_PinOUT.png](https://github.com/WeActStudio/WeActStudio.RP2350ACoreBoard/blob/main/RP2350A_V10/HDK/V10_PinOUT.png)

Fixes #2776