### PR TITLE
Add `gpio_init_mask64` function

### DIFF
--- a/src/host/hardware_gpio/gpio.c
+++ b/src/host/hardware_gpio/gpio.c
@@ -213,6 +213,11 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(__unused uint gpio_mask) {
 
 }
 
+PICO_WEAK_FUNCTION_DEF(gpio_init_mask64)
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask64)(__unused uint64_t gpio_mask) {
+
+}
+
 PICO_WEAK_FUNCTION_DEF(gpio_get)
 bool PICO_WEAK_FUNCTION_IMPL_NAME(gpio_get)(uint gpio) {
     check_gpio_param(gpio);

--- a/src/host/hardware_gpio/gpio.c
+++ b/src/host/hardware_gpio/gpio.c
@@ -209,7 +209,7 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_deinit)(uint gpio) {
 }
 
 PICO_WEAK_FUNCTION_DEF(gpio_init_mask)
-void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(__unused uint gpio_mask) {
+void PICO_WEAK_FUNCTION_IMPL_NAME(gpio_init_mask)(__unused uint32_t gpio_mask) {
 
 }
 

--- a/src/host/hardware_gpio/include/hardware/gpio.h
+++ b/src/host/hardware_gpio/include/hardware/gpio.h
@@ -148,7 +148,7 @@ void gpio_init(uint gpio);
 
 void gpio_deinit(uint gpio);
 
-void gpio_init_mask(uint gpio_mask);
+void gpio_init_mask(uint32_t gpio_mask);
 void gpio_init_mask64(uint64_t gpio_mask);
 
 // ----------------------------------------------------------------------------

--- a/src/host/hardware_gpio/include/hardware/gpio.h
+++ b/src/host/hardware_gpio/include/hardware/gpio.h
@@ -149,6 +149,7 @@ void gpio_init(uint gpio);
 void gpio_deinit(uint gpio);
 
 void gpio_init_mask(uint gpio_mask);
+void gpio_init_mask64(uint64_t gpio_mask);
 
 // ----------------------------------------------------------------------------
 // Input

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -275,7 +275,7 @@ void gpio_init(uint gpio) {
     gpio_set_dir(gpio, GPIO_IN);
     gpio_put(gpio, 0);
     gpio_set_function(gpio, GPIO_FUNC_SIO);
-}
+}7
 
 void gpio_deinit(uint gpio) {
     gpio_set_function(gpio, GPIO_FUNC_NULL);
@@ -292,11 +292,12 @@ void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
 }
 
 void gpio_init_mask(uint32_t gpio_mask) {
-    gpio_set_dir_masked(gpio_mask, GPIO_IN);
+    gpio_set_dir_in_masked(gpio_mask);
     gpio_clr_mask(gpio_mask);
     gpio_set_function_masked(gpio_mask, GPIO_FUNC_SIO);
 }
 
+// these functions are provided (in gpio.h) as inlined calls to the 32 bit versions if we have <= 32 GPIOs
 #if NUM_BANK0_GPIOS > 32
 void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
     for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
@@ -308,9 +309,8 @@ void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
     }
 }
 
