### PR TITLE
fix: Add missing block_cipher.c to pico_mbedtls

### DIFF
--- a/src/rp2_common/pico_mbedtls/CMakeLists.txt
+++ b/src/rp2_common/pico_mbedtls/CMakeLists.txt
@@ -37,7 +37,6 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
             asn1write.c
             base64.c
             bignum.c
-            block_cipher.c
             camellia.c
             ccm.c
             chacha20.c
@@ -122,6 +121,14 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
                 sha3.c
             )
         endif()
+
+        # block_cipher.c was only added with v3.6.0. Support versions without it as well
+        if (EXISTS ${PICO_MBEDTLS_PATH}/library/block_cipher.c)
+            list(APPEND src_crypto
+                block_cipher.c
+            )
+        endif()
+
         list(TRANSFORM src_crypto PREPEND ${PICO_MBEDTLS_PATH}/library/)
         set(src_crypto ${src_crypto} PARENT_SCOPE)
     endfunction()

--- a/src/rp2_common/pico_mbedtls/CMakeLists.txt
+++ b/src/rp2_common/pico_mbedtls/CMakeLists.txt
@@ -37,6 +37,7 @@ if (EXISTS ${PICO_MBEDTLS_PATH}/${MBEDTLS_TEST_PATH})
             asn1write.c
             base64.c
             bignum.c
+            block_cipher.c
             camellia.c
             ccm.c
             chacha20.c


### PR DESCRIPTION
Fixes #2882

It looks like the reference to `block_cipher.c` was missed in pico_mbedtls.

I did NOT recompile any examples with this changes but the file exists on disk and will do nothing if the relevant `#define` is not set in `mbedtls_config.h`