### PR TITLE
Fix description rp2350 svd

### DIFF
--- a/src/rp2350/hardware_regs/RP2350.svd
+++ b/src/rp2350/hardware_regs/RP2350.svd
@@ -76208,7 +76208,7 @@ SPDX-License-Identifier: BSD-3-Clause
             <register>
                 <name>MTIME</name>
                 <addressOffset>0x000001b0</addressOffset>
-                <description>Read/write access to the high half of RISC-V Machine-mode timer. This register is shared between both cores. If both cores write on the same cycle, core 1 takes precedence.</description>
+                <description>Read/write access to the low half of RISC-V Machine-mode timer. This register is shared between both cores. If both cores write on the same cycle, core 1 takes precedence.</description>
                 <resetValue>0x00000000</resetValue>
                 <fields>
                     <field>

--- a/src/rp2350/hardware_regs/include/hardware/regs/sio.h
+++ b/src/rp2350/hardware_regs/include/hardware/regs/sio.h
@@ -2132,7 +2132,7 @@
 #define SIO_MTIME_CTRL_EN_ACCESS "RW"
 // =============================================================================
 // Register    : SIO_MTIME
-// Description : Read/write access to the high half of RISC-V Machine-mode
+// Description : Read/write access to the low half of RISC-V Machine-mode
 //               timer. This register is shared between both cores. If both
 //               cores write on the same cycle, core 1 takes precedence.
 #define SIO_MTIME_OFFSET _u(0x000001b0)

--- a/src/rp2350/hardware_structs/include/hardware/structs/sio.h
+++ b/src/rp2350/hardware_structs/include/hardware/structs/sio.h
@@ -249,7 +249,7 @@ typedef struct {
     uint32_t _pad3[2];
  
     _REG_(SIO_MTIME_OFFSET) // SIO_MTIME
-    // Read/write access to the high half of RISC-V Machine-mode timer
+    // Read/write access to the low half of RISC-V Machine-mode timer
     // 0xffffffff [31:0]  MTIME        (0x00000000) 
     io_rw_32 mtime;
  

--- a/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/RP2350.h
+++ b/src/rp2_common/cmsis/stub/CMSIS/Device/RP2350/Include/RP2350.h
@@ -4017,7 +4017,7 @@ typedef struct {                                /*!< SIO Structure              
                                                      interrupts are routed to normal system-level interrupt
                                                      lines as well as to the MIP.MTIP inputs on the RISC-V cores.              */
   __IM  uint32_t  RESERVED3[2];
-  __IOM uint32_t  MTIME;                        /*!< Read/write access to the high half of RISC-V Machine-mode timer.
+  __IOM uint32_t  MTIME;                        /*!< Read/write access to the low half of RISC-V Machine-mode timer.
                                                      This register is shared between both cores. If both cores
                                                      write on the same cycle, core 1 takes precedence.                         */
   __IOM uint32_t  MTIMEH;                       /*!< Read/write access to the high half of RISC-V Machine-mode timer.


### PR DESCRIPTION
The description of RISC-V's MTIME register is a duplicate of the High register MTIMEH.
This seems to be the low half of the machine-mode time.
The fallout is that comments in several autogenerated header files is affected, too -- hence submitted in a separate commit.