### PR TITLE
Added VCC-GND YD-RP2040 boards.

### DIFF
--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/pico.h"
+
+#ifndef _BOARDS_VCC-GND_YD-RP2040_16M_H
+#define _BOARDS_VCC-GND_YD-RP2040_16M_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2040)
+
+// For board detection
+#define VCC-GND_YD-RP2040_16M
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- RGB (NeoPixel) LED ---
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 23
+#endif
+
+// User Button
+#define VCC-GND_YD-RP2040_16M_BUTTON0_PIN 24
+
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// These boards come in 2, 4, 8, 16 MB Flash.
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+// Not used on this board as GPIO23 is the RGB LED pin.
+//#define PICO_SMPS_MODE_PIN 23
+
+#ifndef PICO_RP2040_B2_SUPPORTED
+#define PICO_RP2040_B2_SUPPORTED 1
+#endif
+
+// The GPIO Pin used to read VBUS to determine if the device is battery powered.
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+#endif

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC_GND_YD_RP2040_16M_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_BUTTON0_PIN 24
 
 
 // --- I2C ---

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
@@ -9,15 +9,15 @@
 //       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
 // -----------------------------------------------------
 
-// This header may be included by other board headers as "boards/pico.h"
+// This header may be included by other board headers as "boards/vcc-gnd_yd-rp2040_16m.h"
 
-#ifndef _BOARDS_VCC-GND_YD-RP2040_16M_H
-#define _BOARDS_VCC-GND_YD-RP2040_16M_H
+#ifndef _BOARDS_VCC_GND_YD_RP2040_16M_H
+#define _BOARDS_VCC_GND_YD_RP2040_16M_H
 
 pico_board_cmake_set(PICO_PLATFORM, rp2040)
 
 // For board detection
-#define VCC-GND_YD-RP2040_16M
+#define VCC_GND_YD_RP2040_16M
 
 // --- UART ---
 #ifndef PICO_DEFAULT_UART
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC-GND_YD-RP2040_16M_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_16M_BUTTON0_PIN 24
 
 
 // --- I2C ---
@@ -80,15 +80,11 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #define PICO_FLASH_SPI_CLKDIV 2
 #endif
 
-// These boards come in 2, 4, 8, 16 MB Flash.
+// These boards come in 4, 8, 16 MB Flash.
 pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
 #ifndef PICO_FLASH_SIZE_BYTES
 #define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
 #endif
-
-// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
-// Not used on this board as GPIO23 is the RGB LED pin.
-//#define PICO_SMPS_MODE_PIN 23
 
 #ifndef PICO_RP2040_B2_SUPPORTED
 #define PICO_RP2040_B2_SUPPORTED 1

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
@@ -95,10 +95,5 @@ pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
 #define PICO_VBUS_PIN 24
 #endif
 
-// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
-// There is an example in adc/read_vsys in pico-examples.
-#ifndef PICO_VSYS_PIN
-#define PICO_VSYS_PIN 29
-#endif
 
 #endif

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
@@ -36,6 +36,10 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // --- RGB (NeoPixel) LED ---
+// NOTE: Some YD-RP2040 boards have a link above the RGB
+// marked "RGB" or "R56" or "R58" or similar. On those you
+// have to solder a tiny wire across the link, carefully,
+// to enable the RGB LED.
 #ifndef PICO_DEFAULT_WS2812_PIN
 #define PICO_DEFAULT_WS2812_PIN 23
 #endif
@@ -88,11 +92,6 @@ pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
 
 #ifndef PICO_RP2040_B2_SUPPORTED
 #define PICO_RP2040_B2_SUPPORTED 1
-#endif
-
-// The GPIO Pin used to read VBUS to determine if the device is battery powered.
-#ifndef PICO_VBUS_PIN
-#define PICO_VBUS_PIN 24
 #endif
 
 

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_16m.h
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC_GND_YD_RP2040_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_BUTTON_PIN 24
 
 
 // --- I2C ---

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
@@ -9,15 +9,15 @@
 //       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
 // -----------------------------------------------------
 
-// This header may be included by other board headers as "boards/pico.h"
+// This header may be included by other board headers as "boards/vcc-gnd_yd-rp2040_4m.h"
 
-#ifndef _BOARDS_VCC-GND_YD-RP2040_4M_H
-#define _BOARDS_VCC-GND_YD-RP2040_4M_H
+#ifndef _BOARDS_VCC_GND_YD_RP2040_4M_H
+#define _BOARDS_VCC_GND_YD_RP2040_4M_H
 
 pico_board_cmake_set(PICO_PLATFORM, rp2040)
 
 // For board detection
