### PR TITLE
pio_claim_free_sm_and_add_program_for_gpio_range does not clean up claimed state machines

### DIFF
--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -433,7 +433,8 @@ bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *progr
                 sm_index[num_claimed] = (int8_t)pio_claim_unused_sm(*pio, false);
                 if (sm_index[num_claimed] < 0) break;
             }
-            int rc = num_claimed && (!pass || num_claimed == NUM_PIO_STATE_MACHINES) ? 0 : -1;
+            // rc = 0 if we claimed all the required state machines for the pass, <0 otherwise
+            int rc = num_claimed - (pass ? NUM_PIO_STATE_MACHINES : 1)
             if (rc >= 0) {
                 uint32_t save = hw_claim_lock();
                 if (pass) {

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -433,27 +433,28 @@ bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *progr
                 sm_index[num_claimed] = (int8_t)pio_claim_unused_sm(*pio, false);
                 if (sm_index[num_claimed] < 0) break;
             }
-            if (num_claimed && (!pass || num_claimed == NUM_PIO_STATE_MACHINES)) {
+            int rc = num_claimed && (!pass || num_claimed == NUM_PIO_STATE_MACHINES) ? 0 : -1;
+            if (rc >= 0) {
                 uint32_t save = hw_claim_lock();
                 if (pass) {
                     pio_set_gpio_base_unsafe(*pio, required_gpio_ranges & 4 ? 16 : 0);
                 }
-                int rc = is_gpio_compatible(*pio, required_gpio_ranges) ? PICO_OK : PICO_ERROR_BAD_ALIGNMENT;
-                if (rc == PICO_OK) rc = find_offset_for_program(*pio, program);
+                rc = is_gpio_compatible(*pio, required_gpio_ranges) ? 0 : -1;
+                if (rc >= 0) rc = find_offset_for_program(*pio, program);
                 if (rc >= 0) rc = add_program_at_offset(*pio, program, (uint)rc);
                 if (rc >= 0) {
                     *sm = (uint) sm_index[0];
                     *offset = (uint) rc;
                 }
                 hw_claim_unlock(save);
-                // always un-claim all SMs other than the one we need (array index 0),
-                // or all of them if we had an error
-                for (uint i = (rc >= 0); i < num_claimed; i++) {
-                    pio_sm_unclaim(*pio, (uint) sm_index[i]);
-                }
-                if (rc >= 0) {
-                    return true;
-                }
+            }
+            // always un-claim all SMs other than the one we need (array index 0),
+            // or all of them if we had an error
+            for (uint i = (rc >= 0); i < num_claimed; i++) {
+                pio_sm_unclaim(*pio, (uint) sm_index[i]);
+            }
+            if (rc >= 0) {
+                return true;
             }
         }
     }

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -434,7 +434,7 @@ bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *progr
                 if (sm_index[num_claimed] < 0) break;
             }
             // rc = 0 if we claimed all the required state machines for the pass, <0 otherwise
