### PR TITLE
Fix bit mask in powman_set_debug_power_request_ignored

### DIFF
--- a/src/rp2_common/hardware_powman/include/hardware/powman.h
+++ b/src/rp2_common/hardware_powman/include/hardware/powman.h
@@ -273,7 +273,7 @@ static inline void powman_set_debug_power_request_ignored(bool ignored) {
     if (ignored)
         powman_set_bits(&powman_hw->dbg_pwrcfg, 1);
     else
-        powman_clear_bits(&powman_hw->dbg_pwrcfg, 0);
+        powman_clear_bits(&powman_hw->dbg_pwrcfg, 1);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes #2824

Changed the bit-number mask for the `powman_clear_bits()`.

This change restores the functionality of `void powman_set_debug_power_request_ignored(bool ignored)`.
When `ignored` was `true`, the debug power request is ignored, when `ignored` is `false`, the function did nothing.

This fix restores that functionality, allowing developers to undo a call to `powman_set_debug_power_request_ignored(true)` with `powman_set_debug_power_request_ignored(false)`.