-// these functions collapse to the non 64 bit versions as inline funcs if we have < 32 GPIOs
 void gpio_init_mask64(uint64_t gpio_mask) {
-    gpio_set_dir_masked64(gpio_mask, GPIO_IN);
+    gpio_set_dir_in_masked64(gpio_mask);
     gpio_clr_mask64(gpio_mask);
     gpio_set_function_masked64(gpio_mask, GPIO_FUNC_SIO);
 }

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -282,25 +282,39 @@ void gpio_deinit(uint gpio) {
 }
 
 void gpio_init_mask(uint32_t gpio_mask) {
-    for(uint32_t i=0;i<NUM_BANK0_GPIOS;i++) {
+    for(uint i=0;i<NUM_BANK0_GPIOS;i++) {
         if (gpio_mask & 1) {
             gpio_init(i);
         }
         gpio_mask >>= 1;
+        if (!gpio_mask) break;
     }
 }
 
 void gpio_init_mask64(uint64_t gpio_mask) {
-    for(uint64_t i=0;i<NUM_BANK0_GPIOS;i++) {
-        if (gpio_mask & 1) {
+#if NUM_BANK0_GPIOS <= 32
+    // code is much smaller in this case, especially for Cortex-M0+ which is convenient since RP2040 has < 32 pins
+    uint32_t gpio_mask32 = (uint32_t)gpio_mask;
+    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
+        if (gpio_mask32 & 1u) {
+            gpio_init(i);
+        }
+        gpio_mask32 >>= 1;
+        if (!gpio_mask32) break;
+    }
+#else
+    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
+        if (gpio_mask & 1u) {
             gpio_init(i);
         }
         gpio_mask >>= 1;
+        if (!gpio_mask) break;
     }
+#endif
 }
 
 void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
-    for (uint i = 0; i < MIN(NUM_BANK0_GPIOS, 32u); i++) {
+    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
         if (gpio_mask & 1u) {
             gpio_set_function(i, fn);
         }
@@ -309,10 +323,23 @@ void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
 }
 
 void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
-    for (uint i = 0; i < MIN(NUM_BANK0_GPIOS, 64u); i++) {
+#if NUM_BANK0_GPIOS <= 32
+    // code is much smaller in this case, especially for Cortex-M0+ which is convenient since RP2040 has < 32 pins
+    uint32_t gpio_mask32 = (uint32_t)gpio_mask;
+    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
+        if (gpio_mask32 & 1u) {
+            gpio_set_function(i, fn);
+        }
+        gpio_mask32 >>= 1;
+        if (!gpio_mask32) break;
+    }
+#else
+    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
         if (gpio_mask & 1u) {
             gpio_set_function(i, fn);
         }
         gpio_mask >>= 1;
+        if (!gpio_mask) break;
     }
+#endif
 }

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -319,6 +319,7 @@ void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
             gpio_set_function(i, fn);
         }
         gpio_mask >>= 1;
+        if (!gpio_mask) break;
     }
 }
 

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -281,16 +281,6 @@ void gpio_deinit(uint gpio) {
     gpio_set_function(gpio, GPIO_FUNC_NULL);
 }
 
-void gpio_init_mask(uint32_t gpio_mask) {
-    for(uint i=0;i<NUM_BANK0_GPIOS;i++) {
-        if (gpio_mask & 1) {
-            gpio_init(i);
-        }
-        gpio_mask >>= 1;
-        if (!gpio_mask) break;
-    }
-}
-
 void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
     for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
         if (gpio_mask & 1u) {
@@ -301,18 +291,13 @@ void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
     }
 }
 
-#if NUM_BANK0_GPIOS > 32
-// these functions collapse to the non 64 bit versions as inline funcs if we have < 32 GPIOs
-void gpio_init_mask64(uint64_t gpio_mask) {
-    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
-        if (gpio_mask & 1u) {
-            gpio_init(i);
-        }
-        gpio_mask >>= 1;
-        if (!gpio_mask) break;
-    }
+void gpio_init_mask(uint32_t gpio_mask) {
+    gpio_set_dir_masked(gpio_mask, GPIO_IN);
+    gpio_clr_mask(gpio_mask);
+    gpio_set_function_masked(gpio_mask, GPIO_FUNC_SIO);
 }
 
+#if NUM_BANK0_GPIOS > 32
 void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
     for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
         if (gpio_mask & 1u) {
@@ -322,4 +307,12 @@ void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
         if (!gpio_mask) break;
     }
 }
+
+// these functions collapse to the non 64 bit versions as inline funcs if we have < 32 GPIOs
+void gpio_init_mask64(uint64_t gpio_mask) {
+    gpio_set_dir_masked64(gpio_mask, GPIO_IN);
+    gpio_clr_mask64(gpio_mask);
+    gpio_set_function_masked64(gpio_mask, GPIO_FUNC_SIO);
+}
+
 #endif

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -301,7 +301,7 @@ void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
     }
 }
 
-#if NUM_BANK0_GPIOS >= 32
+#if NUM_BANK0_GPIOS > 32
 // these functions collapse to the non 64 bit versions as inline funcs if we have < 32 GPIOs
 void gpio_init_mask64(uint64_t gpio_mask) {
     for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -290,6 +290,15 @@ void gpio_init_mask(uint gpio_mask) {
     }
 }
 
