### PR TITLE
Document Clock Divider = 1 in pio_get_default_sm_config  in pio.h

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -741,6 +741,7 @@ static inline void sm_config_set_mov_status(pio_sm_config *c, enum pio_mov_statu
  *
  * Setting | Default
  * --------|--------
+ * Clock Divider | 1
  * Out Pins | 32 starting at 0
  * Set Pins | 0 starting at 0
  * In Pins | 32 starting at 0


### PR DESCRIPTION
Add Clock Divider = 1 to documentation of pio_get_default_sm_config

Fixes #2862
