### PR TITLE
pioasm: Enhance JSON output with additional program metadata

### DIFF
--- a/tools/pioasm/BUILD.bazel
+++ b/tools/pioasm/BUILD.bazel
@@ -12,7 +12,6 @@ cc_library(
         "gen/parser.cpp",
         "gen/parser.hpp",
         "go_output.cpp",
-        "json_output.cpp",
         "main.cpp",
         "output_format.h",
         "pio_assembler.cpp",
@@ -36,6 +35,13 @@ cc_library(
         "gen",
     ],
     target_compatible_with = ["//bazel/constraint:host"],
+)
+
+cc_library(
+    name = "json_output",
+    srcs = ["json_output.cpp"],
+    deps = [":pioasm_core"],
+    alwayslink = True,
 )
 
 cc_library(
@@ -81,6 +87,7 @@ cc_binary(
         ":ada_output",
         ":c_sdk_output",
         ":hex_output",
+        ":json_output",
         ":pioasm_core",
         ":python_output",
     ],

--- a/tools/pioasm/json_output.cpp
+++ b/tools/pioasm/json_output.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include "output_format.h"
 #include "pio_disassembler.h"
+#include "version.h"
 
 struct json_output : public output_format {
     struct factory {
@@ -22,6 +23,32 @@ struct json_output : public output_format {
         return "Machine-formatted output for integrating with external tools";
     }
 
+    std::string json_escape(const std::string& s) {
+        std::string result;
+        result.reserve(s.size());
+        for (unsigned char c : s) {
+            switch (c) {
+                case '"':  result += "\\\""; break;
+                case '\\': result += "\\\\"; break;
+                case '\b': result += "\\b"; break;
+                case '\f': result += "\\f"; break;
+                case '\n': result += "\\n"; break;
+                case '\r': result += "\\r"; break;
+                case '\t': result += "\\t"; break;
+                default:
+                    if (c < 0x20 || c == 0x7F) {
+                        // Control characters
+                        char buf[8];
+                        snprintf(buf, sizeof(buf), "\\u%04x", c);
+                        result += buf;
+                    } else {
+                        result += c;
+                    }
+            }
+        }
+        return result;
+    }
+
     void output_symbols(FILE *out, bool output_labels, std::string prefix, const std::vector<compiled_source::symbol> &symbols) {
 
         fprintf(out, "%s\"publicSymbols\": {\n", prefix.c_str());
@@ -34,7 +61,7 @@ struct json_output : public output_format {
                 } else {
                     first = false;
                 }
-                fprintf(out, "%s\t\"%s\": %d", prefix.c_str(), s.name.c_str(), s.value);
+                fprintf(out, "%s\t\"%s\": %d", prefix.c_str(), json_escape(s.name).c_str(), s.value);
             }
         }
         if (!first)
@@ -54,7 +81,7 @@ struct json_output : public output_format {
                 } else {
                     first = false;
                 }
-                fprintf(out, "%s\t\"%s\": %d", prefix.c_str(), s.name.c_str(), s.value);
+                fprintf(out, "%s\t\"%s\": %d", prefix.c_str(), json_escape(s.name).c_str(), s.value);
             }
         }
         if (!first)
