### PR TITLE
Correct Seeed XIAO RP2350 flash size from 4MB to 2MB

### DIFF
--- a/src/boards/include/boards/seeed_xiao_rp2350.h
+++ b/src/boards/include/boards/seeed_xiao_rp2350.h
@@ -140,9 +140,9 @@ pico_board_cmake_set(PICO_PLATFORM, rp2350)
 #define PICO_FLASH_SPI_CLKDIV 4
 #endif
 
-pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (4 * 1024 * 1024))
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (2 * 1024 * 1024))
 #ifndef PICO_FLASH_SIZE_BYTES
-#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
 #endif
 
 pico_board_cmake_set_default(PICO_RP2350_A2_SUPPORTED, 1)


### PR DESCRIPTION
Fixes the `PICO_FLASH_SIZE_BYTES` for the Seeed XIAO RP2350 board from 4MB to 2MB. The board uses a PUYA P25Q16H-UXH-IR flash chip, which is 16-Mbit (2MB), not 4MB.

**Evidence:**
- The flash chip part number (P25Q**16**H) indicates 16 Megabits = 2 Megabytes
- `picotool info -a` reports `flash size: 2048K` when the board is in BOOTSEL mode
- Seeed's own [product page](https://www.seeedstudio.com/Seeed-XIAO-RP2350-p-5944.html) and [wiki](https://wiki.seeedstudio.com/getting-started-xiao-rp2350/#specification) both list 2MB flash
- The [board schematic](https://files.seeedstudio.com/wiki/XIAO-RP2350/res/Seeed-Studio-XIAO-RP2350-v1.0.pdf) confirms the P25Q16H chip

Closes #2834