### PR TITLE
pioasm: Throw syntax_error for unsupported 'rel' with irq prev/next

### DIFF
--- a/tools/pioasm/gen/parser.cpp
+++ b/tools/pioasm/gen/parser.cpp
@@ -1347,11 +1347,11 @@ namespace yy {
     break;
 
   case 77: // base_instruction: "irq" "prev" irq_modifiers value "rel"
-                                                          { pioasm.check_version(1, yylhs.location, "irq prev"); error(yystack_[0].location, "'rel' is not supported for 'irq prev'"); }
+                                                         { pioasm.check_version(1, yylhs.location, "irq prev"); throw syntax_error(yystack_[0].location, "'rel' is not supported for 'irq prev'"); }
     break;
 
   case 78: // base_instruction: "irq" "next" irq_modifiers value "rel"
-                                                          { pioasm.check_version(1, yylhs.location, "irq next"); error(yystack_[0].location, "'rel' is not supported for 'irq next'"); }
+                                                         { pioasm.check_version(1, yylhs.location, "irq next"); throw syntax_error(yystack_[0].location, "'rel' is not supported for 'irq next'"); }
     break;
 
   case 79: // base_instruction: "irq" irq_modifiers value
@@ -1415,11 +1415,11 @@ namespace yy {
     break;
 
   case 94: // wait_source: "irq" "prev" comma value "rel"
-                             { pioasm.check_version(1, yylhs.location, "irq prev"); error(yystack_[0].location, "'rel' is not supported for 'irq prev'"); }
+                            { pioasm.check_version(1, yylhs.location, "irq prev"); throw syntax_error(yystack_[0].location, "'rel' is not supported for 'irq prev'"); }
     break;
 
   case 95: // wait_source: "irq" "next" comma value "rel"
-                             { pioasm.check_version(1, yylhs.location, "irq next"); error(yystack_[0].location, "'rel' is not supported for 'irq next'"); }
+                            { pioasm.check_version(1, yylhs.location, "irq next"); throw syntax_error(yystack_[0].location, "'rel' is not supported for 'irq next'"); }
     break;
 
   case 96: // wait_source: "irq" comma value

--- a/tools/pioasm/parser.yy
+++ b/tools/pioasm/parser.yy
@@ -269,8 +269,8 @@ base_instruction:
     | IRQ irq_modifiers value REL                         { $$ = std::shared_ptr<instruction>(new instr_irq(@$, $2, $3, 2)); }
     | IRQ PREV irq_modifiers value                        { pioasm.check_version(1, @$, "irq prev"); $$ = std::shared_ptr<instruction>(new instr_irq(@$, $3, $4, 1)); }
     | IRQ NEXT irq_modifiers value                        { pioasm.check_version(1, @$, "irq next"); $$ = std::shared_ptr<instruction>(new instr_irq(@$, $3, $4, 3)); }
-    | IRQ PREV irq_modifiers value REL                    { pioasm.check_version(1, @$, "irq prev"); error(@5, "'rel' is not supported for 'irq prev'"); }
-    | IRQ NEXT irq_modifiers value REL                    { pioasm.check_version(1, @$, "irq next"); error(@5, "'rel' is not supported for 'irq next'"); }
+    | IRQ PREV irq_modifiers value REL                    { pioasm.check_version(1, @$, "irq prev"); throw syntax_error(@5, "'rel' is not supported for 'irq prev'"); }
+    | IRQ NEXT irq_modifiers value REL                    { pioasm.check_version(1, @$, "irq next"); throw syntax_error(@5, "'rel' is not supported for 'irq next'"); }
     | IRQ irq_modifiers value                             { $$ = std::shared_ptr<instruction>(new instr_irq(@$, $2, $3)); }
     | SET set_target comma value                          { $$ = std::shared_ptr<instruction>(new instr_set(@$, $2, $4)); }
 ;
@@ -299,8 +299,8 @@ wait_source:
     IRQ comma value REL     { $$ = std::shared_ptr<wait_source>(new wait_source(wait_source::irq, $3, 2)); }
   | IRQ PREV comma value    { pioasm.check_version(1, @$, "irq prev"); $$ = std::shared_ptr<wait_source>(new wait_source(wait_source::irq, $4, 1)); }
   | IRQ NEXT comma value    { pioasm.check_version(1, @$, "irq next"); $$ = std::shared_ptr<wait_source>(new wait_source(wait_source::irq, $4, 3)); }
-  | IRQ PREV comma value REL { pioasm.check_version(1, @$, "irq prev"); error(@5, "'rel' is not supported for 'irq prev'"); }
-  | IRQ NEXT comma value REL { pioasm.check_version(1, @$, "irq next"); error(@5, "'rel' is not supported for 'irq next'"); }
+  | IRQ PREV comma value REL { pioasm.check_version(1, @$, "irq prev"); throw syntax_error(@5, "'rel' is not supported for 'irq prev'"); }
+  | IRQ NEXT comma value REL { pioasm.check_version(1, @$, "irq next"); throw syntax_error(@5, "'rel' is not supported for 'irq next'"); }
   | IRQ comma value         { $$ = std::shared_ptr<wait_source>(new wait_source(wait_source::irq, $3, 0)); }
   | GPIO comma value        { $$ = std::shared_ptr<wait_source>(new wait_source(wait_source::gpio, $3)); }
   | PIN comma value         { $$ = std::shared_ptr<wait_source>(new wait_source(wait_source::pin, $3)); }


### PR DESCRIPTION
Replaces error() with throw syntax_error when `rel` is used with `irq prev` or `irq next` instructions in parser.yy. Without this fix the compiler will segfault instead of throw an error when trying to compile the following inputs:

```
.program irq_next_rel
.pio_version 1
    irq next set 0 rel
```

```
.program irq_prev_rel
.pio_version 1
    irq prev set 0 rel
```

Before this fix:
```
% ./bazel-bin/tools/pioasm/pioasm /var/folders/44/bgmj54wj15vbrvzxnp57kk2w0000gn/T/tmp.LC5BPmyQJb
/var/folders/44/bgmj54wj15vbrvzxnp57kk2w0000gn/T/tmp.LC5BPmyQJb:3.20-22: 'rel' is not supported for 'irq prev'
    3 |     irq prev set 0 rel
      |                    ^~~
zsh: segmentation fault  ./bazel-bin/tools/pioasm/pioasm 
```
After the fix:
```
% ./bazel-bin/tools/pioasm/pioasm /var/folders/44/bgmj54wj15vbrvzxnp57kk2w0000gn/T/tmp.LC5BPmyQJb
/var/folders/44/bgmj54wj15vbrvzxnp57kk2w0000gn/T/tmp.LC5BPmyQJb:3.20-22: 'rel' is not supported for 'irq prev'
    3 |     irq prev set 0 rel
      |                    ^~~
```