@@ -78,6 +105,7 @@ struct json_output : public output_format {
         fprintf(out, "{\n");
         bool first = true;
 
+        fprintf(out, "\t\"pioASMVersion\": \"%s\",\n", json_escape(PIOASM_VERSION_STRING).c_str());
         output_symbols(out, false, "\t", source.global_symbols);
 
         const char* tabs = "\t\t\t";
@@ -92,20 +120,84 @@ struct json_output : public output_format {
             }
             fprintf(out, "\t\t{\n");
 
-            fprintf(out, "%s\"name\": \"%s\",\n", tabs, program.name.c_str());
+            fprintf(out, "%s\"name\": \"%s\",\n", tabs, json_escape(program.name).c_str());
+            fprintf(out, "%s\"pioVersion\": %d,\n", tabs, program.pio_version);
             fprintf(out, "%s\"wrapTarget\": %d,\n", tabs, program.wrap_target);
             fprintf(out, "%s\"wrap\": %d,\n", tabs, program.wrap);
             fprintf(out, "%s\"origin\": %d,\n", tabs, program.origin.get());
+
+            fprintf(out, "%s\"usedGPIORanges\": %d,\n", tabs, program.used_gpio_ranges);
+
+            output_symbols(out, true, tabs, program.symbols);
+
+            if (program.in.pin_count >= 0) {
+                fprintf(out, "%s\"in\": {\"pinCount\": %d, \"right\": %s, \"autopush\": %s, \"threshold\": %d},\n",
+                        tabs, program.in.pin_count,
+                        program.in.right ? "true" : "false",
+                        program.in.autop ? "true" : "false",
+                        program.in.threshold);
+            } else {
+                fprintf(out, "%s\"in\": null,\n", tabs);
+            }
+
+            if (program.out.pin_count >= 0) {
+                fprintf(out, "%s\"out\": {\"pinCount\": %d, \"right\": %s, \"autopull\": %s, \"threshold\": %d},\n",
+                        tabs, program.out.pin_count,
+                        program.out.right ? "true" : "false",
+                        program.out.autop ? "true" : "false",
+                        program.out.threshold);
+            } else {
+                fprintf(out, "%s\"out\": null,\n", tabs);
+            }
+
+            if (program.set_count >= 0) {
+                fprintf(out, "%s\"setCount\": %d,\n", tabs, program.set_count);
+            } else {
+                fprintf(out, "%s\"setCount\": null,\n", tabs);
+            }
 
             if (program.sideset_bits_including_opt.is_specified()) {
                 fprintf(out, "%s\"sideset\": {\"size\": %d, \"optional\": %s, \"pindirs\": %s},\n", tabs, program.sideset_bits_including_opt.get(),
                         program.sideset_opt ? "true" : "false",
                         program.sideset_pindirs ? "true" : "false");
             } else {
-                fprintf(out, "%s\"sideset\": {\"size\": 0, \"optional\": false, \"pindirs\": false},\n", tabs);
+                fprintf(out, "%s\"sideset\": null,\n", tabs);
             }
 
-            output_symbols(out, true, tabs, program.symbols);
+            if (program.mov_status_type != -1) {
+                const char *types[] = {
+                        "STATUS_TX_LESSTHAN",
+                        "STATUS_RX_LESSTHAN",
+                        "STATUS_IRQ_SET",
+                };
+                if (program.mov_status_type < 0 || program.mov_status_type >= 3) {
+                    throw std::runtime_error("unknown mov_status type");
+                }
+                fprintf(out, "%s\"movStatus\": {\"type\": %s, \"n\": %d},\n", tabs, types[program.mov_status_type], program.mov_status_n);
+            } else {
+                fprintf(out, "%s\"movStatus\": null,\n", tabs);
+            }
+
+            if (program.fifo != fifo_config::txrx) {
+                const char *type;
+                switch (program.fifo) {
+                    case fifo_config::tx:     type = "PIO_FIFO_JOIN_TX"; break;
+                    case fifo_config::rx:     type = "PIO_FIFO_JOIN_RX"; break;
+                    case fifo_config::txput:  type = "PIO_FIFO_JOIN_TXPUT"; break;
+                    case fifo_config::txget:  type = "PIO_FIFO_JOIN_TXGET"; break;
+                    case fifo_config::putget: type = "PIO_FIFO_JOIN_PUTGET"; break;
+                    default: throw std::runtime_error("unknown fifo_config type");
+                }
+                fprintf(out, "%s\"fifoConfig\": \"%s\",\n", tabs, type);
+            } else {
+                fprintf(out, "%s\"fifoConfig\": null,\n", tabs);
+            }
+
+            if (program.clock_div_int != 1 || program.clock_div_frac != 0) {
+                fprintf(out, "%s\"clockDiv\": {\"int\": %u, \"frac\": %u},\n", tabs, program.clock_div_int, program.clock_div_frac);
+            } else {
+                fprintf(out, "%s\"clockDiv\": null,\n", tabs);
+            }
 
             fprintf(out, "%s\"instructions\": [\n", tabs);
             bool first_inst = true;
@@ -120,14 +212,61 @@ struct json_output : public output_format {
                 // TODO: find a nice, supportable, output format for instruction disassembly.
                 // Note that may require tearing apart pio_disassembler to return to us something
                 // that we could output as {"instr":"mov", args: ["x", "~y"], side: 3, delay: 1}
-                // but that will likely wait for now
-                fprintf(out, "%s\t{\"hex\": \"%04X\"}",// \"disassembly\": \"%s\"}",
-                        tabs, inst
-                        //, disassemble(inst, program.sideset_bits_including_opt.get(), program.sideset_opt).c_str()
+                // but that will likely wait for now. A dissasembly string instruction is added
+                // for the time being.
+                fprintf(out, "%s\t{\"hex\": \"%04X\", \"instruction\": \"%s\"}",
+                        tabs, inst,
+                        json_escape(disassemble(inst, program.sideset_bits_including_opt.get(), program.sideset_opt)).c_str()
                         );
             }
             fprintf(out, "\n");
-            fprintf(out, "%s]\n", tabs);
+            fprintf(out, "%s],\n", tabs);
+
+            // This prints: codeBlocks: [
+            //   { "lang": "c-sdk", "contents": "...." },
+            //   { "lang": "c-sdk", "contents": "...." },
+            //   { "lang": "python", "contents": "...." },
+            //   { "lang": "c-sdk", "contents": "...." }
+            // ]
+            // This is how order is preserved while supporting multiple blocks per language.
+            fprintf(out, "%s\"codeBlocks\": [\n", tabs);
+            bool first_block = true;
+            for(const auto& o : program.code_blocks) {
+                for(const auto &contents : o.second) {
+                    // output trailing comma if necessary
+                    if (!first_block) {
+                        fprintf(out, ",\n");
+                    } else {
+                        first_block = false;
+                    }
+                    fprintf(out, "%s\t{\n", tabs);
+                    fprintf(out, "%s\t\t\"lang\": \"%s\",\n", tabs, json_escape(o.first).c_str());
+                    fprintf(out, "%s\t\t\"contents\": \"%s\"\n", tabs, json_escape(contents).c_str());
+                    fprintf(out, "%s\t}", tabs);
+                }
+            }
+            fprintf(out, "\n%s],\n", tabs);
+
+            // Similarly to codeBlocks, order is preserved while supporting multiple lang_opts.
+            fprintf(out, "%s\"langOpts\": [\n", tabs);
+            bool first_opt = true;
+            for(const auto& o : program.lang_opts) {
+                for(const auto &pair : o.second) {
+                    // output trailing comma if necessary
+                    if (!first_opt) {
+                        fprintf(out, ",\n");
+                    } else {
+                        first_opt = false;
+                    }
+                    fprintf(out, "%s\t{\n", tabs);
+                    fprintf(out, "%s\t\t\"lang\": \"%s\",\n", tabs, json_escape(o.first).c_str());
+                    fprintf(out, "%s\t\t\"name\": \"%s\",\n", tabs, json_escape(pair.first).c_str());
+                    fprintf(out, "%s\t\t\"value\": \"%s\"\n", tabs, json_escape(pair.second).c_str());
+                    fprintf(out, "%s\t}", tabs);
+                }
+            }
+            fprintf(out, "\n%s]\n", tabs);
+
             fprintf(out, "\t\t}");
         }
         fprintf(out, "\n\t]\n}\n");

--- a/tools/pioasm/json_output.cpp
+++ b/tools/pioasm/json_output.cpp
@@ -173,7 +173,7 @@ struct json_output : public output_format {
                 if (program.mov_status_type < 0 || program.mov_status_type >= 3) {
                     throw std::runtime_error("unknown mov_status type");
                 }
-                fprintf(out, "%s\"movStatus\": {\"type\": %s, \"n\": %d},\n", tabs, types[program.mov_status_type], program.mov_status_n);
+                fprintf(out, "%s\"movStatus\": {\"type\": \"%s\", \"n\": %d},\n", tabs, types[program.mov_status_type], program.mov_status_n);
             } else {
                 fprintf(out, "%s\"movStatus\": null,\n", tabs);
             }

--- a/tools/pioasm/json_output_schema.json
+++ b/tools/pioasm/json_output_schema.json
@@ -9,6 +9,7 @@
   ],
   "additionalProperties": false,
   "properties": {
+    "$schema": {},
     "pioASMVersion": {
       "type": "string"
     },

--- a/tools/pioasm/json_output_schema.json
+++ b/tools/pioasm/json_output_schema.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "pioasm JSON output",
+  "type": "object",
+  "required": [
+    "pioASMVersion",
+    "publicSymbols",
+    "programs"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "pioASMVersion": {
+      "type": "string"
+    },
+    "publicSymbols": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "programs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/program"
+      }
+    }
+  },
+  "definitions": {
+    "symbolMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "program": {
+      "type": "object",
+      "required": [
+        "name",
+        "pioVersion",
+        "wrapTarget",
+        "wrap",
+        "origin",
+        "usedGPIORanges",
+        "publicSymbols",
+        "publicLabels",
+        "in",
+        "out",
+        "setCount",
+        "sideset",
+        "movStatus",
+        "fifoConfig",
+        "clockDiv",
+        "instructions",
+        "codeBlocks",
+        "langOpts"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "pioVersion": {
+          "type": "integer"
+        },
+        "wrapTarget": {
+          "type": "integer"
+        },
+        "wrap": {
+          "type": "integer"
+        },
+        "origin": {
+          "type": "integer"
+        },
+        "usedGPIORanges": {
+          "type": "integer"
+        },
+        "publicSymbols": {
+          "$ref": "#/definitions/symbolMap"
+        },
+        "publicLabels": {
+          "$ref": "#/definitions/symbolMap"
+        },
+        "in": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "pinCount",
+            "right",
+            "autopush",
+            "threshold"
+          ],
+          "properties": {
+            "pinCount": {
+              "type": "integer"
+            },
+            "right": {
+              "type": "boolean"
+            },
+            "autopush": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "out": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "pinCount",
+            "right",
+            "autopull",
+            "threshold"
+          ],
+          "properties": {
+            "pinCount": {
+              "type": "integer"
+            },
+            "right": {
+              "type": "boolean"
+            },
+            "autopull": {
+              "type": "boolean"
+            },
+            "threshold": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "setCount": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sideset": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "size",
+            "optional",
+            "pindirs"
+          ],
+          "properties": {
+            "size": {
+              "type": "integer"
+            },
+            "optional": {
+              "type": "boolean"
+            },
+            "pindirs": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "movStatus": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "type",
+            "n"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "STATUS_TX_LESSTHAN",
+                "STATUS_RX_LESSTHAN",
+                "STATUS_IRQ_SET"
+              ]
+            },
+            "n": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "fifoConfig": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "PIO_FIFO_JOIN_TX",
+            "PIO_FIFO_JOIN_RX",
+            "PIO_FIFO_JOIN_TXPUT",
+            "PIO_FIFO_JOIN_TXGET",
+            "PIO_FIFO_JOIN_PUTGET",
+            null
+          ]
+        },
+        "clockDiv": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "int",
+            "frac"
+          ],
+          "properties": {
+            "int": {
+              "type": "integer"
+            },
+            "frac": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "instructions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "hex",
+              "instruction"
+            ],
+            "properties": {
+              "hex": {
+                "type": "string",
+                "pattern": "^[0-9A-F]{4}$"
+              },
+              "instruction": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "codeBlocks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "lang",
+              "contents"
+            ],
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "contents": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "langOpts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "lang",
+              "name",
+              "value"
+            ],
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/pioasm/json_output_schema.json
+++ b/tools/pioasm/json_output_schema.json
@@ -1,289 +1,289 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "pioasm JSON output",
-  "type": "object",
-  "required": [
-    "pioASMVersion",
-    "publicSymbols",
-    "programs"
-  ],
-  "additionalProperties": false,
-  "properties": {
-    "$schema": {},
-    "pioASMVersion": {
-      "type": "string"
-    },
-    "publicSymbols": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "integer"
-      }
-    },
-    "programs": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/program"
-      }
-    }
-  },
-  "definitions": {
-    "symbolMap": {
-      "type": "object",
-      "additionalProperties": {
-        "type": "integer"
-      }
-    },
-    "program": {
-      "type": "object",
-      "required": [
-        "name",
-        "pioVersion",
-        "wrapTarget",
-        "wrap",
-        "origin",
-        "usedGPIORanges",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "pioasm JSON output",
+    "type": "object",
+    "required": [
+        "pioASMVersion",
         "publicSymbols",
-        "publicLabels",
-        "in",
-        "out",
-        "setCount",
-        "sideset",
-        "movStatus",
-        "fifoConfig",
-        "clockDiv",
-        "instructions",
-        "codeBlocks",
-        "langOpts"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "pioVersion": {
-          "type": "integer"
-        },
-        "wrapTarget": {
-          "type": "integer"
-        },
-        "wrap": {
-          "type": "integer"
-        },
-        "origin": {
-          "type": "integer"
-        },
-        "usedGPIORanges": {
-          "type": "integer"
+        "programs"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {},
+        "pioASMVersion": {
+            "type": "string"
         },
         "publicSymbols": {
-          "$ref": "#/definitions/symbolMap"
-        },
-        "publicLabels": {
-          "$ref": "#/definitions/symbolMap"
-        },
-        "in": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "pinCount",
-            "right",
-            "autopush",
-            "threshold"
-          ],
-          "properties": {
-            "pinCount": {
-              "type": "integer"
-            },
-            "right": {
-              "type": "boolean"
-            },
-            "autopush": {
-              "type": "boolean"
-            },
-            "threshold": {
-              "type": "integer"
-            }
-          },
-          "additionalProperties": false
-        },
-        "out": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "pinCount",
-            "right",
-            "autopull",
-            "threshold"
-          ],
-          "properties": {
-            "pinCount": {
-              "type": "integer"
-            },
-            "right": {
-              "type": "boolean"
-            },
-            "autopull": {
-              "type": "boolean"
-            },
-            "threshold": {
-              "type": "integer"
-            }
-          },
-          "additionalProperties": false
-        },
-        "setCount": {
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "sideset": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "size",
-            "optional",
-            "pindirs"
-          ],
-          "properties": {
-            "size": {
-              "type": "integer"
-            },
-            "optional": {
-              "type": "boolean"
-            },
-            "pindirs": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "movStatus": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "type",
-            "n"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "STATUS_TX_LESSTHAN",
-                "STATUS_RX_LESSTHAN",
-                "STATUS_IRQ_SET"
-              ]
-            },
-            "n": {
-              "type": "integer"
-            }
-          },
-          "additionalProperties": false
-        },
-        "fifoConfig": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "enum": [
-            "PIO_FIFO_JOIN_TX",
-            "PIO_FIFO_JOIN_RX",
-            "PIO_FIFO_JOIN_TXPUT",
-            "PIO_FIFO_JOIN_TXGET",
-            "PIO_FIFO_JOIN_PUTGET",
-            null
-          ]
-        },
-        "clockDiv": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "required": [
-            "int",
-            "frac"
-          ],
-          "properties": {
-            "int": {
-              "type": "integer"
-            },
-            "frac": {
-              "type": "integer"
-            }
-          },
-          "additionalProperties": false
-        },
-        "instructions": {
-          "type": "array",
-          "items": {
             "type": "object",
-            "required": [
-              "hex",
-              "instruction"
-            ],
-            "properties": {
-              "hex": {
-                "type": "string",
-                "pattern": "^[0-9A-F]{4}$"
-              },
-              "instruction": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
+            "additionalProperties": {
+                "type": "integer"
+            }
         },
-        "codeBlocks": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "lang",
-              "contents"
-            ],
-            "properties": {
-              "lang": {
-                "type": "string"
-              },
-              "contents": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "langOpts": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "lang",
-              "name",
-              "value"
-            ],
-            "properties": {
-              "lang": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
+        "programs": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/program"
+            }
         }
