### PR TITLE
Fix rapid changes to colored_status_led

### DIFF
--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -44,7 +44,7 @@ static bool colored_status_led_on;
 #define PICO_COLORED_STATUS_LED_WS2812_FREQ 800000
 #endif
 
-// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED, type=int, default=50, group=pico_status_led
+// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED, type=int, default=100, group=pico_status_led
 #ifndef PICO_COLORED_STATUS_LED_RESET_DELAY_US
 #define PICO_COLORED_STATUS_LED_RESET_DELAY_US 100
 #endif

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -44,9 +44,9 @@ static bool colored_status_led_on;
 #define PICO_COLORED_STATUS_LED_WS2812_FREQ 800000
 #endif
 
-// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED, type=int, default=100, group=pico_status_led
+// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED, type=int, default=50, group=pico_status_led
 #ifndef PICO_COLORED_STATUS_LED_RESET_DELAY_US
-#define PICO_COLORED_STATUS_LED_RESET_DELAY_US 100
+#define PICO_COLORED_STATUS_LED_RESET_DELAY_US 50
 #endif
 
 #ifndef PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
@@ -65,7 +65,7 @@ static int8_t alarm_pending;
 #define alarm_pending false
 #endif
 
-#define COLOR_STATUS_LED_UPDATE_TIME_US (1 + (1000000 * (PICO_COLORED_STATUS_LED_USES_WRGB ? 32 : 24)) / PICO_COLORED_STATUS_LED_WS2812_FREQ)
+#define COLOR_STATUS_LED_UPDATE_TIME_US (2 + (1000000 * (PICO_COLORED_STATUS_LED_USES_WRGB ? 32 : 24)) / PICO_COLORED_STATUS_LED_WS2812_FREQ)
 
 // Extract from 0xWWRRGGBB
 #define RED(c) (((c) >> 16) & 0xff)
