### PR TITLE
newlib/picolibc auto detection

### DIFF
--- a/src/rp2_common/pico_clib_interface/CMakeLists.txt
+++ b/src/rp2_common/pico_clib_interface/CMakeLists.txt
@@ -21,6 +21,10 @@ if (NOT TARGET pico_clib_interface)
     #            PICO_STDIO_SHORT_CIRCUIT_CLIB_FUNCS=0
     #)
 
+    target_include_directories(pico_picolibc_interface SYSTEM INTERFACE
+            ${CMAKE_CURRENT_LIST_DIR}/include/picolibc
+    )
+    
     #  ---- llvm_libc ----
     pico_add_library(pico_llvm_libc_interface)
 
@@ -35,9 +39,23 @@ if (NOT TARGET pico_clib_interface)
     pico_mirrored_target_link_libraries(pico_llvm_libc_interface INTERFACE pico_stdio)
 
     if (NOT PICO_CLIB)
-        # PICO_CMAKE_CONFIG: PICO_CLIB, The C library to use e.g. newlib/picolibc/llvm_libc, type=string, default=based on PICO_COMPILER, group=build, docref=cmake-toolchain-config
-        set(PICO_CLIB newlib)
-    endif()
-
+        # if no PICO_CLIB specified check for gcc existance of either newlib or picolibc 
+        if(PICO_COMPILER_CC MATCHES "gcc$")
+            execute_process(
+                COMMAND ${PICO_COMPILER_CC} -print-file-name=nano.specs
+                OUTPUT_VARIABLE PICOLIBC_SPECS_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+    
+            # nano.specs exists if gcc/clang returns a complete path -> newlib exists
+            if(EXISTS "${PICOLIBC_SPECS_PATH}")
+                set(PICO_CLIB "newlib")
+            else()
+                # otherwise give picolibc a try
+                set(PICO_CLIB "picolibc")
+            endif()
+        endif()
+    endif()    
+    
     target_link_libraries(pico_clib_interface INTERFACE pico_${PICO_CLIB}_interface)
 endif()

--- a/src/rp2_common/pico_clib_interface/CMakeLists.txt
+++ b/src/rp2_common/pico_clib_interface/CMakeLists.txt
@@ -21,10 +21,6 @@ if (NOT TARGET pico_clib_interface)
     #            PICO_STDIO_SHORT_CIRCUIT_CLIB_FUNCS=0
     #)
 
-    target_include_directories(pico_picolibc_interface SYSTEM INTERFACE
-            ${CMAKE_CURRENT_LIST_DIR}/include/picolibc
-    )
-    
     #  ---- llvm_libc ----
     pico_add_library(pico_llvm_libc_interface)
 


### PR DESCRIPTION
For Debian testing there exists no longer newlib, instead picolibc is provided.

If the user does not explicitly selects picolibc with PICO_CLIB=picolibc the linking stage returns an undefined symbol "stdout" because the wrong newlib_interface.c had been compiled in.

This PR checks in case of gcc toolchain if newlib is installed and if not tries to use picolibc instead.  The logic should be generic also for other development  environments than Debian.

If another toolchain is selected (like clang), the auto-detect mechanism is omitted.  In this case the clang toolchain logic must catch this case.  See #2700 ;-)

Fixes #2933