### PR TITLE
Fix riscv hardware_exception handlers

### DIFF
--- a/src/rp2_common/hardware_exception/exception.c
+++ b/src/rp2_common/hardware_exception/exception.c
@@ -12,7 +12,7 @@
 static bool exception_is_compile_time_default(exception_handler_t handler) {
 #ifdef __riscv
     extern char __unhandled_exception;
-    return (uintptr_t)handler == (uintptr_t)__unhandled_exception;
+    return (uintptr_t)handler == (uintptr_t)&__unhandled_exception;
 #else
     extern char __default_isrs_start;
     extern char __default_isrs_end;

--- a/test/kitchen_sink/kitchen_sink.c
+++ b/test/kitchen_sink/kitchen_sink.c
@@ -136,6 +136,8 @@ int main(void) {
     // this should compile as we are Cortex-M
     pico_default_asm ("SVC #3");
 #else
-    puts("PASSED");
+    exception_set_exclusive_handler(INSTR_ILLEGAL_EXCEPTION, svc_call);
+    // this is an illegal instruction
+    pico_default_asm (".word 0");
 #endif
 }


### PR DESCRIPTION
A missing `&` meant that `exception_set_exclusive_handler` always failed with a hard_assert - this fixes that, and adds a Risc-V exception to finish kitchen_sink to test it works, similar to the Arm svcall