@@ -118,6 +118,7 @@ static void set_ws2812(uint32_t value) {
 #else
         if (alarm_pending) {
             // we defer the set to the already waiting alarm
+            spin_unlock(spin_lock, save);
             break;
         } else {
             uint64_t now = time_us_64();
@@ -250,7 +251,7 @@ void status_led_deinit(void) {
         cancel_alarm(alarm_id);
         alarm_id = 0;
     }
-    alarm_pending = false;
+    alarm_pending = 0;
 #endif
     if (pio) {
         pio_remove_program_and_unclaim_sm(&ws2812_program, pio, sm, offset);

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -44,7 +44,7 @@ static bool colored_status_led_on;
 #define PICO_COLORED_STATUS_LED_WS2812_FREQ 800000
 #endif
 
-// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED , type=int, default=50, group=pico_status_led
+// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED, type=int, default=50, group=pico_status_led
 #ifndef PICO_COLORED_STATUS_LED_RESET_DELAY_US
 #define PICO_COLORED_STATUS_LED_RESET_DELAY_US 50
 #endif
@@ -75,7 +75,7 @@ static int8_t alarm_pending;
 
 static void unsafe_set_ws2812(uint32_t value, uint64_t now) {
     if (pio) {
-        pio_sm_drain_tx_fifo(pio, sm); // want to jump passed any previous queued values
+        pio_sm_drain_tx_fifo(pio, sm); // want to jump past any previous queued values
 #if PICO_COLORED_STATUS_LED_USES_WRGB
         // Convert to 0xWWGGRRBB
         pio_sm_put_blocking(pio, sm, WHITE(value) << 24 | GREEN(value) << 16 | RED(value) << 8 | BLUE(value));

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -6,6 +6,8 @@
 
 #include "pico/status_led.h"
 
+#include "hardware/sync/spin_lock.h"
+
 #if PICO_STATUS_LED_AVAILABLE && defined(CYW43_WL_GPIO_LED_PIN) && !defined(PICO_DEFAULT_LED_PIN)
 #define STATUS_LED_USING_WL_GPIO 1
 #else
@@ -33,7 +35,8 @@ static uint32_t colored_status_led_on_color = PICO_DEFAULT_COLORED_STATUS_LED_ON
 static bool colored_status_led_on;
 
 #if COLORED_STATUS_LED_USING_WS2812_PIO
-#include <hardware/pio.h>
+#include "hardware/pio.h"
+#include "pico/time.h"
 #include "ws2812.pio.h"
 
 // PICO_CONFIG: PICO_COLORED_STATUS_LED_WS2812_FREQ, Frequency per bit for the WS2812 colored status LED, type=int, default=800000, group=pico_status_led
@@ -41,9 +44,28 @@ static bool colored_status_led_on;
 #define PICO_COLORED_STATUS_LED_WS2812_FREQ 800000
 #endif
 
+// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required delay in microsecond to reset the WS2812 colored status LED , type=int, default=800000, group=pico_status_led
+#ifndef PICO_COLORED_STATUS_LED_RESET_DELAY_US
+#define PICO_COLORED_STATUS_LED_RESET_DELAY_US 50
+#endif
+
+#ifndef PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
+#define PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL !PICO_TIME_DEFAULT_ALARM_POOL_DISABLED
+#endif
+
 static PIO pio;
 static uint sm;
 static uint offset;
+static uint32_t next_value;
+static uint64_t next_safe_set_time;
+#if PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
+static alarm_id_t alarm_id;
+static int8_t alarm_pending;
+#else
+#define alarm_id 0
+#endif
+
+#define MINIMUM_WS2812_DELAY_US (1 + (1000000 * (PICO_COLORED_STATUS_LED_USES_WRGB ? 32 : 24)) / PICO_COLORED_STATUS_LED_WS2812_FREQ)
 
 // Extract from 0xWWRRGGBB
 #define RED(c) (((c) >> 16) & 0xff)
@@ -51,8 +73,9 @@ static uint offset;
 #define BLUE(c) (((c) >> 0) & 0xff)
 #define WHITE(c) (((c) >> 24) && 0xff)
 
-bool set_ws2812(uint32_t value) {
+static void unsafe_set_ws2812(uint32_t value, uint64_t now) {
     if (pio) {
+        pio_sm_drain_tx_fifo(pio, sm); // want to jump passed any previous queued values
 #if PICO_COLORED_STATUS_LED_USES_WRGB
         // Convert to 0xWWGGRRBB
         pio_sm_put_blocking(pio, sm, WHITE(value) << 24 | GREEN(value) << 16 | RED(value) << 8 | BLUE(value));
@@ -60,8 +83,53 @@ bool set_ws2812(uint32_t value) {
         // Convert to 0xGGRRBB00
         pio_sm_put_blocking(pio, sm, GREEN(value) << 24 | RED(value) << 16 | BLUE(value) << 8);
 #endif
-        return true;
+        next_safe_set_time = now + MINIMUM_WS2812_DELAY_US;
     }
+}
+
+static int64_t deferred_set_ws2812(__unused alarm_id_t id, __unused  void *user_data) {
+    spin_lock_t *spin_lock = spin_lock_instance(PICO_SPINLOCK_ID_ATOMIC);
+    uint32_t save = spin_lock_blocking(spin_lock);
+    unsafe_set_ws2812(next_value, time_us_64());
+    alarm_id = 0;
+    alarm_pending--;
+    spin_unlock(spin_lock, save);
+    return 0;
+}
+
+static bool set_ws2812(uint32_t value) {
+    spin_lock_t *spin_lock = spin_lock_instance(PICO_SPINLOCK_ID_ATOMIC);
+    uint32_t save = spin_lock_blocking(spin_lock);
+    next_value = value;
+    while (true) {
+        if (alarm_pending) {
+            // we defer the set to the already waiting alarm
+            break;
+        } else {
+            uint64_t now = time_us_64();
+            if (now >= next_safe_set_time) {
+                unsafe_set_ws2812(value, now);
+                break;
+            } else {
+                // we want to defer the set until it is safe to do so
+                //
+                // note we use alarm_pending separate from alarm_id, as alarm_id may be returned even if the
+                // alarm fires during the add_alarm_at. and don't use a boolean because if we fail
+                // to add the alarm, we don't know what has happened in between since we unlock the spin lock
+                // before adding the alarm since that is a slowish call
+                alarm_pending++;
+                spin_unlock(spin_lock, save);
+#if PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
+                alarm_id = add_alarm_at(next_safe_set_time, deferred_set_ws2812, NULL, true);
+                if (alarm_id > 0) break;
+#endif
+                busy_wait_until(next_safe_set_time);
+                save = spin_lock_blocking(spin_lock);
+                alarm_pending--;
+            }
+        }
+    }
+    spin_unlock(spin_lock, save);
     return false;
 }
 #endif
@@ -165,6 +233,11 @@ void status_led_deinit(void) {
     status_led_context = NULL;
 #endif
 #if COLORED_STATUS_LED_USING_WS2812_PIO
+#if PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
+    if (alarm_id > 0) {
+        cancel_alarm(alarm_id);
+    }
+#endif
     if (pio) {
         pio_remove_program_and_unclaim_sm(&ws2812_program, pio, sm, offset);
         pio = NULL;

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -99,7 +99,7 @@ static int64_t deferred_set_ws2812(__unused alarm_id_t id, __unused  void *user_
 }
 #endif
 
-static bool set_ws2812(uint32_t value) {
+static void set_ws2812(uint32_t value) {
     spin_lock_t *spin_lock = spin_lock_instance(PICO_SPINLOCK_ID_ATOMIC);
     uint32_t save = spin_lock_blocking(spin_lock);
     next_value = value;
@@ -143,7 +143,6 @@ static bool set_ws2812(uint32_t value) {
         }
 #endif
     }
-    return true;
 }
 #endif
 
@@ -157,20 +156,19 @@ uint32_t colored_status_led_get_on_color(void) {
 }
 
 bool colored_status_led_set_state(bool led_on) {
-    bool success = false;
     if (colored_status_led_supported()) {
 #if COLORED_STATUS_LED_USING_WS2812_PIO
-        success = true;
         if (led_on) {
             // Turn the LED "on" even if it was already on, as the color might have changed
-            success = set_ws2812(colored_status_led_on_color);
-        } else if (!led_on && colored_status_led_on) {
-            success = set_ws2812(0);
+            set_ws2812(colored_status_led_on_color);
+        } else if (colored_status_led_on) {
+            set_ws2812(0);
         }
+        colored_status_led_on = led_on;
+        return true;
 #endif
     }
-    if (success) colored_status_led_on = led_on;
-    return success;
+    return false;
 }
 
 bool colored_status_led_get_state(void) {

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -46,7 +46,7 @@ static bool colored_status_led_on;
 
 // PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED, type=int, default=50, group=pico_status_led
 #ifndef PICO_COLORED_STATUS_LED_RESET_DELAY_US
-#define PICO_COLORED_STATUS_LED_RESET_DELAY_US 50
+#define PICO_COLORED_STATUS_LED_RESET_DELAY_US 100
 #endif
 
 #ifndef PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
@@ -62,10 +62,10 @@ static uint64_t next_safe_set_time;
 static alarm_id_t alarm_id;
 static int8_t alarm_pending;
 #else
-#define alarm_id 0
+#define alarm_pending false
 #endif
 
-#define MINIMUM_WS2812_DELAY_US (1 + (1000000 * (PICO_COLORED_STATUS_LED_USES_WRGB ? 32 : 24)) / PICO_COLORED_STATUS_LED_WS2812_FREQ)
+#define COLOR_STATUS_LED_UPDATE_TIME_US (1 + (1000000 * (PICO_COLORED_STATUS_LED_USES_WRGB ? 32 : 24)) / PICO_COLORED_STATUS_LED_WS2812_FREQ)
 
 // Extract from 0xWWRRGGBB
 #define RED(c) (((c) >> 16) & 0xff)
@@ -83,10 +83,11 @@ static void unsafe_set_ws2812(uint32_t value, uint64_t now) {
         // Convert to 0xGGRRBB00
         pio_sm_put_blocking(pio, sm, GREEN(value) << 24 | RED(value) << 16 | BLUE(value) << 8);
 #endif
-        next_safe_set_time = now + MINIMUM_WS2812_DELAY_US;
+        next_safe_set_time = now + COLOR_STATUS_LED_UPDATE_TIME_US + PICO_COLORED_STATUS_LED_RESET_DELAY_US;
     }
 }
 
+#if PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
 static int64_t deferred_set_ws2812(__unused alarm_id_t id, __unused  void *user_data) {
     spin_lock_t *spin_lock = spin_lock_instance(PICO_SPINLOCK_ID_ATOMIC);
     uint32_t save = spin_lock_blocking(spin_lock);
@@ -96,12 +97,25 @@ static int64_t deferred_set_ws2812(__unused alarm_id_t id, __unused  void *user_
     spin_unlock(spin_lock, save);
     return 0;
 }
+#endif
 
 static bool set_ws2812(uint32_t value) {
     spin_lock_t *spin_lock = spin_lock_instance(PICO_SPINLOCK_ID_ATOMIC);
     uint32_t save = spin_lock_blocking(spin_lock);
     next_value = value;
     while (true) {
+#if !PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
+        uint64_t now = time_us_64();
+        if (now >= next_safe_set_time) {
+            unsafe_set_ws2812(value, now);
+            spin_unlock(spin_lock, save);
+            break;
+        } else {
+            spin_unlock(spin_lock, save);
+            busy_wait_until(next_safe_set_time);
+            save = spin_lock_blocking(spin_lock);
+        }
+#else
         if (alarm_pending) {
             // we defer the set to the already waiting alarm
             break;
@@ -109,6 +123,7 @@ static bool set_ws2812(uint32_t value) {
             uint64_t now = time_us_64();
             if (now >= next_safe_set_time) {
                 unsafe_set_ws2812(value, now);
+                spin_unlock(spin_lock, save);
                 break;
             } else {
                 // we want to defer the set until it is safe to do so
@@ -119,18 +134,16 @@ static bool set_ws2812(uint32_t value) {
                 // before adding the alarm since that is a slowish call
                 alarm_pending++;
                 spin_unlock(spin_lock, save);
-#if PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
                 alarm_id = add_alarm_at(next_safe_set_time, deferred_set_ws2812, NULL, true);
                 if (alarm_id > 0) break;
-#endif
                 busy_wait_until(next_safe_set_time);
                 save = spin_lock_blocking(spin_lock);
                 alarm_pending--;
             }
         }
+#endif
     }
-    spin_unlock(spin_lock, save);
-    return false;
+    return true;
 }
 #endif
 
@@ -236,7 +249,9 @@ void status_led_deinit(void) {
 #if PICO_COLORED_STATUS_LED_USE_DEFAULT_ALARM_POOL
     if (alarm_id > 0) {
         cancel_alarm(alarm_id);
+        alarm_id = 0;
     }
+    alarm_pending = false;
 #endif
     if (pio) {
         pio_remove_program_and_unclaim_sm(&ws2812_program, pio, sm, offset);

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -65,7 +65,8 @@ static int8_t alarm_pending;
 #define alarm_pending false
 #endif
 
-#define COLOR_STATUS_LED_UPDATE_TIME_US (2 + (1000000 * (PICO_COLORED_STATUS_LED_USES_WRGB ? 32 : 24)) / PICO_COLORED_STATUS_LED_WS2812_FREQ)
+// 2 + is empirical and allows WS2812 reset delay of 50us to work 
+#define COLORED_STATUS_LED_UPDATE_TIME_US (2 + (1000000 * (PICO_COLORED_STATUS_LED_USES_WRGB ? 32 : 24)) / PICO_COLORED_STATUS_LED_WS2812_FREQ)
 
 // Extract from 0xWWRRGGBB
 #define RED(c) (((c) >> 16) & 0xff)
@@ -83,7 +84,7 @@ static void unsafe_set_ws2812(uint32_t value, uint64_t now) {
         // Convert to 0xGGRRBB00
         pio_sm_put_blocking(pio, sm, GREEN(value) << 24 | RED(value) << 16 | BLUE(value) << 8);
 #endif
-        next_safe_set_time = now + COLOR_STATUS_LED_UPDATE_TIME_US + PICO_COLORED_STATUS_LED_RESET_DELAY_US;
+        next_safe_set_time = now + COLORED_STATUS_LED_UPDATE_TIME_US + PICO_COLORED_STATUS_LED_RESET_DELAY_US;
     }
 }
 

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -44,7 +44,7 @@ static bool colored_status_led_on;
 #define PICO_COLORED_STATUS_LED_WS2812_FREQ 800000
 #endif
 
-// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required delay in microsecond to reset the WS2812 colored status LED , type=int, default=800000, group=pico_status_led
+// PICO_CONFIG: PICO_COLORED_STATUS_LED_RESET_DELAY_US, Required reset delay in microseconds for the WS2812 colored status LED , type=int, default=50, group=pico_status_led
 #ifndef PICO_COLORED_STATUS_LED_RESET_DELAY_US
 #define PICO_COLORED_STATUS_LED_RESET_DELAY_US 50
 #endif

--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -168,6 +168,7 @@ bool colored_status_led_set_state(bool led_on) {
         return true;
 #endif
     }
+    ((void)led_on);
     return false;
 }
 


### PR DESCRIPTION
WS2812 style LEDs require a reset time before setting the color againprior to this fix, setting color/on/off

in rapid succession would just send the updated values "down the string"

Whilst it would be nice to have the PIO program take care of updating the latest FIFO value after the relevant delay, that costs a fair amount of PIO instrution space, so I have decided to "fix" the issue on the CPU side.

Since the delays in question are non trivial (e.g. 50us), i've decided not to have the call block,  but instead set a timer when necessary (using the default alarm pool) - if that isn't available or the alarm add fails, then the caller blocks instead.

Note the implementation uses a spin lock, because it needs to work with multicore, but also to be fair you might expect to be able to set an LED from an IRQ