### PR TITLE
Small test fixups

### DIFF
--- a/src/host/pico_stdio/include/pico/stdio.h
+++ b/src/host/pico_stdio/include/pico/stdio.h
@@ -14,6 +14,7 @@ typedef struct stdio_driver stdio_driver_t;
 static inline void stdio_usb_init() {}
 void stdio_uart_init();
 static inline void stdio_init_all() { stdio_uart_init(); }
+static inline void stdio_deinit_all() {}
 static inline void stdio_filter_driver(stdio_driver_t *driver) {}
 static inline void stdio_set_translate_crlf(stdio_driver_t *driver, bool enabled) {}
 static inline bool stdio_usb_connected(void) { return true; }

--- a/test/hardware_sync_spin_lock_test/CMakeLists.txt
+++ b/test/hardware_sync_spin_lock_test/CMakeLists.txt
@@ -11,3 +11,5 @@ pico_add_extra_outputs(hardware_sync_spin_lock_test)
 target_compile_definitions(hardware_sync_spin_lock_test PRIVATE
 	PICO_STDOUT_MUTEX=0
 	)
+
+set_target_properties(hardware_sync_spin_lock_test PROPERTIES PICO_TEST_TIMEOUT 10)

--- a/test/pico_test/include/pico/test.h
+++ b/test/pico_test/include/pico/test.h
@@ -55,10 +55,16 @@ but not sure that is implemented yet.
                                     }
 
 // Calls stdio_deinit_all before exiting, to avoid losing final output
-#define PICOTEST_END_TEST()       if (picotest_error_code != 0)                                     \
-                                      {printf("%s: Failed\n", picotest_description); stdio_deinit_all(); return -1;}  \
-                                  else                                                              \
-                                      {printf("%s: Success\n", picotest_description); puts("PASSED"); stdio_deinit_all(); return 0;}
+#define PICOTEST_END_TEST()         if (picotest_error_code != 0) {                                 \
+                                        printf("%s: Failed\n", picotest_description);               \
+                                        stdio_deinit_all();                                         \
+                                        return -1;                                                  \
+                                    } else {                                                        \
+                                        printf("%s: Success\n", picotest_description);              \
+                                        puts("PASSED");                                             \
+                                        stdio_deinit_all();                                         \
+                                        return 0;                                                   \
+                                    }
 
 
 #endif

--- a/test/pico_test/include/pico/test.h
+++ b/test/pico_test/include/pico/test.h
@@ -54,10 +54,17 @@ but not sure that is implemented yet.
                                         return -1;                                                  \
                                     }
 
+#if LIB_PICO_STDIO_USB  // Must deinit before exiting, to avoid losing final output
+#define PICOTEST_END_TEST()       if (picotest_error_code != 0)                                     \
+                                      {printf("%s: Failed\n", picotest_description); stdio_deinit_all(); return -1;}  \
+                                  else                                                              \
+                                      {printf("%s: Success\n", picotest_description); puts("PASSED"); stdio_deinit_all(); return 0;}
+#else
 #define PICOTEST_END_TEST()       if (picotest_error_code != 0)                                     \
                                       {printf("%s: Failed\n", picotest_description); return -1;}  \
                                   else                                                              \
                                       {printf("%s: Success\n", picotest_description); puts("PASSED"); return 0;}
+#endif
 
 
 #endif

--- a/test/pico_test/include/pico/test.h
+++ b/test/pico_test/include/pico/test.h
@@ -54,17 +54,11 @@ but not sure that is implemented yet.
                                         return -1;                                                  \
                                     }
 
-#if LIB_PICO_STDIO_USB  // Must deinit before exiting, to avoid losing final output
+// Calls stdio_deinit_all before exiting, to avoid losing final output
 #define PICOTEST_END_TEST()       if (picotest_error_code != 0)                                     \
                                       {printf("%s: Failed\n", picotest_description); stdio_deinit_all(); return -1;}  \
                                   else                                                              \
                                       {printf("%s: Success\n", picotest_description); puts("PASSED"); stdio_deinit_all(); return 0;}
-#else
-#define PICOTEST_END_TEST()       if (picotest_error_code != 0)                                     \
-                                      {printf("%s: Failed\n", picotest_description); return -1;}  \
-                                  else                                                              \
-                                      {printf("%s: Success\n", picotest_description); puts("PASSED"); return 0;}
-#endif
 
 
 #endif


### PR DESCRIPTION
Tests with stdio_usb need the final output to be flushed before exiting (which is done by `stdio_deinit_all`), otherwise they don't always print `PASSED`

`hardware_sync_spin_lock_test` takes too long on RP2040, so increase the timeout as it was close to timing out on RP2350 anyway