-            int rc = num_claimed - (pass ? NUM_PIO_STATE_MACHINES : 1)
+            int rc = num_claimed - (pass ? NUM_PIO_STATE_MACHINES : 1);
             if (rc >= 0) {
                 uint32_t save = hw_claim_lock();
                 if (pass) {


### PR DESCRIPTION
The RP2350B requires the use of gpio_base to shift the pins for a PIO. The pio_claim_free_sm_and_add_program_for_gpio_range function handles this incorrectly, and forgets to unclaim unused state machines. This PR fixes that.

## Steps to reproduce

Execute this program on a RP2350B

```
#if !defined(PICO_RP2350) || PICO_RP2350A
    #error "use RP2350B"
#endif

static const uint16_t ws2812_program_instructions[] = {
    //     .wrap_target
    0x6221, //  0: out    x, 1            side 0 [2]
    0x1123, //  1: jmp    !x, 3           side 1 [1]
    0x1400, //  2: jmp    0               side 1 [4]
    0xa442, //  3: nop                    side 0 [4]
            //     .wrap
};

static const struct pio_program ws2812_program = {
    .instructions = ws2812_program_instructions,
    .length = 4,
    .origin = -1,
};

void setup() {
  int pin;
  PIO pio_claim;
  uint sm_claim;
  uint pio_program_offset;
  bool success;

  Serial.begin();
  delay(5000);

  //start with all SM unclaimed and base=0
  for(uint p = 0; p < NUM_PIOS; p++) {
    PIO pio = PIO_INSTANCE(p);
    for(uint sm = 0; sm < NUM_PIO_STATE_MACHINES; sm++) {
        if(pio_sm_is_claimed(pio, sm)) {
            pio_sm_unclaim(pio, sm);
            pio_set_gpio_base(pio, 0);
        }
    }
  }

  //claim SM for pin 0 (base=0)
  pin = 0;
  success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio_claim, &sm_claim, &pio_program_offset, pin, 1, true);
  if (!success) {
    Serial.println("claim1 failed");
    return; 
  }
  Serial.printf("\nclaim1: claimed pio%d-sm%d\n", PIO_NUM(pio_claim), sm_claim);
  for(uint p = 0; p < NUM_PIOS; p++) {
    PIO pio = PIO_INSTANCE(p);
    for(uint sm = 0; sm < NUM_PIO_STATE_MACHINES; sm++) {
        int base = pio_get_gpio_base(pio);
        bool claimed = pio_sm_is_claimed(pio, sm);
        Serial.printf("  pio%d-sm%d ", p, sm);
        Serial.printf("%-10s ", (claimed ? "claimed" : "free"));
        Serial.printf("base=%2d ", base);
        Serial.println();
    }
  }

  //claim SM for pin 47 (base=16)
  pin = 47;
  success = pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_program, &pio_claim, &sm_claim, &pio_program_offset, pin, 1, true);
  if (!success) {
    Serial.println("claim2 failed");
    return; 
  }
  Serial.printf("\nclaim2: claimed pio%d-sm%d\n", PIO_NUM(pio_claim), sm_claim);
  for(uint p = 0; p < NUM_PIOS; p++) {
    PIO pio = PIO_INSTANCE(p);
    for(uint sm = 0; sm < NUM_PIO_STATE_MACHINES; sm++) {
        int base = pio_get_gpio_base(pio);
        bool claimed = pio_sm_is_claimed(pio, sm);
        Serial.printf("  pio%d-sm%d ", p, sm);
        Serial.printf("%-10s ", (claimed ? "claimed" : "free"));
        Serial.printf("base=%2d ", base);
        Serial.println();
    }
  }

}

void loop() {}
```

Result:

```
claim1: claimed pio2-sm0
  pio0-sm0 free       base= 0 
  pio0-sm1 free       base= 0 
  pio0-sm2 free       base= 0 
  pio0-sm3 free       base= 0 
  pio1-sm0 free       base= 0 
  pio1-sm1 free       base= 0 
  pio1-sm2 free       base= 0 
  pio1-sm3 free       base= 0 
  pio2-sm0 claimed    base= 0 
  pio2-sm1 free       base= 0 
  pio2-sm2 free       base= 0 
  pio2-sm3 free       base= 0 

claim2: claimed pio1-sm0
  pio0-sm0 free       base= 0 
  pio0-sm1 free       base= 0 
  pio0-sm2 free       base= 0 
  pio0-sm3 free       base= 0 
  pio1-sm0 claimed    base=16 
  pio1-sm1 free       base=16 
  pio1-sm2 free       base=16 
  pio1-sm3 free       base=16 
  pio2-sm0 claimed    base= 0 
  pio2-sm1 claimed    base= 0 
  pio2-sm2 claimed    base= 0 
  pio2-sm3 claimed    base= 0
```

I.e. 3 additional SMs are claimed with the second pio_claim_free_sm_and_add_program_for_gpio_range() call