### PR TITLE
Omit semicolons after _Pragma directives

### DIFF
--- a/src/rp2_common/hardware_sync/include/hardware/sync.h
+++ b/src/rp2_common/hardware_sync/include/hardware/sync.h
@@ -372,8 +372,8 @@ bool spin_lock_is_claimed(uint lock_num);
 #define remove_volatile_cast(t, x) (t)(x)
 #define remove_volatile_cast_no_barrier(t, x) (t)(x)
 #else
-#define remove_volatile_cast(t, x) ({__compiler_memory_barrier(); Clang_Pragma("clang diagnostic push"); Clang_Pragma("clang diagnostic ignored \"-Wcast-qual\""); (t)(x); Clang_Pragma("clang diagnostic pop"); })
-#define remove_volatile_cast_no_barrier(t, x) ({ Clang_Pragma("clang diagnostic push"); Clang_Pragma("clang diagnostic ignored \"-Wcast-qual\""); (t)(x); Clang_Pragma("clang diagnostic pop"); })
+#define remove_volatile_cast(t, x) (__compiler_memory_barrier(), Clang_Pragma("clang diagnostic push") Clang_Pragma("clang diagnostic ignored \"-Wcast-qual\"") (t)(x) Clang_Pragma("clang diagnostic pop"))
+#define remove_volatile_cast_no_barrier(t, x) Clang_Pragma("clang diagnostic push") Clang_Pragma("clang diagnostic ignored \"-Wcast-qual\"") (t)(x) Clang_Pragma("clang diagnostic pop")
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
These are not statements and shouldn't be terminated by semicolons; in newer versions of Clang separating these by semicolons results in a build error.

We can also further simplify `remove_volatile_cast` by using the comma operator and avoiding the reliance on non-standard GNU extensions.
