### PR TITLE
Fix picotool bazel build

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])

--- a/bazel/config/BUILD.bazel
+++ b/bazel/config/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag")
 
 package(default_visibility = ["//visibility:public"])

--- a/bazel/defs.bzl
+++ b/bazel/defs.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
-load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_common", "cc_library", "CcInfo")
 
 def _pico_generate_pio_header_impl(ctx):
     generated_headers = []

--- a/bazel/pico_btstack_make_gatt_header.bzl
+++ b/bazel/pico_btstack_make_gatt_header.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_common", "CcInfo")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cpp_toolchain", "use_cc_toolchain")
 
 def _pico_btstack_make_gatt_header_impl(ctx):

--- a/bazel/toolchain/objcopy.bzl
+++ b/bazel/toolchain/objcopy.bzl
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "OBJ_COPY_ACTION_NAME")
+load("@rules_cc//cc:defs.bzl", "cc_common")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cpp_toolchain", "use_cc_toolchain")
 
 def _objcopy_to_bin_impl(ctx):

--- a/bazel/util/sdk_define.bzl
+++ b/bazel/util/sdk_define.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_common", "CcInfo")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def _pico_sdk_define_impl(ctx):

--- a/src/boards/BUILD.bazel
+++ b/src/boards/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "pico_board_config")
 load("//bazel/util:multiple_choice_flag.bzl", "declare_flag_choices", "flag_choice")
 

--- a/src/common/boot_picobin_headers/BUILD.bazel
+++ b/src/common/boot_picobin_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/boot_picoboot_headers/BUILD.bazel
+++ b/src/common/boot_picoboot_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # This needs to remain compatible with the host build since it's used by

--- a/src/common/boot_uf2_headers/BUILD.bazel
+++ b/src/common/boot_uf2_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/hardware_claim/BUILD.bazel
+++ b/src/common/hardware_claim/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/pico_base_headers/BUILD.bazel
+++ b/src/common/pico_base_headers/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/common/pico_binary_info/BUILD.bazel
+++ b/src/common/pico_binary_info/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/common/pico_bit_ops_headers/BUILD.bazel
+++ b/src/common/pico_bit_ops_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # This exists to break dependency cycles between

--- a/src/common/pico_divider_headers/BUILD.bazel
+++ b/src/common/pico_divider_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/pico_stdlib_headers/BUILD.bazel
+++ b/src/common/pico_stdlib_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # Use //host/pico_stdlib or //rp2_common/pico_stdlib to get the

--- a/src/common/pico_sync/BUILD.bazel
+++ b/src/common/pico_sync/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/common/pico_time/BUILD.bazel
+++ b/src/common/pico_time/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/common/pico_usb_reset_interface_headers/BUILD.bazel
+++ b/src/common/pico_usb_reset_interface_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/common/pico_util/BUILD.bazel
+++ b/src/common/pico_util/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/host/BUILD.bazel
+++ b/src/host/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # This is currently unused in Bazel.

