### PR TITLE
Update Clang toolchain used by Bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,34 +69,34 @@ http_archive(
 http_archive(
     name = "clang_linux-x86_64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "82302f8f0d9cb1062e60756147403c1525e965e1d7b777fab8076c74c7a5a19b",
+    sha256 = "7a4f040d87461825a507eaeaa4d51e3dcc685a238df5c4daa1cd3a6ad7c853cd",
     type = "zip",
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/linux-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/linux-amd64/+/git_revision:9431920bfaee50f4b1552fc01ea081a5c18a5a3b",
 )
 
 http_archive(
     name = "clang_win-x86_64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "2e9b8ac889838754e5305b6fd73c7bba7a6ec7364f1ce8ac60268b6d3bc61e6c",
+    sha256 = "e333c66cbdc1a981aef0be34d7b582db4636e72ae89ebd9809da4e91fa2c9fe0",
     type = "zip",
     # Windows doesn't like `:` in the produced filename, so replace it with `%3A`.
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/windows-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c".replace("git_revision:", "git_revision%3A"),
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/windows-amd64/+/git_revision:9431920bfaee50f4b1552fc01ea081a5c18a5a3b".replace("git_revision:", "git_revision%3A"),
 )
 
 http_archive(
     name = "clang_mac-x86_64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "d3f2ef6f391ef66141092cfdf07facd18d2587a25616e1251e6e6b13b05ab3df",
+    sha256 = "860920075ab45e12a36d3da0f871a28ddca71ae95b02bc1fac8f8a23a6c831c7",
     type = "zip",
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-amd64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-amd64/+/git_revision:9431920bfaee50f4b1552fc01ea081a5c18a5a3b",
 )
 
 http_archive(
     name = "clang_mac-aarch64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "61109b8464e9213ef8b9bfe55ce56298b94d4c66eaea308cf2b6556b0b85429e",
+    sha256 = "717d41447ff1a947dd376feddb9798155b575f7e642a5cd4582d0f3dad9067d4",
     type = "zip",
-    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:910be4ff90d7d07bd4518ea03b85c0974672bf9c",
+    url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:9431920bfaee50f4b1552fc01ea081a5c18a5a3b",
 )
 
 new_git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -94,7 +94,7 @@ http_archive(
 http_archive(
     name = "clang_mac-aarch64",
     build_file = "//bazel/toolchain:clang.BUILD",
-    sha256 = "717d41447ff1a947dd376feddb9798155b575f7e642a5cd4582d0f3dad9067d4",
+    sha256 = "7c27b1e73cc98c547fdfb104f7071ff29ba1ef132b0e9f8cf802222db480e771",
     type = "zip",
     url = "https://chrome-infra-packages.appspot.com/dl/fuchsia/third_party/clang/mac-arm64/+/git_revision:9431920bfaee50f4b1552fc01ea081a5c18a5a3b",
 )


### PR DESCRIPTION
The Clang toolchain is updated to a newer revision  9431920bfaee50f4b1552fc01ea081a5c18a5a3b from March 20, 2026.
    
Fixes #2859
