### PR TITLE
make host hardware_ libraries depend on hardware_claim too as it was moved to common in 2.0.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,9 +165,7 @@ macro(pico_simple_hardware_impl_target NAME)
                 )
 
         pico_mirrored_target_link_libraries(hardware_${NAME} INTERFACE pico_platform)
-        if (NOT PICO_NO_HARDWARE)
-            target_link_libraries(hardware_${NAME} INTERFACE hardware_claim)
-        endif()
+        target_link_libraries(hardware_${NAME} INTERFACE hardware_claim)
     endif()
 endmacro()
 

--- a/src/host/hardware_irq/CMakeLists.txt
+++ b/src/host/hardware_irq/CMakeLists.txt
@@ -1,2 +1,1 @@
 pico_simple_hardware_target(irq)
-target_link_libraries(hardware_irq INTERFACE hardware_claim)


### PR DESCRIPTION
fixes #2735 
