### PR TITLE
Add bazel load() directive for CcInfo

### DIFF
--- a/bazel/util/pico_linker_scripts.bzl
+++ b/bazel/util/pico_linker_scripts.bzl
@@ -1,4 +1,6 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _linker_scripts_impl(ctx):
     link_flags = []


### PR DESCRIPTION
Newer Bazel versions removed the CcInfo symbol. Add a load() from rules_cc in pico_linker_scripts.bzl. Was done with buildifier so cc_common was also added.

Fixes: #2902