### PR TITLE
Use alternate macro mode to evaluate expressions

### DIFF
--- a/src/rp2_common/pico_crt0/crt0_riscv.S
+++ b/src/rp2_common/pico_crt0/crt0_riscv.S
@@ -171,11 +171,13 @@ __soft_vector_table:
 .word isr_irq\n
 .endm
 
+.altmacro
 .set IRQN, 0
 .rept PICO_NUM_VTABLE_IRQS
-vtable_irq_n IRQN
+vtable_irq_n %IRQN
 .set IRQN, IRQN + 1
 .endr
+.noaltmacro
 
 // all default trap handlers do nothing, and we can check for them being set to our
 // default values by seeing if they point to somewhere between __defaults_isrs_start and __default_isrs_end
@@ -222,11 +224,13 @@ decl_isr_bkpt isr_riscv_machine_soft_irq
 .endif
 .endm
 
+.altmacro
 .set IRQN, 0
 .rept PICO_NUM_VTABLE_IRQS
-decl_isr_n IRQN
+decl_isr_n %IRQN
 .set IRQN, IRQN + 1
 .endr
+.noaltmacro
     // fall through
 
 // All unhandled USER IRQs fall through to here. Note there is no way to get


### PR DESCRIPTION
Without the alternate macro mode, when building with Clang, the arguments to macros weren't evaluated.