-#define VCC-GND_YD-RP2040_4M
+#define VCC_GND_YD_RP2040_4M
 
 // --- UART ---
 #ifndef PICO_DEFAULT_UART
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC-GND_YD-RP2040_4M_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_4M_BUTTON0_PIN 24
 
 
 // --- I2C ---
@@ -80,15 +80,11 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #define PICO_FLASH_SPI_CLKDIV 2
 #endif
 
-// These boards come in 2, 4, 8, 16 MB Flash.
+// These boards come in 4, 8, 16 MB Flash.
 pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (4 * 1024 * 1024))
 #ifndef PICO_FLASH_SIZE_BYTES
 #define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
 #endif
-
-// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
-// Not used on this board as GPIO23 is the RGB LED pin.
-//#define PICO_SMPS_MODE_PIN 23
 
 #ifndef PICO_RP2040_B2_SUPPORTED
 #define PICO_RP2040_B2_SUPPORTED 1

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC_GND_YD_RP2040_4M_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_BUTTON0_PIN 24
 
 
 // --- I2C ---

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
@@ -95,10 +95,5 @@ pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (4 * 1024 * 1024))
 #define PICO_VBUS_PIN 24
 #endif
 
-// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
-// There is an example in adc/read_vsys in pico-examples.
-#ifndef PICO_VSYS_PIN
-#define PICO_VSYS_PIN 29
-#endif
 
 #endif

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC_GND_YD_RP2040_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_BUTTON_PIN 24
 
 
 // --- I2C ---

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
@@ -36,6 +36,10 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // --- RGB (NeoPixel) LED ---
+// NOTE: Some YD-RP2040 boards have a link above the RGB
+// marked "RGB" or "R56" or "R58" or similar. On those you
+// have to solder a tiny wire across the link, carefully,
+// to enable the RGB LED.
 #ifndef PICO_DEFAULT_WS2812_PIN
 #define PICO_DEFAULT_WS2812_PIN 23
 #endif
@@ -88,11 +92,6 @@ pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (4 * 1024 * 1024))
 
 #ifndef PICO_RP2040_B2_SUPPORTED
 #define PICO_RP2040_B2_SUPPORTED 1
-#endif
-
-// The GPIO Pin used to read VBUS to determine if the device is battery powered.
-#ifndef PICO_VBUS_PIN
-#define PICO_VBUS_PIN 24
 #endif
 
 

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_4m.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/pico.h"
+
+#ifndef _BOARDS_VCC-GND_YD-RP2040_4M_H
+#define _BOARDS_VCC-GND_YD-RP2040_4M_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2040)
+
+// For board detection
+#define VCC-GND_YD-RP2040_4M
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- RGB (NeoPixel) LED ---
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 23
+#endif
+
+// User Button
+#define VCC-GND_YD-RP2040_4M_BUTTON0_PIN 24
+
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// These boards come in 2, 4, 8, 16 MB Flash.
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (4 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+// Not used on this board as GPIO23 is the RGB LED pin.
+//#define PICO_SMPS_MODE_PIN 23
+
+#ifndef PICO_RP2040_B2_SUPPORTED
+#define PICO_RP2040_B2_SUPPORTED 1
+#endif
+
+// The GPIO Pin used to read VBUS to determine if the device is battery powered.
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+#endif

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
@@ -95,10 +95,5 @@ pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (8 * 1024 * 1024))
 #define PICO_VBUS_PIN 24
 #endif
 
-// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
-// There is an example in adc/read_vsys in pico-examples.
-#ifndef PICO_VSYS_PIN
-#define PICO_VSYS_PIN 29
-#endif
 
 #endif

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
@@ -9,15 +9,15 @@
 //       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
 // -----------------------------------------------------
 
-// This header may be included by other board headers as "boards/pico.h"
+// This header may be included by other board headers as "boards/vcc-gnd_yd-rp2040_8m.h"
 
-#ifndef _BOARDS_VCC-GND_YD-RP2040_8M_H
-#define _BOARDS_VCC-GND_YD-RP2040_8M_H
+#ifndef _BOARDS_VCC_GND_YD_RP2040_8M_H
+#define _BOARDS_VCC_GND_YD_RP2040_8M_H
 
 pico_board_cmake_set(PICO_PLATFORM, rp2040)
 
 // For board detection
-#define VCC-GND_YD-RP2040_8M
+#define VCC_GND_YD_RP2040_8M
 
 // --- UART ---
 #ifndef PICO_DEFAULT_UART
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC-GND_YD-RP2040_8M_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_8M_BUTTON0_PIN 24
 
 
 // --- I2C ---
