### PR TITLE
Rename pio_claim_free_sm_and_add_program_for_gpio_range's gpio_base parameter to gpio_start

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -2005,26 +2005,26 @@ bool pio_claim_free_sm_and_add_program(const pio_program_t *program, PIO *pio, u
 /*! \brief Finds a PIO and statemachine and adds a program into PIO memory
  *  \ingroup hardware_pio
  *
- * This variation of \ref pio_claim_free_sm_and_add_program is useful on RP2350 QFN80 where the "GPIO Base"
+ * This variation of \ref pio_claim_free_sm_and_add_program is useful on RP2350B where the "GPIO Base"
  * must be set per PIO instance to either address the 32 GPIOs (0->31) or the 32 GPIOS (16-47). No single
  * PIO instance can interact with both pins 0->15 or 32->47 at the same time.
  *
- * This method takes additional information about the GPIO pins needed (via gpio_base and gpio_count),
+ * This method takes additional information about the GPIO pins needed (via gpio_start and gpio_count),
  * and optionally will set the GPIO base (see \ref pio_set_gpio_base) of an unused PIO instance if necessary
  *
  * \param program PIO program to add
  * \param pio Returns the PIO hardware instance or NULL if no PIO is available
  * \param sm Returns the index of the PIO state machine that was claimed
  * \param offset Returns the instruction memory offset of the start of the program
- * \param gpio_base the lowest GPIO number required (0-47 on RP2350B, 0-31 otherwise)
- * \param gpio_count the count of GPIOs required
+ * \param gpio_start the lowest GPIO number required (0-47 on RP2350B, 0-31 otherwise)
+ * \param gpio_count the count of consecutive GPIOs required
  * \param set_gpio_base if there is no free SM on a PIO instance with the right GPIO base, and there IS an unused PIO
  *                      instance, then that PIO will be reconfigured so that this method can succeed
  *
  * \return true on success, false otherwise
  * \see pio_remove_program_and_unclaim_sm
  */
-bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *program, PIO *pio, uint *sm, uint *offset, uint gpio_base, uint gpio_count, bool set_gpio_base);
+bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *program, PIO *pio, uint *sm, uint *offset, uint gpio_start, uint gpio_count, bool set_gpio_base);
 
 /*! \brief Removes a program from PIO memory and unclaims the state machine
  *  \ingroup hardware_pio

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -405,8 +405,8 @@ bool pio_claim_free_sm_and_add_program(const pio_program_t *program, PIO *pio, u
     return pio_claim_free_sm_and_add_program_for_gpio_range(program, pio, sm, offset, 0, 0, false);
 }
 
-bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *program, PIO *pio, uint *sm, uint *offset, uint gpio_base, uint gpio_count, bool set_gpio_base) {
-    invalid_params_if(HARDWARE_PIO, (gpio_base + gpio_count) > NUM_BANK0_GPIOS);
+bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *program, PIO *pio, uint *sm, uint *offset, uint gpio_start, uint gpio_count, bool set_gpio_base) {
+    invalid_params_if(HARDWARE_PIO, (gpio_start + gpio_count) > NUM_BANK0_GPIOS);
 
 #if !PICO_PIO_USE_GPIO_BASE
     // short-circuit some logic when not using GIO_BASE
@@ -417,7 +417,7 @@ bool pio_claim_free_sm_and_add_program_for_gpio_range(const pio_program_t *progr
     // note if we gpio_count == 0, we don't care about GPIOs so use a zero mask for what we require
     // if gpio_count > 0, then we just set used mask for the ends, since that is all that is checked at the moment
     uint32_t required_gpio_ranges;
-    if (gpio_count) required_gpio_ranges = (1u << (gpio_base >> 4)) | (1u << ((gpio_base + gpio_count - 1) >> 4));
+    if (gpio_count) required_gpio_ranges = (1u << (gpio_start >> 4)) | (1u << ((gpio_start + gpio_count - 1) >> 4));
     else            required_gpio_ranges = 0;
     int passes = set_gpio_base ? 2 : 1;
 


### PR DESCRIPTION
in order to avoid confusion with pio_set_gpio_base's gpio_base parameter

IMHO it's slightly confusing that [`pio_set_gpio_base`](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_pio_1ga332210f0e594b24bf64f4bb1c8f49be3) has a `gpio_base` parameter which can only be set to 0 or 16, and [`pio_claim_free_sm_and_add_program_for_gpio_range`](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_pio_1ga53c3bbe939b3c58585d0e19ffe91e18e) has a similar-sounding `gpio_base` parameter which can be set to any GPIO number! This PR fixes that confusion by renaming `pio_claim_free_sm_and_add_program_for_gpio_range`'s parameter to `gpio_start`, which I think better reflects the parameter's actual purpose.
(I also squeezed in a couple of small Doxygen tweaks at the same time.)