-      }
+    },
+    "definitions": {
+        "symbolMap": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "integer"
+            }
+        },
+        "program": {
+            "type": "object",
+            "required": [
+                "name",
+                "pioVersion",
+                "wrapTarget",
+                "wrap",
+                "origin",
+                "usedGPIORanges",
+                "publicSymbols",
+                "publicLabels",
+                "in",
+                "out",
+                "setCount",
+                "sideset",
+                "movStatus",
+                "fifoConfig",
+                "clockDiv",
+                "instructions",
+                "codeBlocks",
+                "langOpts"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "pioVersion": {
+                    "type": "integer"
+                },
+                "wrapTarget": {
+                    "type": "integer"
+                },
+                "wrap": {
+                    "type": "integer"
+                },
+                "origin": {
+                    "type": "integer"
+                },
+                "usedGPIORanges": {
+                    "type": "integer"
+                },
+                "publicSymbols": {
+                    "$ref": "#/definitions/symbolMap"
+                },
+                "publicLabels": {
+                    "$ref": "#/definitions/symbolMap"
+                },
+                "in": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "required": [
+                        "pinCount",
+                        "right",
+                        "autopush",
+                        "threshold"
+                    ],
+                    "properties": {
+                        "pinCount": {
+                            "type": "integer"
+                        },
+                        "right": {
+                            "type": "boolean"
+                        },
+                        "autopush": {
+                            "type": "boolean"
+                        },
+                        "threshold": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "out": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "required": [
+                        "pinCount",
+                        "right",
+                        "autopull",
+                        "threshold"
+                    ],
+                    "properties": {
+                        "pinCount": {
+                            "type": "integer"
+                        },
+                        "right": {
+                            "type": "boolean"
+                        },
+                        "autopull": {
+                            "type": "boolean"
+                        },
+                        "threshold": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "setCount": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "sideset": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "required": [
+                        "size",
+                        "optional",
+                        "pindirs"
+                    ],
+                    "properties": {
+                        "size": {
+                            "type": "integer"
+                        },
+                        "optional": {
+                            "type": "boolean"
+                        },
+                        "pindirs": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "movStatus": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "required": [
+                        "type",
+                        "n"
+                    ],
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "STATUS_TX_LESSTHAN",
+                                "STATUS_RX_LESSTHAN",
+                                "STATUS_IRQ_SET"
+                            ]
+                        },
+                        "n": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "fifoConfig": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "PIO_FIFO_JOIN_TX",
+                        "PIO_FIFO_JOIN_RX",
+                        "PIO_FIFO_JOIN_TXPUT",
+                        "PIO_FIFO_JOIN_TXGET",
+                        "PIO_FIFO_JOIN_PUTGET",
+                        null
+                    ]
+                },
+                "clockDiv": {
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "required": [
+                        "int",
+                        "frac"
+                    ],
+                    "properties": {
+                        "int": {
+                            "type": "integer"
+                        },
+                        "frac": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "instructions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "hex",
+                            "instruction"
+                        ],
+                        "properties": {
+                            "hex": {
+                                "type": "string",
+                                "pattern": "^[0-9A-F]{4}$"
+                            },
+                            "instruction": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "codeBlocks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "lang",
+                            "contents"
+                        ],
+                        "properties": {
+                            "lang": {
+                                "type": "string"
+                            },
+                            "contents": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "langOpts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "lang",
+                            "name",
+                            "value"
+                        ],
+                        "properties": {
+                            "lang": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                }
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
Hello,

My primary goal with this PR is to put `json_output` in a position where it could be used to derive any other output without having to modify `pioasm`.

Adds escaping for JSON strings and includes new fields in the output such as `pioASMVersion`, `pioVersion`, `usedGPIORanges`, `in`/`out`/`setCount` configurations, `movStatus`, `fifoConfig`, `clockDiv`, `codeBlocks`, and `langOpts`. Also uncomments the instruction output disassembly and ensures proper escaping for symbol names and other string fields.

There is only one spec breaking change: `sideset` moves to be optional, using the value `null` when not specified. This change aims to allow consumers have a clear representation of the input. All the other changes are additive.

Please let me know if this direction is aligned with the vision for this output, an alternative could be creating a new raw output to avoid leaking too much information to general consumers of `json_output`.

Looking forward to your feedback, and appreciate your consideration.