@@ -80,15 +80,11 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #define PICO_FLASH_SPI_CLKDIV 2
 #endif
 
-// These boards come in 2, 4, 8, 16 MB Flash.
+// These boards come in 4, 8, 16 MB Flash.
 pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (8 * 1024 * 1024))
 #ifndef PICO_FLASH_SIZE_BYTES
 #define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
 #endif
-
-// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
-// Not used on this board as GPIO23 is the RGB LED pin.
-//#define PICO_SMPS_MODE_PIN 23
 
 #ifndef PICO_RP2040_B2_SUPPORTED
 #define PICO_RP2040_B2_SUPPORTED 1

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// This header may be included by other board headers as "boards/pico.h"
+
+#ifndef _BOARDS_VCC-GND_YD-RP2040_8M_H
+#define _BOARDS_VCC-GND_YD-RP2040_8M_H
+
+pico_board_cmake_set(PICO_PLATFORM, rp2040)
+
+// For board detection
+#define VCC-GND_YD-RP2040_8M
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// --- LED ---
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+// --- RGB (NeoPixel) LED ---
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 23
+#endif
+
+// User Button
+#define VCC-GND_YD-RP2040_8M_BUTTON0_PIN 24
+
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// These boards come in 2, 4, 8, 16 MB Flash.
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (8 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (8 * 1024 * 1024)
+#endif
+
+// Drive high to force power supply into PWM mode (lower ripple on 3V3 at light loads)
+// Not used on this board as GPIO23 is the RGB LED pin.
+//#define PICO_SMPS_MODE_PIN 23
+
+#ifndef PICO_RP2040_B2_SUPPORTED
+#define PICO_RP2040_B2_SUPPORTED 1
+#endif
+
+// The GPIO Pin used to read VBUS to determine if the device is battery powered.
+#ifndef PICO_VBUS_PIN
+#define PICO_VBUS_PIN 24
+#endif
+
+// The GPIO Pin used to monitor VSYS. Typically you would use this with ADC.
+// There is an example in adc/read_vsys in pico-examples.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29
+#endif
+
+#endif

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
@@ -36,6 +36,10 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // --- RGB (NeoPixel) LED ---
+// NOTE: Some YD-RP2040 boards have a link above the RGB
+// marked "RGB" or "R56" or "R58" or similar. On those you
+// have to solder a tiny wire across the link, carefully,
+// to enable the RGB LED.
 #ifndef PICO_DEFAULT_WS2812_PIN
 #define PICO_DEFAULT_WS2812_PIN 23
 #endif
@@ -88,11 +92,6 @@ pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (8 * 1024 * 1024))
 
 #ifndef PICO_RP2040_B2_SUPPORTED
 #define PICO_RP2040_B2_SUPPORTED 1
-#endif
-
-// The GPIO Pin used to read VBUS to determine if the device is battery powered.
-#ifndef PICO_VBUS_PIN
-#define PICO_VBUS_PIN 24
 #endif
 
 

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC_GND_YD_RP2040_8M_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_BUTTON0_PIN 24
 
 
 // --- I2C ---

--- a/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
+++ b/src/boards/include/boards/vcc-gnd_yd-rp2040_8m.h
@@ -41,7 +41,7 @@ pico_board_cmake_set(PICO_PLATFORM, rp2040)
 #endif
 
 // User Button
-#define VCC_GND_YD_RP2040_BUTTON0_PIN 24
+#define VCC_GND_YD_RP2040_BUTTON_PIN 24
 
 
 // --- I2C ---


### PR DESCRIPTION
Added three new VCC-GND YD-RP2040 boards to cover the 4M, 8M and 16M flash sizes.

Fixes #2873.

I have added three new board files:

* `vcc_gnd_yd-rp2040_4m.h` for the 4M flash variant.
* `vcc_gnd_yd-rp2040_8m.h` for the 8M flash variant.
* `vcc_gnd_yd-rp2040_16m.h` for the 16M flash variant.

* There is an RGB LED on GPIO-23.
* There is a user button on GPIO-24.
* The 3v3_EN pin on the Pico, is apparently not implemented. Physical pin is GPIO-23.
* ADC_VREF is not brought out to physical pin 35 unless a link is soldered. Without the link, it's GPIO-29/ADC3.
* The RGB LED is not usable unless a link is soldered. GPIO-23 is a normal GPIO pin without the link.
* The chip on these boards appears to be the B2 release of the RP2040. (PICO_RP2040_B2_SUPPORTED is defined.)

These are my first attempts at board definitions, please be gentle!

Thanks.
