### PR TITLE
Fix one output interleavement issue with pico_printf_compiler

### DIFF
--- a/src/rp2_common/pico_stdio/stdio.c
+++ b/src/rp2_common/pico_stdio/stdio.c
@@ -336,6 +336,21 @@ int PRIMARY_STDIO_FUNC(vprintf)(const char *format, va_list va) {
     ret = 0;
 #else
     ret = REAL_FUNC(vprintf)(format, va);
+    // if we're using PICO_STDIO_SHORT_CIRCUIT_CLIB_FUNCS, then vprintf is short-circuited to here,
+    // but we just go ahead and call the library function anyway as we're PICO_PRINTF_COMPILER.
+    // therefore we should flush stdout here in case the next thing is a puts/putchar which DO still
+    // short-circuit the c library completely.
+    //
+    // note the more correct place to handle this would be in the short-circuited functions
+    // but that would cause infinite recursion as they are called during flush of stdout!
+    // this is reasonable best-effort solution (if you really care you can set
+    // PICO_STDIO_SHORT_CIRCUIT_CLIB_FUNCS=0 when using pico_printf_compiler)
+#if PICO_STDIO_SHORT_CIRCUIT_CLIB_FUNCS
+    // llvm libc doesn't have fflush, nor does it buffer separately
+#if !LIB_PICO_LLVM_LIBC_INTERFACE
+    fflush(stdout);
+#endif
+#endif
 #endif
     if (serialized) {
         stdout_serialize_end();


### PR DESCRIPTION
Force `fflush()` of `stdout` after `printf` when using `pico_set_printf_implementation(compiler)` and `PICO_STDIO_SHORT_CIRCUIT_CLIB_FUNCS` as a semi-workaround for the c library buffering `stdout` during `printf`

Note: the correct solution would be to flush `stdout` in the short-circuited functions, but this rather destroys the point of making them fast.

This takes care of the common case. For complete/best support use `PICO_STDIO_SHORT_CIRCUIT_CLIB_FUNCS=0` when using `pico_printf_compiler`

