### PR TITLE
Updates to RISC-V compiler selection (prefer gcc-riscv32-pico-elf and maximum -march opts)

### DIFF
--- a/cmake/preload/toolchains/pico_riscv_gcc.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc.cmake
@@ -4,6 +4,7 @@ set(PICO_DEFAULT_GCC_TRIPLE riscv32-pico-elf riscv32-unknown-elf riscv32-corev-e
 
 # ordered list of preferred flags to support
 set(PICO_COMMON_LANG_FLAGS_LIST
+        " -mcpu=hazard3-rp2350"
         " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32"
         " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32")
 include(${CMAKE_CURRENT_LIST_DIR}/util/pico_riscv_gcc_common.cmake)

--- a/cmake/preload/toolchains/pico_riscv_gcc.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc.cmake
@@ -1,7 +1,9 @@
 set(CMAKE_SYSTEM_PROCESSOR hazard3)
 
-set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
+set(PICO_DEFAULT_GCC_TRIPLE riscv32-pico-elf riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
 
-set(PICO_COMMON_LANG_FLAGS " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32")
-
+# ordered list of preferred flags to support
+set(PICO_COMMON_LANG_FLAGS_LIST
+        " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32"
+        " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32")
 include(${CMAKE_CURRENT_LIST_DIR}/util/pico_riscv_gcc_common.cmake)

--- a/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
@@ -3,7 +3,7 @@
 
 set(CMAKE_SYSTEM_PROCESSOR hazard3)
 
-set(PICO_DEFAULT_GCC_TRIPLE riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
+set(PICO_DEFAULT_GCC_TRIPLE riscv32-pico-elf riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
 
 set(PICO_COMMON_LANG_FLAGS " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32")
 

--- a/cmake/preload/toolchains/util/find_compiler.cmake
+++ b/cmake/preload/toolchains/util/find_compiler.cmake
@@ -41,7 +41,7 @@ function(pico_find_compiler_with_triples compiler_path triples compiler_suffix)
 endfunction()
 
 # If no single compiler flags variable is set, then choose first working compiler flags from a list.
-# This is done by doing a test compile via execute_proces, as we can't use check_c_compiler_flag
+# This is done by doing a test compile via execute_process, as we can't use check_c_compiler_flag
 # prior to project_setup.
 # Assuming the single flag variable is not already set, each of the flag_var_list flags are tried in order.
 # If the flags don't cause an error the single flag variable is set to the good flag value. If no valid flags
@@ -68,7 +68,7 @@ function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_l
                     return()
                 endif()
             endforeach()
-            message(FATAL_ERROR "No compiler that supported required compiler flags")
+            message(FATAL_ERROR "No compiler found that supports required compiler flags")
         else()
             if (${common_lang_flags_var_list})
                 message(FATAL_ERROR "Either ${common_lang_flags_var} or ${common_lang_flags_var_list} must be set")

--- a/cmake/preload/toolchains/util/find_compiler.cmake
+++ b/cmake/preload/toolchains/util/find_compiler.cmake
@@ -39,3 +39,40 @@ function(pico_find_compiler_with_triples compiler_path triples compiler_suffix)
     pico_find_compiler(${compiler_path} "${triples}")
     set(${compiler_path} ${${compiler_path}} PARENT_SCOPE)
 endfunction()
+
+# If no single compiler flags variable is set, then choose first working compiler flags from a list.
+# This is done by doing a test compile via execute_proces, as we can't use check_c_compiler_flag
+# prior to project_setup.
+# Assuming the single flag variable is not already set, each of the flag_var_list flags are tried in order.
+# If the flags don't cause an error the single flag variable is set to the good flag value. If no valid flags
+# are found, a fatal error is raised.
+function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_lang_flags_var_list)
+    # simplify logic by not complaining if both set, since CMake calls compiler setup repeatedly
+    if (NOT ${common_lang_flags_var})
+        if (${common_lang_flags_var_list})
+            if(CMAKE_HOST_WIN32)
+                set(NULL_DEVICE "NUL")
+            else()
+                set(NULL_DEVICE "/dev/null")
+            endif()
+            foreach(flags IN LISTS ${common_lang_flags_var_list})
+                separate_arguments(COMPILER_CMD NATIVE_COMMAND "${compiler_path} ${flags} -x c -c ${NULL_DEVICE} -o ${NULL_DEVICE}")
+                execute_process(
+                        COMMAND ${COMPILER_CMD}
+                        RESULT_VARIABLE COMPILE_FAILED
+                        ERROR_QUIET
+                )
+
+                if (NOT COMPILE_FAILED)
+                    set(${common_lang_flags_var} ${flags} PARENT_SCOPE)
+                    return()
+                endif()
+            endforeach()
+            message(FATAL_ERROR "No compiler that supported required compiler flags")
+        else()
+            if (${common_lang_flags_var_list})
+                message(FATAL_ERROR "Either ${common_lang_flags_var} or ${common_lang_flags_var_list} must be set")
+            endif()
+        endif()
+    endif()
+endfunction()

--- a/cmake/preload/toolchains/util/find_compiler.cmake
+++ b/cmake/preload/toolchains/util/find_compiler.cmake
@@ -56,7 +56,7 @@ function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_l
                 set(NULL_DEVICE "/dev/null")
             endif()
             foreach(flags IN LISTS ${common_lang_flags_var_list})
-                separate_arguments(COMPILER_CMD NATIVE_COMMAND "${compiler_path} ${flags} -x c -c ${CMAKE_CURRENT_LIST_DIR}/empty.c -o ${NULL_DEVICE}")
+                separate_arguments(COMPILER_CMD NATIVE_COMMAND "${compiler_path} ${flags} -x c -c \"${CMAKE_CURRENT_LIST_DIR}/empty.c\" -o ${NULL_DEVICE}")
                 execute_process(
                         COMMAND ${COMPILER_CMD}
                         RESULT_VARIABLE COMPILE_FAILED

--- a/cmake/preload/toolchains/util/find_compiler.cmake
+++ b/cmake/preload/toolchains/util/find_compiler.cmake
@@ -56,7 +56,7 @@ function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_l
                 set(NULL_DEVICE "/dev/null")
             endif()
             foreach(flags IN LISTS ${common_lang_flags_var_list})
-                separate_arguments(COMPILER_CMD NATIVE_COMMAND "${compiler_path} ${flags} -x c -c ${NULL_DEVICE} -o ${NULL_DEVICE}")
+                separate_arguments(COMPILER_CMD NATIVE_COMMAND "${compiler_path} ${flags} -x c -c ${CMAKE_CURRENT_LIST_DIR}/empty.c -o ${NULL_DEVICE}")
                 execute_process(
                         COMMAND ${COMPILER_CMD}
                         RESULT_VARIABLE COMPILE_FAILED

--- a/cmake/preload/toolchains/util/pico_gcc_common.cmake
+++ b/cmake/preload/toolchains/util/pico_gcc_common.cmake
@@ -23,6 +23,7 @@ set(ENV{_SAVED_PICO_GCC_TRIPLE} "${PICO_GCC_TRIPLE}")
 
 # Find GCC
 pico_find_compiler_with_triples(PICO_COMPILER_CC "${PICO_GCC_TRIPLE}" gcc)
+pico_choose_compiler_flags(${PICO_COMPILER_CC} PICO_COMMON_LANG_FLAGS PICO_COMMON_LANG_FLAGS_LIST)
 pico_find_compiler_with_triples(PICO_COMPILER_CXX "${PICO_GCC_TRIPLE}" g++)
 set(PICO_COMPILER_ASM "${PICO_COMPILER_CC}" CACHE INTERNAL "")
 pico_find_compiler_with_triples(PICO_OBJCOPY "${PICO_GCC_TRIPLE}" objcopy)

--- a/cmake/preload/toolchains/util/set_flags.cmake
+++ b/cmake/preload/toolchains/util/set_flags.cmake
@@ -3,6 +3,10 @@ option(PICO_DEOPTIMIZED_DEBUG "Build debug builds with -O0" 0)
 # PICO_CMAKE_CONFIG: PICO_DEBUG_INFO_IN_RELEASE, Include debug information in release builds, type=bool, default=1, group=build, docref=cmake-toolchain-config
 option(PICO_DEBUG_INFO_IN_RELEASE "Include debug info in release builds" 1)
 
+if (NOT PICO_COMMON_LANG_FLAGS)
+    message(FATAL_ERROR "PICO_COMMON_LANG_FLAGS not set")
+endif()
+
 get_property(IS_IN_TRY_COMPILE GLOBAL PROPERTY IN_TRY_COMPILE)
 foreach(LANG IN ITEMS C CXX ASM)
     set(CMAKE_${LANG}_FLAGS_INIT "${PICO_COMMON_LANG_FLAGS}")


### PR DESCRIPTION
Make gcc-riscv32-pico-elf the preferred compiler, and add support for  trying different compiler flags until supported ones are found (we try more aggressive -march for RISC-V then less aggressive)