### PR TITLE
Change a couple of hardcoded numbers to PIO_INSTRUCTION_COUNT for clarity

### DIFF
--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -68,11 +68,11 @@ static int find_offset_for_program(PIO pio, const pio_program_t *program) {
     uint32_t used_mask = _used_instruction_space[pio_get_index(pio)];
     uint32_t program_mask = (1u << program->length) - 1;
     if (program->origin >= 0) {
-        if (program->origin > 32 - program->length) return PICO_ERROR_GENERIC;
+        if (program->origin > PIO_INSTRUCTION_COUNT - program->length) return PICO_ERROR_GENERIC;
         return used_mask & (program_mask << program->origin) ? -1 : program->origin;
     } else {
         // work down from the top always
-        for (int i = 32 - program->length; i >= 0; i--) {
+        for (int i = PIO_INSTRUCTION_COUNT - program->length; i >= 0; i--) {
             if (!(used_mask & (program_mask << (uint) i))) {
                 return i;
             }

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -68,7 +68,7 @@ static int find_offset_for_program(PIO pio, const pio_program_t *program) {
     uint32_t used_mask = _used_instruction_space[pio_get_index(pio)];
     uint32_t program_mask = (1u << program->length) - 1;
     if (program->origin >= 0) {
-        if (program->origin > PIO_INSTRUCTION_COUNT - program->length) return PICO_ERROR_GENERIC;
+        if ((uint8_t)program->origin > PIO_INSTRUCTION_COUNT - program->length) return PICO_ERROR_GENERIC;
         return used_mask & (program_mask << program->origin) ? -1 : program->origin;
     } else {
         // work down from the top always


### PR DESCRIPTION
32 is:
 * number of words in a PIO's instruction memory
 * number of GPIO pins that can be addressed by a PIO block
 * number of bits that get shifted in or out by a PULL or PUSH instruction

so this PR clarifies "which 32" is being used here :wink:  (Which IMHO also tallies nicely with the `assert(program->length <= PIO_INSTRUCTION_COUNT);` on line 67)

I was also _tempted_ to change
```c
if (program->origin > PIO_INSTRUCTION_COUNT - program->length) return PICO_ERROR_GENERIC;
```
to
```c
if (program->origin > PIO_INSTRUCTION_COUNT - program->length) return PICO_ERROR_BAD_ALIGNMENT;
```
to match up with the error being returned [here](https://github.com/raspberrypi/pico-sdk/blob/develop/src/rp2_common/hardware_pio/pio.c#L139) from `add_program_at_offset_check`, but I refrained from doing so in case that would be considered a backwards-incompatible change.