+void gpio_init_mask64(uint64_t gpio_mask) {
+    for(uint64_t i=0;i<NUM_BANK0_GPIOS;i++) {
+        if (gpio_mask & 1) {
+            gpio_init(i);
+        }
+        gpio_mask >>= 1;
+    }
+}
+
 void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
     for (uint i = 0; i < MIN(NUM_BANK0_GPIOS, 32u); i++) {
         if (gpio_mask & 1u) {

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -275,7 +275,7 @@ void gpio_init(uint gpio) {
     gpio_set_dir(gpio, GPIO_IN);
     gpio_put(gpio, 0);
     gpio_set_function(gpio, GPIO_FUNC_SIO);
-}7
+}
 
 void gpio_deinit(uint gpio) {
     gpio_set_function(gpio, GPIO_FUNC_NULL);

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -281,8 +281,8 @@ void gpio_deinit(uint gpio) {
     gpio_set_function(gpio, GPIO_FUNC_NULL);
 }
 
-void gpio_init_mask(uint gpio_mask) {
-    for(uint i=0;i<NUM_BANK0_GPIOS;i++) {
+void gpio_init_mask(uint32_t gpio_mask) {
+    for(uint32_t i=0;i<NUM_BANK0_GPIOS;i++) {
         if (gpio_mask & 1) {
             gpio_init(i);
         }

--- a/src/rp2_common/hardware_gpio/gpio.c
+++ b/src/rp2_common/hardware_gpio/gpio.c
@@ -291,28 +291,6 @@ void gpio_init_mask(uint32_t gpio_mask) {
     }
 }
 
-void gpio_init_mask64(uint64_t gpio_mask) {
-#if NUM_BANK0_GPIOS <= 32
-    // code is much smaller in this case, especially for Cortex-M0+ which is convenient since RP2040 has < 32 pins
-    uint32_t gpio_mask32 = (uint32_t)gpio_mask;
-    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
-        if (gpio_mask32 & 1u) {
-            gpio_init(i);
-        }
-        gpio_mask32 >>= 1;
-        if (!gpio_mask32) break;
-    }
-#else
-    for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
-        if (gpio_mask & 1u) {
-            gpio_init(i);
-        }
-        gpio_mask >>= 1;
-        if (!gpio_mask) break;
-    }
-#endif
-}
-
 void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
     for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
         if (gpio_mask & 1u) {
@@ -323,18 +301,19 @@ void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn) {
     }
 }
 
-void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
-#if NUM_BANK0_GPIOS <= 32
-    // code is much smaller in this case, especially for Cortex-M0+ which is convenient since RP2040 has < 32 pins
-    uint32_t gpio_mask32 = (uint32_t)gpio_mask;
+#if NUM_BANK0_GPIOS >= 32
+// these functions collapse to the non 64 bit versions as inline funcs if we have < 32 GPIOs
+void gpio_init_mask64(uint64_t gpio_mask) {
     for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
-        if (gpio_mask32 & 1u) {
-            gpio_set_function(i, fn);
+        if (gpio_mask & 1u) {
+            gpio_init(i);
         }
-        gpio_mask32 >>= 1;
-        if (!gpio_mask32) break;
+        gpio_mask >>= 1;
+        if (!gpio_mask) break;
     }
-#else
+}
+
+void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
     for (uint i = 0; i < NUM_BANK0_GPIOS; i++) {
         if (gpio_mask & 1u) {
             gpio_set_function(i, fn);
@@ -342,5 +321,5 @@ void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
         gpio_mask >>= 1;
         if (!gpio_mask) break;
     }
-#endif
 }
+#endif

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -859,6 +859,16 @@ void gpio_deinit(uint gpio);
  * \param gpio_mask Mask with 1 bit per GPIO number to initialize
  */
 void gpio_init_mask(uint gpio_mask);
+
+/*! \brief Initialise multiple GPIOs (enabled I/O and set func to GPIO_FUNC_SIO)
+ *  \ingroup hardware_gpio
+ *
+ * Clear the output enable (i.e. set to input).
+ * Clear any output value.
+ *
+ * \param gpio_mask Mask with 1 bit per GPIO number to initialize
+ */
+void gpio_init_mask64(uint64_t gpio_mask);
 // ----------------------------------------------------------------------------
 // Input
 // ----------------------------------------------------------------------------

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -49,7 +49,7 @@ extern "C" {
  *
  * \if rp2350_specific
  * The number of GPIO pins available depends on the package. There are 30 user GPIOs in bank 0 in the QFN-60 package (RP2350A), or 48 user GPIOs
- * in the QFN-80 package. Bank 1 contains the 6 QSPI pins and the USB DP/DM pins.
+ * in the QFN-80 package (RP2350B). Bank 1 contains the 6 QSPI pins and the USB DP/DM pins.
  * \endif
  *
  * All GPIOs support digital input and output, but a subset can also be used as inputs to the chip’s Analogue to Digital

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -274,7 +274,13 @@ void gpio_set_function_masked(uint32_t gpio_mask, gpio_function_t fn);
  * \param gpio_mask Mask with 1 bit per GPIO number to set the function for
  * \param fn Which GPIO function select to use from list \ref gpio_function_t
 */
+#if NUM_BANK0_GPIOS <= 32
+static inline void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn) {
+    gpio_set_function_masked((uint32_t)gpio_mask, fn);
+}
+#else
 void gpio_set_function_masked64(uint64_t gpio_mask, gpio_function_t fn);
+#endif
 
 /*! \brief Determine current GPIO function
  *  \ingroup hardware_gpio
@@ -868,7 +874,13 @@ void gpio_init_mask(uint32_t gpio_mask);
  *
  * \param gpio_mask Mask with 1 bit per GPIO number to initialize
  */
+#if NUM_BANK0_GPIOS <= 32
+static inline void gpio_init_mask64(uint64_t gpio_mask) {
+    gpio_init_mask((uint32_t)gpio_mask);
+}
+#else
 void gpio_init_mask64(uint64_t gpio_mask);
+#endif
 // ----------------------------------------------------------------------------
 // Input
 // ----------------------------------------------------------------------------

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -41,23 +41,23 @@ extern "C" {
  * \brief General Purpose Input/Output (GPIO) API
  *
  * RP-series microcontrollers have two banks of General Purpose Input / Output (GPIO) pins, which are assigned as follows:
- * 
+ *
  * \if rp2040_specific
- * RP2040 has 30 user GPIO pins in bank 0, and 6 QSPI pins in the QSPI bank 1 (QSPI_SS, QSPI_SCLK and QSPI_SD0 to QSPI_SD3). The QSPI 
- * pins are used to execute code from an external flash device, leaving the User bank (GPIO0 to GPIO29) for the programmer to use. 
+ * RP2040 has 30 user GPIO pins in bank 0, and 6 QSPI pins in the QSPI bank 1 (QSPI_SS, QSPI_SCLK and QSPI_SD0 to QSPI_SD3). The QSPI
+ * pins are used to execute code from an external flash device, leaving the User bank (GPIO0 to GPIO29) for the programmer to use.
  * \endif
- * 
+ *
  * \if rp2350_specific
- * The number of GPIO pins available depends on the package. There are 30 user GPIOs in bank 0 in the QFN-60 package (RP2350A), or 48 user GPIOs 
+ * The number of GPIO pins available depends on the package. There are 30 user GPIOs in bank 0 in the QFN-60 package (RP2350A), or 48 user GPIOs
  * in the QFN-80 package. Bank 1 contains the 6 QSPI pins and the USB DP/DM pins.
  * \endif
- *  
+ *
  * All GPIOs support digital input and output, but a subset can also be used as inputs to the chip’s Analogue to Digital
  * Converter (ADC). The allocation of GPIO pins to the ADC depends on the packaging.
- * 
+ *
  * RP2040 and RP2350 QFN-60 GPIO, ADC pins are 26-29.
  * RP2350 QFN-80, ADC pins are 40-47.
- *  
+ *
  * Each GPIO can be controlled directly by software running on the processors, or by a number of other functional blocks.
  *
  * The function allocated to each GPIO is selected by calling the \ref gpio_set_function function. \note Not all functions

--- a/src/rp2_common/hardware_gpio/include/hardware/gpio.h
+++ b/src/rp2_common/hardware_gpio/include/hardware/gpio.h
@@ -858,7 +858,7 @@ void gpio_deinit(uint gpio);
  *
  * \param gpio_mask Mask with 1 bit per GPIO number to initialize
  */
-void gpio_init_mask(uint gpio_mask);
+void gpio_init_mask(uint32_t gpio_mask);
 
 /*! \brief Initialise multiple GPIOs (enabled I/O and set func to GPIO_FUNC_SIO)
  *  \ingroup hardware_gpio


### PR DESCRIPTION
Add `gpio_init_mask64` function mirroring the other `mask64`/`masked64` GPIO functions used by RP2350B with more than 32 GPIO's.

See #2643
