### PR TITLE
[bazel] Run buildifier on Bazel build files

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -1,5 +1,7 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _pico_generate_pio_header_impl(ctx):
     generated_headers = []

--- a/bazel/pico_btstack_make_gatt_header.bzl
+++ b/bazel/pico_btstack_make_gatt_header.bzl
@@ -1,4 +1,6 @@
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cpp_toolchain", "use_cc_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _pico_btstack_make_gatt_header_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
@@ -21,7 +23,6 @@ def _pico_btstack_make_gatt_header_impl(ctx):
             "-I",
             ctx.file._btstack_hdr.dirname,
         ] + [
-
         ],
         inputs = [
             ctx.file.src,
@@ -37,7 +38,7 @@ def _pico_btstack_make_gatt_header_impl(ctx):
 
     return [
         DefaultInfo(files = depset(direct = [out])),
-        CcInfo(compilation_context = cc_ctx)
+        CcInfo(compilation_context = cc_ctx),
     ]
 
 pico_btstack_make_gatt_header = rule(

--- a/bazel/toolchain/BUILD.bazel
+++ b/bazel/toolchain/BUILD.bazel
@@ -100,7 +100,7 @@ cc_args(
             "-Og",
             "-g3",
         ],
-    })
+    }),
 )
 
 cc_args(
@@ -115,7 +115,7 @@ cc_args(
             "-O2",
             "-DNDEBUG",
         ],
-    })
+    }),
 )
 
 cc_args(
@@ -128,7 +128,7 @@ cc_args(
         "//bazel/constraint:pico_compilation_no_fastbuild_args_set": [],
         # The conditions default are kept as nothing here, The bazel docs default are -gmlt -Wl,-S.
         "//conditions:default": [],
-    })
+    }),
 )
 
 configurable_toolchain_feature(
@@ -162,7 +162,6 @@ configurable_toolchain_feature(
     name = "override_max_page_size",
     linkopts = ["-Wl,-z,max-page-size=4096"],
 )
-
 
 cc_feature(
     name = "dbg",
@@ -203,29 +202,12 @@ _HOST_CPU_CONSTRAINTS = {
 
 [cc_toolchain(
     name = "arm_gcc_{}-{}_toolchain_cortex-m".format(host_os, host_cpu),
-    tool_map = "@arm_gcc_{}-{}//:all_tools".format(host_os, host_cpu),
     args = select({
         "//bazel/constraint:rp2040": [":cortex-m0"],
         "//bazel/constraint:rp2350": [":cortex-m33"],
         "//conditions:default": [],
     }) + [
         ":bazel_no_absolute_paths",
-    ],
-    exec_compatible_with = [
-        _HOST_CPU_CONSTRAINTS[host_cpu],
-        _HOST_OS_CONSTRAINTS[host_os],
-    ],
-    tags = ["manual"],  # Don't try to build this in wildcard builds.
-    known_features = [
-        "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
-        "@pico-sdk//bazel/toolchain:dbg",
-        "@pico-sdk//bazel/toolchain:opt",
-        "@pico-sdk//bazel/toolchain:fastbuild",
-        "@pico-sdk//bazel/toolchain:gc_sections",
-        "@pico-sdk//bazel/toolchain:cxx_no_exceptions",
-        "@pico-sdk//bazel/toolchain:cxx_no_rtti",
-        "@pico-sdk//bazel/toolchain:cxx_no_cxa_atexit",
-        "@pico-sdk//bazel/toolchain:override_max_page_size",
     ],
     enabled_features = [
         "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
@@ -245,11 +227,27 @@ _HOST_CPU_CONSTRAINTS = {
         "//bazel/constraint:pico_use_default_max_page_size_enabled": [],
         "//conditions:default": [":override_max_page_size"],
     }),
+    exec_compatible_with = [
+        _HOST_CPU_CONSTRAINTS[host_cpu],
+        _HOST_OS_CONSTRAINTS[host_os],
+    ],
+    known_features = [
+        "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
+        "@pico-sdk//bazel/toolchain:dbg",
+        "@pico-sdk//bazel/toolchain:opt",
+        "@pico-sdk//bazel/toolchain:fastbuild",
+        "@pico-sdk//bazel/toolchain:gc_sections",
+        "@pico-sdk//bazel/toolchain:cxx_no_exceptions",
+        "@pico-sdk//bazel/toolchain:cxx_no_rtti",
+        "@pico-sdk//bazel/toolchain:cxx_no_cxa_atexit",
+        "@pico-sdk//bazel/toolchain:override_max_page_size",
+    ],
+    tags = ["manual"],  # Don't try to build this in wildcard builds.
+    tool_map = "@arm_gcc_{}-{}//:all_tools".format(host_os, host_cpu),
 ) for host_os, host_cpu in HOSTS]
 
 [cc_toolchain(
     name = "clang_{}-{}_toolchain_cortex-m".format(host_os, host_cpu),
-    tool_map = "@clang_{}-{}//:all_tools".format(host_os, host_cpu),
     args = select({
         "//bazel/constraint:rp2040": [
             ":armv6m-none-eabi",
@@ -264,22 +262,6 @@ _HOST_CPU_CONSTRAINTS = {
         ":bazel_no_absolute_paths",
         ":llvm-libc_args",
     ],
-    exec_compatible_with = [
-        _HOST_CPU_CONSTRAINTS[host_cpu],
-        _HOST_OS_CONSTRAINTS[host_os],
-    ],
-    tags = ["manual"],  # Don't try to build this in wildcard builds.
-    known_features = [
-        "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
-        "@pico-sdk//bazel/toolchain:dbg",
-        "@pico-sdk//bazel/toolchain:opt",
-        "@pico-sdk//bazel/toolchain:fastbuild",
-        "@pico-sdk//bazel/toolchain:gc_sections",
-        "@pico-sdk//bazel/toolchain:cxx_no_exceptions",
-        "@pico-sdk//bazel/toolchain:cxx_no_rtti",
-        "@pico-sdk//bazel/toolchain:cxx_no_cxa_atexit",
-        "@pico-sdk//bazel/toolchain:override_max_page_size",
-    ],
     enabled_features = [
         "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
     ] + select({
@@ -298,6 +280,23 @@ _HOST_CPU_CONSTRAINTS = {
         "//bazel/constraint:pico_use_default_max_page_size_enabled": [],
         "//conditions:default": [":override_max_page_size"],
     }),
+    exec_compatible_with = [
+        _HOST_CPU_CONSTRAINTS[host_cpu],
+        _HOST_OS_CONSTRAINTS[host_os],
+    ],
+    known_features = [
+        "@rules_cc//cc/toolchains/args:experimental_replace_legacy_action_config_features",
+        "@pico-sdk//bazel/toolchain:dbg",
+        "@pico-sdk//bazel/toolchain:opt",
+        "@pico-sdk//bazel/toolchain:fastbuild",
+        "@pico-sdk//bazel/toolchain:gc_sections",
+        "@pico-sdk//bazel/toolchain:cxx_no_exceptions",
+        "@pico-sdk//bazel/toolchain:cxx_no_rtti",
+        "@pico-sdk//bazel/toolchain:cxx_no_cxa_atexit",
+        "@pico-sdk//bazel/toolchain:override_max_page_size",
+    ],
+    tags = ["manual"],  # Don't try to build this in wildcard builds.
+    tool_map = "@clang_{}-{}//:all_tools".format(host_os, host_cpu),
 ) for host_os, host_cpu in HOSTS]
 
 [toolchain(

--- a/bazel/toolchain/configurable_feature.bzl
+++ b/bazel/toolchain/configurable_feature.bzl
@@ -3,7 +3,6 @@ load("@rules_cc//cc/toolchains:args_list.bzl", "cc_args_list")
 load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 
 def configurable_toolchain_feature(name, copts = [], cxxopts = [], linkopts = []):
-
     all_args = []
 
     if copts:

--- a/bazel/toolchain/objcopy.bzl
+++ b/bazel/toolchain/objcopy.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "OBJ_COPY_ACTION_NAME")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cpp_toolchain", "use_cc_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 
 def _objcopy_to_bin_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)

--- a/bazel/util/label_flag_matches.bzl
+++ b/bazel/util/label_flag_matches.bzl
@@ -1,7 +1,6 @@
 """A wrapper that enables a `config_setting` matcher for label_flag flags."""
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 
 def _match_label_flag_impl(ctx):
     matches = str(ctx.attr.expected_value.label) == str(ctx.attr.flag.label)

--- a/bazel/util/sdk_define.bzl
+++ b/bazel/util/sdk_define.bzl
@@ -1,4 +1,6 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _pico_sdk_define_impl(ctx):
     val = ctx.attr.from_flag[BuildSettingInfo].value

--- a/bazel/util/transition.bzl
+++ b/bazel/util/transition.bzl
@@ -93,7 +93,7 @@ rp2040_bootloader_binary = declare_transtion(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
-	"_link_extra_libs": attr.label(default = "//bazel:empty_cc_lib"),
+        "_link_extra_libs": attr.label(default = "//bazel:empty_cc_lib"),
     },
     flag_overrides = {
         # We don't want --custom_malloc to ever apply to the bootloader, so
@@ -104,7 +104,7 @@ rp2040_bootloader_binary = declare_transtion(
         # binary via `link_extra_libs`, so we must drop these deps when
         # building the bootloader binaries themselves in order to avoid a
         # circular dependency.
-	"@bazel_tools//tools/cpp:link_extra_libs": "_link_extra_libs",
+        "@bazel_tools//tools/cpp:link_extra_libs": "_link_extra_libs",
     },
 )
 

--- a/src/boards/BUILD.bazel
+++ b/src/boards/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "pico_board_config")
 load("//bazel/util:multiple_choice_flag.bzl", "declare_flag_choices", "flag_choice")
 

--- a/src/common/boot_picobin_headers/BUILD.bazel
+++ b/src/common/boot_picobin_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/boot_picoboot_headers/BUILD.bazel
+++ b/src/common/boot_picoboot_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # This needs to remain compatible with the host build since it's used by

--- a/src/common/boot_uf2_headers/BUILD.bazel
+++ b/src/common/boot_uf2_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/hardware_claim/BUILD.bazel
+++ b/src/common/hardware_claim/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/pico_base_headers/BUILD.bazel
+++ b/src/common/pico_base_headers/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/common/pico_binary_info/BUILD.bazel
+++ b/src/common/pico_binary_info/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/common/pico_bit_ops_headers/BUILD.bazel
+++ b/src/common/pico_bit_ops_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # This exists to break dependency cycles between

--- a/src/common/pico_divider_headers/BUILD.bazel
+++ b/src/common/pico_divider_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/pico_stdlib_headers/BUILD.bazel
+++ b/src/common/pico_stdlib_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # Use //host/pico_stdlib or //rp2_common/pico_stdlib to get the

--- a/src/common/pico_sync/BUILD.bazel
+++ b/src/common/pico_sync/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/common/pico_time/BUILD.bazel
+++ b/src/common/pico_time/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/common/pico_usb_reset_interface_headers/BUILD.bazel
+++ b/src/common/pico_usb_reset_interface_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/pico_util/BUILD.bazel
+++ b/src/common/pico_util/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/src/host/BUILD.bazel
+++ b/src/host/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 # This is currently unused in Bazel.

--- a/src/host/hardware_divider/BUILD.bazel
+++ b/src/host/hardware_divider/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_gpio/BUILD.bazel
+++ b/src/host/hardware_gpio/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_irq/BUILD.bazel
+++ b/src/host/hardware_irq/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_sync/BUILD.bazel
+++ b/src/host/hardware_sync/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_timer/BUILD.bazel
+++ b/src/host/hardware_timer/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 _DEFINES = [

--- a/src/host/hardware_uart/BUILD.bazel
+++ b/src/host/hardware_uart/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_bit_ops/BUILD.bazel
+++ b/src/host/pico_bit_ops/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_divider/BUILD.bazel
+++ b/src/host/pico_divider/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_multicore/BUILD.bazel
+++ b/src/host/pico_multicore/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_platform/BUILD.bazel
+++ b/src/host/pico_platform/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_printf/BUILD.bazel
+++ b/src/host/pico_printf/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_rand/BUILD.bazel
+++ b/src/host/pico_rand/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_runtime/BUILD.bazel
+++ b/src/host/pico_runtime/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_status_led/BUILD.bazel
+++ b/src/host/pico_status_led/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -10,4 +12,3 @@ cc_library(
         "//src/host/hardware_gpio",
     ],
 )
-

--- a/src/host/pico_stdio/BUILD.bazel
+++ b/src/host/pico_stdio/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_stdlib/BUILD.bazel
+++ b/src/host/pico_stdlib/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_time_adapter/BUILD.bazel
+++ b/src/host/pico_time_adapter/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_unique_id/BUILD.bazel
+++ b/src/host/pico_unique_id/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2040/boot_stage2/BUILD.bazel
+++ b/src/rp2040/boot_stage2/BUILD.bazel
@@ -3,6 +3,8 @@
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel/toolchain:objcopy.bzl", "objcopy_to_bin")
 load("//bazel/util:multiple_choice_flag.bzl", "declare_flag_choices", "flag_choice")

--- a/src/rp2040/hardware_regs/BUILD.bazel
+++ b/src/rp2040/hardware_regs/BUILD.bazel
@@ -1,6 +1,8 @@
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2040:__subpackages__",

--- a/src/rp2040/hardware_structs/BUILD.bazel
+++ b/src/rp2040/hardware_structs/BUILD.bazel
@@ -1,6 +1,8 @@
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2040:__subpackages__",

--- a/src/rp2040/pico_platform/BUILD.bazel
+++ b/src/rp2040/pico_platform/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2040:__subpackages__",

--- a/src/rp2350/boot_stage2/BUILD.bazel
+++ b/src/rp2350/boot_stage2/BUILD.bazel
@@ -3,6 +3,8 @@
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("//bazel/toolchain:objcopy.bzl", "objcopy_to_bin")
 load("//bazel/util:multiple_choice_flag.bzl", "declare_flag_choices", "flag_choice")

--- a/src/rp2350/hardware_regs/BUILD.bazel
+++ b/src/rp2350/hardware_regs/BUILD.bazel
@@ -1,6 +1,8 @@
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2350:__subpackages__",

--- a/src/rp2350/hardware_structs/BUILD.bazel
+++ b/src/rp2350/hardware_structs/BUILD.bazel
@@ -1,6 +1,8 @@
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2350:__subpackages__",

--- a/src/rp2350/pico_platform/BUILD.bazel
+++ b/src/rp2350/pico_platform/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2350:__subpackages__",

--- a/src/rp2_common/boot_bootrom_headers/BUILD.bazel
+++ b/src/rp2_common/boot_bootrom_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/cmsis/BUILD.bazel
+++ b/src/rp2_common/cmsis/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_adc/BUILD.bazel
+++ b/src/rp2_common/hardware_adc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_base/BUILD.bazel
+++ b/src/rp2_common/hardware_base/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_boot_lock/BUILD.bazel
+++ b/src/rp2_common/hardware_boot_lock/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
@@ -8,8 +9,8 @@ cc_library(
     hdrs = ["include/hardware/boot_lock.h"],
     includes = ["include"],
     tags = ["manual"],
-    deps = ["//src:pico_platform_internal"],
     visibility = ["//src/rp2_common/pico_bootrom:__pkg__"],
+    deps = ["//src:pico_platform_internal"],
 )
 
 cc_library(

--- a/src/rp2_common/hardware_clocks/BUILD.bazel
+++ b/src/rp2_common/hardware_clocks/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_dcp/BUILD.bazel
+++ b/src/rp2_common/hardware_dcp/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_divider/BUILD.bazel
+++ b/src/rp2_common/hardware_divider/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_dma/BUILD.bazel
+++ b/src/rp2_common/hardware_dma/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_exception/BUILD.bazel
+++ b/src/rp2_common/hardware_exception/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_flash/BUILD.bazel
+++ b/src/rp2_common/hardware_flash/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
@@ -11,8 +12,8 @@ cc_library(
     target_compatible_with = compatible_with_rp2(),
     deps = [
         "//src/rp2_common:hardware_structs",
-        "//src/rp2_common/hardware_xip_cache",
         "//src/rp2_common:pico_platform",
+        "//src/rp2_common/hardware_xip_cache",
         "//src/rp2_common/pico_bootrom",
         "//src/rp2_common/pico_multicore",
     ],

--- a/src/rp2_common/hardware_gpio/BUILD.bazel
+++ b/src/rp2_common/hardware_gpio/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_hazard3/BUILD.bazel
+++ b/src/rp2_common/hardware_hazard3/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_i2c/BUILD.bazel
+++ b/src/rp2_common/hardware_i2c/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_interp/BUILD.bazel
+++ b/src/rp2_common/hardware_interp/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_irq/BUILD.bazel
+++ b/src/rp2_common/hardware_irq/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_pio/BUILD.bazel
+++ b/src/rp2_common/hardware_pio/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_pll/BUILD.bazel
+++ b/src/rp2_common/hardware_pll/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_powman/BUILD.bazel
+++ b/src/rp2_common/hardware_powman/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/hardware_pwm/BUILD.bazel
+++ b/src/rp2_common/hardware_pwm/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_rcp/BUILD.bazel
+++ b/src/rp2_common/hardware_rcp/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_resets/BUILD.bazel
+++ b/src/rp2_common/hardware_resets/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_riscv/BUILD.bazel
+++ b/src/rp2_common/hardware_riscv/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_riscv_platform_timer/BUILD.bazel
+++ b/src/rp2_common/hardware_riscv_platform_timer/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_rtc/BUILD.bazel
+++ b/src/rp2_common/hardware_rtc/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/hardware_sha256/BUILD.bazel
+++ b/src/rp2_common/hardware_sha256/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/hardware_spi/BUILD.bazel
+++ b/src/rp2_common/hardware_spi/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_sync/BUILD.bazel
+++ b/src/rp2_common/hardware_sync/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_sync_spin_lock/BUILD.bazel
+++ b/src/rp2_common/hardware_sync_spin_lock/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_ticks/BUILD.bazel
+++ b/src/rp2_common/hardware_ticks/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_timer/BUILD.bazel
+++ b/src/rp2_common/hardware_timer/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_uart/BUILD.bazel
+++ b/src/rp2_common/hardware_uart/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/hardware_vreg/BUILD.bazel
+++ b/src/rp2_common/hardware_vreg/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_watchdog/BUILD.bazel
+++ b/src/rp2_common/hardware_watchdog/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_xip_cache/BUILD.bazel
+++ b/src/rp2_common/hardware_xip_cache/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_xosc/BUILD.bazel
+++ b/src/rp2_common/hardware_xosc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_aon_timer/BUILD.bazel
+++ b/src/rp2_common/pico_aon_timer/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
@@ -12,8 +13,8 @@ cc_library(
     includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
     deps = [
-        "//src/common/pico_util",
         "//src/common/pico_time",
+        "//src/common/pico_util",
         "//src/rp2_common:hardware_regs",
         "//src/rp2_common:pico_platform",
         "//src/rp2_common/hardware_irq",

--- a/src/rp2_common/pico_async_context/BUILD.bazel
+++ b/src/rp2_common/pico_async_context/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_atomic/BUILD.bazel
+++ b/src/rp2_common/pico_atomic/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_bit_ops/BUILD.bazel
+++ b/src/rp2_common/pico_bit_ops/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_bootrom/BUILD.bazel
+++ b/src/rp2_common/pico_bootrom/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
@@ -17,8 +18,8 @@ cc_library(
     deps = [
         "//src/rp2_common/boot_bootrom_headers",
         "//src/rp2_common/hardware_boot_lock:hardware_boot_lock_headers",
-        "//src/rp2_common/pico_flash:pico_flash_headers",
         "//src/rp2_common/hardware_rcp:hardware_rcp_headers",
+        "//src/rp2_common/pico_flash:pico_flash_headers",
     ] + select({
         "//bazel/constraint:host": ["//src/host/hardware_sync"],
         "//conditions:default": ["//src/rp2_common/hardware_sync"],

--- a/src/rp2_common/pico_bootsel_via_double_reset/BUILD.bazel
+++ b/src/rp2_common/pico_bootsel_via_double_reset/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_btstack/BUILD.bazel
+++ b/src/rp2_common/pico_btstack/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])
@@ -11,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 #   --@pico-sdk//bazel/constraint:PICO_BT_ENABLE_MESH
 cc_library(
     name = "pico_btstack",
+    target_compatible_with = incompatible_with_config("//bazel/constraint:pico_btstack_config_unset"),
     deps = ["pico_btstack_base"] + select({
         "//bazel/constraint:pico_bt_enable_ble_enabled": [":pico_btstack_ble"],
         "//conditions:default": [],
@@ -21,7 +23,6 @@ cc_library(
         "//bazel/constraint:pico_bt_enable_mesh_enabled": [":pico_btstack_mesh"],
         "//conditions:default": [],
     }),
-    target_compatible_with = incompatible_with_config("//bazel/constraint:pico_btstack_config_unset"),
 )
 
 # Prefer these aliases to directly referencing @btstack, as it's possible that

--- a/src/rp2_common/pico_clib_interface/BUILD.bazel
+++ b/src/rp2_common/pico_clib_interface/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_crt0/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(
@@ -6,7 +8,7 @@ exports_files(
         "memmap_copy_to_ram.ld",
         "memmap_default.ld",
         "memmap_no_flash.ld",
-    ]
+    ],
 )
 
 # It's possible to set linker scripts globally or on a per-binary basis.

--- a/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(
@@ -5,7 +7,7 @@ exports_files(
         "memmap_copy_to_ram.ld",
         "memmap_default.ld",
         "memmap_no_flash.ld",
-    ]
+    ],
 )
 
 # It's possible to set linker scripts globally or on a per-binary basis.

--- a/src/rp2_common/pico_cxx_options/BUILD.bazel
+++ b/src/rp2_common/pico_cxx_options/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_cyw43_arch/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_arch/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])
@@ -7,7 +8,7 @@ alias(
     actual = select({
         "//bazel/constraint:pico_lwip_config_unset": ":select_no_lwip",
         "//conditions:default": ":select_lwip",
-    })
+    }),
 )
 
 alias(

--- a/src/rp2_common/pico_cyw43_driver/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_driver/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w", "pico_generate_pio_header")
 
 package(default_visibility = ["//visibility:public"])
@@ -40,7 +41,7 @@ cc_library(
     ] + select({
         "//bazel/constraint:pico_btstack_config_unset": [],
         "//conditions:default": [
-            "//src/rp2_common/pico_btstack:pico_btstack",
+            "//src/rp2_common/pico_btstack",
         ],
     }),
     alwayslink = True,
@@ -51,8 +52,8 @@ cc_library(
     srcs = select({
         "//bazel/constraint:pico_btstack_config_unset": [],
         "//conditions:default": [
-            "btstack_cyw43.c",
             "btstack_chipset_cyw43.c",
+            "btstack_cyw43.c",
             "btstack_hci_transport_cyw43.c",
         ],
     }),
@@ -70,10 +71,10 @@ cc_library(
         "//bazel/constraint:pico_btstack_config_unset": [],
         "//conditions:default": [
             "//bazel/config:PICO_BTSTACK_CONFIG",
-            "//src/rp2_common/pico_cyw43_driver/cybt_shared_bus:cybt_shared_bus_driver",
+            "//src/rp2_common/pico_btstack",
             "//src/rp2_common/pico_btstack:btstack_run_loop_async_context",
-            "//src/rp2_common/pico_btstack:pico_btstack",
             "//src/rp2_common/pico_btstack:pico_btstack_flash_bank",
+            "//src/rp2_common/pico_cyw43_driver/cybt_shared_bus:cybt_shared_bus_driver",
         ],
     }),
     alwayslink = True,
@@ -89,7 +90,7 @@ pico_generate_pio_header(
 filegroup(
     name = "pico_use_partition_firmware",
     srcs = [
-        "wifi_firmware.S",
         "include/cyw43_partition_firmware.h",
-    ]
+        "wifi_firmware.S",
+    ],
 )

--- a/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -6,7 +8,10 @@ cc_library(
         "cybt_shared_bus.c",
         "cybt_shared_bus_driver.c",
     ],
-    hdrs = ["cybt_shared_bus_driver.h", "cybt_logging.h"],
+    hdrs = [
+        "cybt_logging.h",
+        "cybt_shared_bus_driver.h",
+    ],
     includes = ["."],
     deps = [
         "@cyw43-driver//:cyw43_driver",

--- a/src/rp2_common/pico_divider/BUILD.bazel
+++ b/src/rp2_common/pico_divider/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 alias(

--- a/src/rp2_common/pico_double/BUILD.bazel
+++ b/src/rp2_common/pico_double/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_fix/BUILD.bazel
+++ b/src/rp2_common/pico_fix/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/BUILD.bazel
+++ b/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_flash/BUILD.bazel
+++ b/src/rp2_common/pico_flash/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_float/BUILD.bazel
+++ b/src/rp2_common/pico_float/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_i2c_slave/BUILD.bazel
+++ b/src/rp2_common/pico_i2c_slave/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_int64_ops/BUILD.bazel
+++ b/src/rp2_common/pico_int64_ops/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_lwip/BUILD.bazel
+++ b/src/rp2_common/pico_lwip/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w")
 
 package(default_visibility = ["//visibility:public"])
@@ -31,8 +32,8 @@ cc_library(
 cc_library(
     name = "pico_lwip_nosys",
     srcs = ["lwip_nosys.c"],
-    includes = ["include"],
     hdrs = ["include/pico/lwip_nosys.h"],
+    includes = ["include"],
     target_compatible_with = compatible_with_pico_w(),
     deps = [
         ":pico_lwip",

--- a/src/rp2_common/pico_malloc/BUILD.bazel
+++ b/src/rp2_common/pico_malloc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_mbedtls/BUILD.bazel
+++ b/src/rp2_common/pico_mbedtls/BUILD.bazel
@@ -1,12 +1,13 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "pico_mbedtls_config",
-    includes = ["include"],
     hdrs = ["include/pico_mbedtls_config.h"],
     defines = ['MBEDTLS_CONFIG_FILE=\\"pico_mbedtls_config.h\\"'],
+    includes = ["include"],
 )
 
 cc_library(
@@ -16,13 +17,13 @@ cc_library(
     includes = ["include"],
     target_compatible_with = compatible_with_rp2(),
     deps = [
-        ":pico_mbedtls_library",
         ":pico_mbedtls_config",
+        ":pico_mbedtls_library",
         "//src/rp2_common:pico_platform",
         "//src/rp2_common/pico_rand",
     ] + select({
-        "//bazel/constraint:rp2350": [ "//src/rp2_common/pico_sha256" ],
-        "//conditions:default": [ ],
+        "//bazel/constraint:rp2350": ["//src/rp2_common/pico_sha256"],
+        "//conditions:default": [],
     }),
 )
 

--- a/src/rp2_common/pico_mem_ops/BUILD.bazel
+++ b/src/rp2_common/pico_mem_ops/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_multicore/BUILD.bazel
+++ b/src/rp2_common/pico_multicore/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_platform_common/BUILD.bazel
+++ b/src/rp2_common/pico_platform_common/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])
@@ -18,8 +19,8 @@ cc_library(
     target_compatible_with = compatible_with_rp2(),
     deps = [
         ":pico_platform_common_headers",
+        "//src/common/pico_base_headers",
         "//src/rp2_common:platform_defs",
         "//src/rp2_common/hardware_base",
-        "//src/common/pico_base_headers",
     ],
 )

--- a/src/rp2_common/pico_platform_compiler/BUILD.bazel
+++ b/src/rp2_common/pico_platform_compiler/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_platform_panic/BUILD.bazel
+++ b/src/rp2_common/pico_platform_panic/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_platform_sections/BUILD.bazel
+++ b/src/rp2_common/pico_platform_sections/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_printf/BUILD.bazel
+++ b/src/rp2_common/pico_printf/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_rand/BUILD.bazel
+++ b/src/rp2_common/pico_rand/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_runtime/BUILD.bazel
+++ b/src/rp2_common/pico_runtime/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_runtime_init/BUILD.bazel
+++ b/src/rp2_common/pico_runtime_init/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_sha256/BUILD.bazel
+++ b/src/rp2_common/pico_sha256/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_standard_link/BUILD.bazel
+++ b/src/rp2_common/pico_standard_link/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("pico_flash_region.bzl", "generated_pico_flash_region")
 

--- a/src/rp2_common/pico_standard_link/pico_flash_region.bzl
+++ b/src/rp2_common/pico_standard_link/pico_flash_region.bzl
@@ -1,4 +1,6 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _generated_pico_flash_region_impl(ctx):
     flash_region_linker_fragment = ctx.actions.declare_file(ctx.label.name + "/ldinclude/pico_flash_region.ld")

--- a/src/rp2_common/pico_status_led/BUILD.bazel
+++ b/src/rp2_common/pico_status_led/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "pico_generate_pio_header")
 
 package(default_visibility = ["//visibility:public"])
@@ -16,7 +17,7 @@ cc_library(
             "//src/rp2_common/pico_cyw43_driver",
         ],
         "//bazel/constraint:is_pico2_w": [
-            "//src/rp2_common/pico_cyw43_driver"
+            "//src/rp2_common/pico_cyw43_driver",
         ],
         "//conditions:default": [],
     }),

--- a/src/rp2_common/pico_stdio/BUILD.bazel
+++ b/src/rp2_common/pico_stdio/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_stdio_rtt/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_rtt/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdio_semihosting/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_semihosting/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdio_uart/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_uart/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdio_usb/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_usb/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdlib/BUILD.bazel
+++ b/src/rp2_common/pico_stdlib/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_time_adapter/BUILD.bazel
+++ b/src/rp2_common/pico_time_adapter/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_unique_id/BUILD.bazel
+++ b/src/rp2_common/pico_unique_id/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/tinyusb/BUILD.bazel
+++ b/src/rp2_common/tinyusb/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/cmsis_test/BUILD.bazel
+++ b/test/cmsis_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/hardware_irq_test/BUILD.bazel
+++ b/test/hardware_irq_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/hardware_pwm_test/BUILD.bazel
+++ b/test/hardware_pwm_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/hardware_sync_spin_lock_test/BUILD.bazel
+++ b/test/hardware_sync_spin_lock_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:transition.bzl", "extra_copts_for_all_deps")
 

--- a/test/kitchen_sink/BUILD.bazel
+++ b/test/kitchen_sink/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "pico_generate_pio_header")
 load("//bazel/util:transition.bzl", "kitchen_sink_test_binary")
 
@@ -113,8 +115,8 @@ cc_binary(
     tags = ["manual"],  # Built via kitchen_sink_lwip_poll
     deps = [
         ":kitchen_sink_common",
+        "//src/rp2_common/pico_btstack",
         "//src/rp2_common/pico_cyw43_arch:pico_cyw43_arch_lwip_poll",
-        "//src/rp2_common/pico_btstack:pico_btstack",
         "//src/rp2_common/pico_lwip:pico_lwip_mbedtls",
         "//src/rp2_common/pico_mbedtls",
     ],
@@ -127,8 +129,8 @@ cc_binary(
     tags = ["manual"],  # Built via kitchen_sink_lwip_background
     deps = [
         ":kitchen_sink_common",
+        "//src/rp2_common/pico_btstack",
         "//src/rp2_common/pico_cyw43_arch:pico_cyw43_arch_lwip_threadsafe_background",
-        "//src/rp2_common/pico_btstack:pico_btstack",
         "//src/rp2_common/pico_lwip:pico_lwip_mbedtls",
         "//src/rp2_common/pico_mbedtls",
     ],
@@ -139,10 +141,10 @@ kitchen_sink_test_binary(
     testonly = True,
     src = ":kitchen_sink_lwip_poll_actual",
     bt_stack_config = ":btstack_config",
-    lwip_config = ":lwip_config",
-    mbedtls_config = ":mbedtls_config",
     enable_ble = True,
     enable_bt_classic = True,
+    lwip_config = ":lwip_config",
+    mbedtls_config = ":mbedtls_config",
     target_compatible_with = compatible_with_rp2(),
 )
 
@@ -151,9 +153,9 @@ kitchen_sink_test_binary(
     testonly = True,
     src = ":kitchen_sink_lwip_background_actual",
     bt_stack_config = ":btstack_config",
-    lwip_config = ":lwip_config",
-    mbedtls_config = ":mbedtls_config",
     enable_ble = True,
     enable_bt_classic = True,
+    lwip_config = ":lwip_config",
+    mbedtls_config = ":mbedtls_config",
     target_compatible_with = compatible_with_rp2(),
 )

--- a/test/pico_divider_test/BUILD.bazel
+++ b/test/pico_divider_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/pico_float_test/BUILD.bazel
+++ b/test/pico_float_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:transition.bzl", "pico_float_test_binary")
 

--- a/test/pico_sem_test/BUILD.bazel
+++ b/test/pico_sem_test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(

--- a/test/pico_sha256_test/BUILD.bazel
+++ b/test/pico_sha256_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/pico_stdio_test/BUILD.bazel
+++ b/test/pico_stdio_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/pico_stdlib_test/BUILD.bazel
+++ b/test/pico_stdlib_test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(

--- a/test/pico_test/BUILD.bazel
+++ b/test/pico_test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/test/pico_time_test/BUILD.bazel
+++ b/test/pico_time_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:transition.bzl", "extra_copts_for_all_deps")
 
@@ -11,8 +12,8 @@ cc_binary(
     # Doesn't appear to work on host builds yet.
     target_compatible_with = compatible_with_rp2(),
     deps = [
-        "//src/rp2_common/pico_stdlib",
         "//src/rp2_common/pico_aon_timer",
+        "//src/rp2_common/pico_stdlib",
         "//test/pico_test",
     ],
 )

--- a/tools/pioasm/BUILD.bazel
+++ b/tools/pioasm/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -68,11 +70,11 @@ cc_library(
 
 expand_template(
     name = "version",
-    template = "version.h.in",
+    out = "gen/version.h",
     substitutions = {
         "${PIOASM_VERSION_STRING}": module_version() if module_version() != None else "0.0.1-WORKSPACE",
     },
-    out = "gen/version.h",
+    template = "version.h.in",
 )
 
 cc_binary(


### PR DESCRIPTION
This is an automated change with the following command:
```
$ find . -name "BUILD.bazel" -o -name "*.bzl" \
  -exec buildifier -lint=fix {} \;
```

* Add missing `load()` statements for things provided by @rules_cc. This is required for Bazel >9.
* Sort attributes on build targets.
* Add missing trailing commas where applicable.
