### PR TITLE
Add PICO_TEST_FILE_GENERATOR and PICO_TEST_ target properties

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ if (PICO_TEST_FILE_GENERATOR AND EXISTS ${PICO_TEST_FILE_GENERATOR})
     #   Can be used to force failure even when the test prints the success string
     # - PICO_TEST_BUDDY_FILE: File to run on buddy device for the test (default is NONE)
     #   For example, low power dormant tests on RP2040 require rtc_clksrc running on the buddy device
+    #   This can either be a path relative to the test target, or an absolute path
     # - PICO_TEST_SKIP_IN_CI: Whether to skip the test in ci (default is FALSE)
     #   If TRUE, the test is not included in the ci test suite
     include(${PICO_TEST_FILE_GENERATOR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,3 +16,25 @@ if (PICO_ON_DEVICE)
     add_subdirectory(pico_sha256_test)
     add_subdirectory(pico_async_context_test)
 endif()
+
+# PICO_TEST_FILE_GENERATOR: Path to the a CMake script to generate test files for ci
+if (DEFINED ENV{PICO_TEST_FILE_GENERATOR} AND NOT PICO_TEST_FILE_GENERATOR)
+    set(PICO_TEST_FILE_GENERATOR $ENV{PICO_TEST_FILE_GENERATOR})
+    message("Using PICO_TEST_FILE_GENERATOR from environment ('${PICO_TEST_FILE_GENERATOR}')")
+endif()
+
+if (PICO_TEST_FILE_GENERATOR AND EXISTS ${PICO_TEST_FILE_GENERATOR})
+    # Include script file to generate test files for ci
+    # This can use the following extra target properties from the test targets:
+    # - PICO_TEST_TIMEOUT: Timeout in seconds for the test (default is 5)
+    #   Maximum time the test is allowed to run for
+    # - PICO_TEST_SUCCESS_STRING: Success string for the test (default is "PASSED")
+    #   If this string is printed by the test, the test is considered successful
+    # - PICO_TEST_FAILURE_STRING: Failure string for the test (default is "FAILURE_STRING")
+    #   Can be used to force failure even when the test prints the success string
+    # - PICO_TEST_BUDDY_FILE: File to run on buddy device for the test (default is NONE)
+    #   For example, low power dormant tests on RP2040 require rtc_clksrc running on the buddy device
+    # - PICO_TEST_SKIP_IN_CI: Whether to skip the test in ci (default is FALSE)
+    #   If TRUE, the test is not included in the ci test suite
+    include(${PICO_TEST_FILE_GENERATOR})
+endif()

--- a/test/kitchen_sink/CMakeLists.txt
+++ b/test/kitchen_sink/CMakeLists.txt
@@ -192,6 +192,7 @@ add_executable(kitchen_sink_printf_none ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c
 target_link_libraries(kitchen_sink_printf_none kitchen_sink_libs kitchen_sink_options)
 pico_add_extra_outputs(kitchen_sink_printf_none)
 pico_set_printf_implementation(kitchen_sink_printf_none none)
+set_target_properties(kitchen_sink_printf_none PROPERTIES PICO_TEST_SUCCESS_STRING "printf support is disabled")
 
 if (NOT KITCHEN_SINK_NO_BINARY_TYPE_VARIANTS)
     add_executable(kitchen_sink_copy_to_ram ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c)

--- a/test/pico_divider_test/CMakeLists.txt
+++ b/test/pico_divider_test/CMakeLists.txt
@@ -8,7 +8,8 @@ if (PICO_ON_DEVICE)
     add_executable(pico_divider_test
             pico_divider_test.c
             )
-
+    # Skip this test in ci as it never finishes - it ends in an infinite loop in test_random()
+    set_target_properties(pico_divider_test PROPERTIES PICO_TEST_SKIP_IN_CI TRUE)
     target_link_libraries(pico_divider_test pico_stdlib)
 
     if (PICO_RP2040)
@@ -30,6 +31,7 @@ if (PICO_ON_DEVICE)
     target_link_libraries(pico_divider_nesting_test_core INTERFACE pico_stdlib hardware_dma)
 
     add_executable(pico_divider_nesting_test_with_dirty_check)
+    set_target_properties(pico_divider_nesting_test_with_dirty_check PROPERTIES PICO_TEST_TIMEOUT "15")
     target_link_libraries(pico_divider_nesting_test_with_dirty_check pico_divider_nesting_test_core)
     if (PICO_RP2040)
         pico_set_divider_implementation(pico_divider_nesting_test_with_dirty_check hardware)
@@ -37,6 +39,7 @@ if (PICO_ON_DEVICE)
     pico_add_extra_outputs(pico_divider_nesting_test_with_dirty_check)
 
     add_executable(pico_divider_nesting_test_with_disable_irq)
+    set_target_properties(pico_divider_nesting_test_with_disable_irq PROPERTIES PICO_TEST_TIMEOUT "15")
     target_link_libraries(pico_divider_nesting_test_with_disable_irq pico_divider_nesting_test_core)
     target_compile_definitions(pico_divider_nesting_test_with_disable_irq PRIVATE
             PICO_DIVIDER_DISABLE_INTERRUPTS=1)

--- a/test/pico_float_test/CMakeLists.txt
+++ b/test/pico_float_test/CMakeLists.txt
@@ -26,7 +26,6 @@ if (PICO_RISCV)
     target_link_libraries(pico_float_test PRIVATE pico_float pico_stdlib)
     target_include_directories(pico_float_test PRIVATE ${CMAKE_CURRENT_LIST_DIR})
     pico_add_extra_outputs(pico_float_test)
-    set_target_properties(pico_float_test PROPERTIES PICO_TEST_SUCCESS_STRING "Well done, you can relax now")
 
     # pico_enable_stdio_usb(pico_float_test 1)
     # pico_enable_stdio_uart(pico_float_test 0)
@@ -139,7 +138,6 @@ if (PICO_RP2350 AND NOT PICO_RISCV)
     add_executable(m33
             m33.c
     )
-    set_target_properties(m33 PROPERTIES PICO_TEST_SUCCESS_STRING "Pass")
     target_compile_definitions(m33 PRIVATE
             PICO_USE_CRT_PRINTF=1 # want full precision output
             PICO_FLOAT_PROPAGATE_NANS=1

--- a/test/pico_float_test/CMakeLists.txt
+++ b/test/pico_float_test/CMakeLists.txt
@@ -26,6 +26,7 @@ if (PICO_RISCV)
     target_link_libraries(pico_float_test PRIVATE pico_float pico_stdlib)
     target_include_directories(pico_float_test PRIVATE ${CMAKE_CURRENT_LIST_DIR})
     pico_add_extra_outputs(pico_float_test)
+    set_target_properties(pico_float_test PROPERTIES PICO_TEST_SUCCESS_STRING "Well done, you can relax now")
 
     # pico_enable_stdio_usb(pico_float_test 1)
     # pico_enable_stdio_uart(pico_float_test 0)
@@ -138,7 +139,7 @@ if (PICO_RP2350 AND NOT PICO_RISCV)
     add_executable(m33
             m33.c
     )
-
+    set_target_properties(m33 PROPERTIES PICO_TEST_SUCCESS_STRING "Pass")
     target_compile_definitions(m33 PRIVATE
             PICO_USE_CRT_PRINTF=1 # want full precision output
             PICO_FLOAT_PROPAGATE_NANS=1

--- a/test/pico_float_test/m33.c
+++ b/test/pico_float_test/m33.c
@@ -248,6 +248,6 @@ int main() {
     checkd(m33cf_dsqrt_fast(0x030a70b7171e4c51ULL),0x217d166dff1d7836ULL);
     checkd(m33cf_dsqrt_fast(0x5284145a8007521fULL),0x493959345ef6a420ULL);
 
-    if(rc==0) puts("Pass");
+    if(rc==0) puts("PASSED");
     else      puts("Fail");
 }

--- a/test/pico_float_test/pico_float_test_hazard3.c
+++ b/test/pico_float_test/pico_float_test_hazard3.c
@@ -203,7 +203,7 @@ int main() {
 
     printf("%d tests failed.\n", failed);
     if (failed == 0) {
-        printf("Well done, you can relax now\n");
+        printf("PASSED\n");
     }
 done:
     while (true) {asm volatile ("wfi\n");} // keep USB stdout alive

--- a/test/pico_stdlib_test/CMakeLists.txt
+++ b/test/pico_stdlib_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(pico_stdlib_test pico_stdlib_test.c)
-
+set_target_properties(pico_stdlib_test PROPERTIES PICO_TEST_TIMEOUT "15")
 target_compile_definitions(pico_stdlib_test PRIVATE
         #PICO_ENTER_USB_BOOT_ON_EXIT=1
 )

--- a/test/pico_time_test/CMakeLists.txt
+++ b/test/pico_time_test/CMakeLists.txt
@@ -1,5 +1,6 @@
 if (NOT PICO_TIME_NO_ALARM_SUPPORT)
     add_executable(pico_time_test pico_time_test.c)
+    set_target_properties(pico_time_test PROPERTIES PICO_TEST_TIMEOUT "20")
     target_compile_definitions(pico_time_test PRIVATE
             PICO_TIME_DEFAULT_ALARM_POOL_MAX_TIMERS=250
     )


### PR DESCRIPTION
Add `PICO_TEST_FILE_GENERATOR` option, along with `PICO_TEST_` target properties to aid in generation of lists of tests for running in CI.

This allows pointing to a script file with `-DPICO_TEST_FILE_GENERATOR=/path/to/my_test_generator.cmake`, and that script file can generate JSON (or whatever format you want) listing whatever the CI runner needs to know.

The `PICO_TEST_` target properties help that generator understand what certain tests do, such as what string they print on success (`PICO_TEST_SUCCESS_STRING`) or how long they are expected to take (`PICO_TEST_TIMEOUT`). The script file can also access the usual target properties such as `PICO_TARGET_STDIO_USB` or `PICO_TARGET_BINARY_TYPE` if it needs that information, so those don't need to be added as separate `PICO_TEST_` properties.

This should not affect normal SDK builds, as the file is only included when it is specified as an environment variable or on the command line. I haven't added a `PICO_CMAKE_CONFIG` for it as I don't think it should be documented in the SDK PDF, as this is primarily for internal use.