--- a/src/host/hardware_divider/BUILD.bazel
+++ b/src/host/hardware_divider/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_gpio/BUILD.bazel
+++ b/src/host/hardware_gpio/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_irq/BUILD.bazel
+++ b/src/host/hardware_irq/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_sync/BUILD.bazel
+++ b/src/host/hardware_sync/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/hardware_timer/BUILD.bazel
+++ b/src/host/hardware_timer/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 _DEFINES = [

--- a/src/host/hardware_uart/BUILD.bazel
+++ b/src/host/hardware_uart/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_bit_ops/BUILD.bazel
+++ b/src/host/pico_bit_ops/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_divider/BUILD.bazel
+++ b/src/host/pico_divider/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_multicore/BUILD.bazel
+++ b/src/host/pico_multicore/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_platform/BUILD.bazel
+++ b/src/host/pico_platform/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_printf/BUILD.bazel
+++ b/src/host/pico_printf/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_rand/BUILD.bazel
+++ b/src/host/pico_rand/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_runtime/BUILD.bazel
+++ b/src/host/pico_runtime/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_status_led/BUILD.bazel
+++ b/src/host/pico_status_led/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_stdio/BUILD.bazel
+++ b/src/host/pico_stdio/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_stdlib/BUILD.bazel
+++ b/src/host/pico_stdlib/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_time_adapter/BUILD.bazel
+++ b/src/host/pico_time_adapter/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/host/pico_unique_id/BUILD.bazel
+++ b/src/host/pico_unique_id/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2040/boot_stage2/BUILD.bazel
+++ b/src/rp2040/boot_stage2/BUILD.bazel
@@ -1,6 +1,7 @@
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_python//python:defs.bzl", "py_binary")

--- a/src/rp2040/hardware_regs/BUILD.bazel
+++ b/src/rp2040/hardware_regs/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 

--- a/src/rp2040/hardware_structs/BUILD.bazel
+++ b/src/rp2040/hardware_structs/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 

--- a/src/rp2040/pico_platform/BUILD.bazel
+++ b/src/rp2040/pico_platform/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2040:__subpackages__",

--- a/src/rp2350/boot_stage2/BUILD.bazel
+++ b/src/rp2350/boot_stage2/BUILD.bazel
@@ -1,6 +1,7 @@
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_python//python:defs.bzl", "py_binary")

--- a/src/rp2350/hardware_regs/BUILD.bazel
+++ b/src/rp2350/hardware_regs/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 

--- a/src/rp2350/hardware_structs/BUILD.bazel
+++ b/src/rp2350/hardware_structs/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 # Always include these libraries through //src/rp2_common:*!
 # This ensures that you'll get the right headers for the MCU you're targeting.
 

--- a/src/rp2350/pico_platform/BUILD.bazel
+++ b/src/rp2350/pico_platform/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(
     default_visibility = [
         "//src/rp2350:__subpackages__",

--- a/src/rp2_common/boot_bootrom_headers/BUILD.bazel
+++ b/src/rp2_common/boot_bootrom_headers/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/cmsis/BUILD.bazel
+++ b/src/rp2_common/cmsis/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_adc/BUILD.bazel
+++ b/src/rp2_common/hardware_adc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_base/BUILD.bazel
+++ b/src/rp2_common/hardware_base/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_boot_lock/BUILD.bazel
+++ b/src/rp2_common/hardware_boot_lock/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_clocks/BUILD.bazel
+++ b/src/rp2_common/hardware_clocks/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_dcp/BUILD.bazel
+++ b/src/rp2_common/hardware_dcp/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_divider/BUILD.bazel
+++ b/src/rp2_common/hardware_divider/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_dma/BUILD.bazel
+++ b/src/rp2_common/hardware_dma/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_exception/BUILD.bazel
+++ b/src/rp2_common/hardware_exception/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_flash/BUILD.bazel
+++ b/src/rp2_common/hardware_flash/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_gpio/BUILD.bazel
+++ b/src/rp2_common/hardware_gpio/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_hazard3/BUILD.bazel
+++ b/src/rp2_common/hardware_hazard3/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_i2c/BUILD.bazel
+++ b/src/rp2_common/hardware_i2c/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_interp/BUILD.bazel
+++ b/src/rp2_common/hardware_interp/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_irq/BUILD.bazel
+++ b/src/rp2_common/hardware_irq/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_pio/BUILD.bazel
+++ b/src/rp2_common/hardware_pio/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_pll/BUILD.bazel
+++ b/src/rp2_common/hardware_pll/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_powman/BUILD.bazel
+++ b/src/rp2_common/hardware_powman/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/hardware_pwm/BUILD.bazel
+++ b/src/rp2_common/hardware_pwm/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_rcp/BUILD.bazel
+++ b/src/rp2_common/hardware_rcp/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_resets/BUILD.bazel
+++ b/src/rp2_common/hardware_resets/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_riscv/BUILD.bazel
+++ b/src/rp2_common/hardware_riscv/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_riscv_platform_timer/BUILD.bazel
+++ b/src/rp2_common/hardware_riscv_platform_timer/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_rtc/BUILD.bazel
+++ b/src/rp2_common/hardware_rtc/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/hardware_sha256/BUILD.bazel
+++ b/src/rp2_common/hardware_sha256/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/hardware_spi/BUILD.bazel
+++ b/src/rp2_common/hardware_spi/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_sync/BUILD.bazel
+++ b/src/rp2_common/hardware_sync/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_sync_spin_lock/BUILD.bazel
+++ b/src/rp2_common/hardware_sync_spin_lock/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_ticks/BUILD.bazel
+++ b/src/rp2_common/hardware_ticks/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_timer/BUILD.bazel
+++ b/src/rp2_common/hardware_timer/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_uart/BUILD.bazel
+++ b/src/rp2_common/hardware_uart/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/hardware_vreg/BUILD.bazel
+++ b/src/rp2_common/hardware_vreg/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_watchdog/BUILD.bazel
+++ b/src/rp2_common/hardware_watchdog/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_xip_cache/BUILD.bazel
+++ b/src/rp2_common/hardware_xip_cache/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/hardware_xosc/BUILD.bazel
+++ b/src/rp2_common/hardware_xosc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_aon_timer/BUILD.bazel
+++ b/src/rp2_common/pico_aon_timer/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_async_context/BUILD.bazel
+++ b/src/rp2_common/pico_async_context/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_atomic/BUILD.bazel
+++ b/src/rp2_common/pico_atomic/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_bit_ops/BUILD.bazel
+++ b/src/rp2_common/pico_bit_ops/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_bootrom/BUILD.bazel
+++ b/src/rp2_common/pico_bootrom/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_bootsel_via_double_reset/BUILD.bazel
+++ b/src/rp2_common/pico_bootsel_via_double_reset/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_btstack/BUILD.bazel
+++ b/src/rp2_common/pico_btstack/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_btstack/btstack.BUILD
+++ b/src/rp2_common/pico_btstack/btstack.BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@pico-sdk//bazel:defs.bzl", "compatible_with_config", "incompatible_with_config")
 

--- a/src/rp2_common/pico_clib_interface/BUILD.bazel
+++ b/src/rp2_common/pico_clib_interface/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_crt0/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2040/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(

--- a/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
+++ b/src/rp2_common/pico_crt0/rp2350/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(

--- a/src/rp2_common/pico_cxx_options/BUILD.bazel
+++ b/src/rp2_common/pico_cxx_options/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_cyw43_arch/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_arch/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_cyw43_driver/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_driver/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w", "pico_generate_pio_header")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/BUILD.bazel
+++ b/src/rp2_common/pico_cyw43_driver/cybt_shared_bus/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD
+++ b/src/rp2_common/pico_cyw43_driver/cyw43-driver.BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@pico-sdk//bazel:defs.bzl", "compatible_with_pico_w")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_divider/BUILD.bazel
+++ b/src/rp2_common/pico_divider/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 alias(

--- a/src/rp2_common/pico_double/BUILD.bazel
+++ b/src/rp2_common/pico_double/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_fix/BUILD.bazel
+++ b/src/rp2_common/pico_fix/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/BUILD.bazel
+++ b/src/rp2_common/pico_fix/rp2040_usb_device_enumeration/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_flash/BUILD.bazel
+++ b/src/rp2_common/pico_flash/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_float/BUILD.bazel
+++ b/src/rp2_common/pico_float/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_i2c_slave/BUILD.bazel
+++ b/src/rp2_common/pico_i2c_slave/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_int64_ops/BUILD.bazel
+++ b/src/rp2_common/pico_int64_ops/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_lwip/BUILD.bazel
+++ b/src/rp2_common/pico_lwip/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_pico_w")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_lwip/lwip.BUILD
+++ b/src/rp2_common/pico_lwip/lwip.BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config", "compatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_malloc/BUILD.bazel
+++ b/src/rp2_common/pico_malloc/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_mbedtls/BUILD.bazel
+++ b/src/rp2_common/pico_mbedtls/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_mbedtls/mbedtls.BUILD
+++ b/src/rp2_common/pico_mbedtls/mbedtls.BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@pico-sdk//bazel:defs.bzl", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_mem_ops/BUILD.bazel
+++ b/src/rp2_common/pico_mem_ops/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_multicore/BUILD.bazel
+++ b/src/rp2_common/pico_multicore/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_platform_common/BUILD.bazel
+++ b/src/rp2_common/pico_platform_common/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_platform_compiler/BUILD.bazel
+++ b/src/rp2_common/pico_platform_compiler/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_platform_panic/BUILD.bazel
+++ b/src/rp2_common/pico_platform_panic/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_platform_sections/BUILD.bazel
+++ b/src/rp2_common/pico_platform_sections/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_printf/BUILD.bazel
+++ b/src/rp2_common/pico_printf/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_rand/BUILD.bazel
+++ b/src/rp2_common/pico_rand/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_runtime/BUILD.bazel
+++ b/src/rp2_common/pico_runtime/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_runtime_init/BUILD.bazel
+++ b/src/rp2_common/pico_runtime_init/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_sha256/BUILD.bazel
+++ b/src/rp2_common/pico_sha256/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_standard_binary_info/BUILD.bazel
+++ b/src/rp2_common/pico_standard_binary_info/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 load("//src/common/pico_binary_info:binary_info.bzl", "custom_pico_binary_info")
 

--- a/src/rp2_common/pico_standard_link/BUILD.bazel
+++ b/src/rp2_common/pico_standard_link/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("pico_flash_region.bzl", "generated_pico_flash_region")
 

--- a/src/rp2_common/pico_standard_link/pico_flash_region.bzl
+++ b/src/rp2_common/pico_standard_link/pico_flash_region.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_common", "CcInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 
 def _generated_pico_flash_region_impl(ctx):

--- a/src/rp2_common/pico_status_led/BUILD.bazel
+++ b/src/rp2_common/pico_status_led/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "pico_generate_pio_header")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_stdio/BUILD.bazel
+++ b/src/rp2_common/pico_stdio/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_stdio_rtt/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_rtt/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdio_semihosting/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_semihosting/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdio_uart/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_uart/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdio_usb/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_usb/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_config", "compatible_with_rp2", "incompatible_with_config")
 load("//bazel/util:sdk_define.bzl", "pico_sdk_define")
 

--- a/src/rp2_common/pico_stdlib/BUILD.bazel
+++ b/src/rp2_common/pico_stdlib/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_time_adapter/BUILD.bazel
+++ b/src/rp2_common/pico_time_adapter/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/pico_unique_id/BUILD.bazel
+++ b/src/rp2_common/pico_unique_id/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/tinyusb/BUILD.bazel
+++ b/src/rp2_common/tinyusb/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/rp2_common/tinyusb/tinyusb.BUILD
+++ b/src/rp2_common/tinyusb/tinyusb.BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(

--- a/test/cmsis_test/BUILD.bazel
+++ b/test/cmsis_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/hardware_irq_test/BUILD.bazel
+++ b/test/hardware_irq_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/hardware_pwm_test/BUILD.bazel
+++ b/test/hardware_pwm_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/hardware_sync_spin_lock_test/BUILD.bazel
+++ b/test/hardware_sync_spin_lock_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:transition.bzl", "extra_copts_for_all_deps")
 

--- a/test/kitchen_sink/BUILD.bazel
+++ b/test/kitchen_sink/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2", "pico_generate_pio_header")
 load("//bazel/util:transition.bzl", "kitchen_sink_test_binary")
 

--- a/test/pico_divider_test/BUILD.bazel
+++ b/test/pico_divider_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/pico_float_test/BUILD.bazel
+++ b/test/pico_float_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:transition.bzl", "pico_float_test_binary")
 

--- a/test/pico_sem_test/BUILD.bazel
+++ b/test/pico_sem_test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(

--- a/test/pico_sha256_test/BUILD.bazel
+++ b/test/pico_sha256_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/pico_stdio_test/BUILD.bazel
+++ b/test/pico_stdio_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 
 package(default_visibility = ["//visibility:public"])

--- a/test/pico_stdlib_test/BUILD.bazel
+++ b/test/pico_stdlib_test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(

--- a/test/pico_test/BUILD.bazel
+++ b/test/pico_test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/test/pico_time_test/BUILD.bazel
+++ b/test/pico_time_test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("//bazel:defs.bzl", "compatible_with_rp2")
 load("//bazel/util:transition.bzl", "extra_copts_for_all_deps")
 

--- a/tools/pioasm/BUILD.bazel
+++ b/tools/pioasm/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
This PR fixes the picotool bazel build, as these rules are no longer loaded by default - it links with picotool PR https://github.com/raspberrypi/picotool/pull/292

CC @armandomontanez 