### PR TITLE
Add dummy member to picoboot_exec2_cmd

### DIFF
--- a/src/common/boot_picoboot_headers/include/boot/picoboot.h
+++ b/src/common/boot_picoboot_headers/include/boot/picoboot.h
@@ -110,6 +110,7 @@ struct __packed picoboot_range_cmd {
 
 // remains defined for backwards compatibility with RP2350 bootrom builds
 struct __packed picoboot_exec2_cmd {
+    uint32_t dummy;
 };
 
 enum picoboot_exclusive_type {


### PR DESCRIPTION
The picotool Windows MSVC build throws this error
```
src\common\boot_picoboot_headers\include\boot\picoboot.h(113,1): error C2016: C requires that a struct or union have at least one member
```
This is due to the `picoboot_exec2_cmd` struct now being empty. The fix is to add a dummy member to the struct