### PR TITLE
Make boot/picobin.h self-contained

### DIFF
--- a/src/common/boot_picobin_headers/include/boot/picobin.h
+++ b/src/common/boot_picobin_headers/include/boot/picobin.h
@@ -7,15 +7,11 @@
 #ifndef _BOOT_PICOBIN_H
 #define _BOOT_PICOBIN_H
 
-#ifndef NO_PICO_PLATFORM
-#include "pico/platform.h"
-#else
 #ifndef _u
 #ifdef __ASSEMBLER__
 #define _u(x) x
 #else
 #define _u(x) x ## u
-#endif
 #endif
 #endif
 
@@ -149,6 +145,7 @@
 #ifndef __ASSEMBLER__
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct {
     // these must all be word aligned


### PR DESCRIPTION
## Summary

`#include "boot/picobin.h"` before any other SDK header errors out with:
```
pico/platform.h:20: #error pico/platform.h should not be included directly; include pico.h instead
```

`boot/picobin.h` was pulling in `pico/platform.h` directly (gated only by `NO_PICO_PLATFORM`), which works only when something else (typically `pico.h`) has already set `_PICO_H`. The diagnostic blamed `pico/platform.h`, while the actual offender was the non-obvious indirect include via `boot/picobin.h` — a confusing experience flagged in #2797.

The header only uses one platform.h facility: the `_u()` literal-suffix macro. The same `_u()` fallback already existed in the `NO_PICO_PLATFORM` branch of this header. Promote that fallback to the unconditional definition and drop the `pico/platform.h` include. Add `<stdint.h>` next to the existing `<stdbool.h>` in the C-only block so `uint32_t` is available standalone.

This keeps `boot/picobin.h` at the lightweight "common" tier (no new heavy SDK dependency) and makes it includable in any order.

Fixes #2797.

## Test plan

- [x] Repro reproduces on develop: a TU containing only `#include "boot/picobin.h"` fails to compile, citing the `pico/platform.h should not be included directly` error.
- [x] After the change, the same TU compiles.
- [x] `__ASSEMBLER__`-mode preprocessing still works (`_u(x)` falls through to the asm branch).
- [x] Full SDK build remains clean (`cmake --build build`) for the default `PICO_PLATFORM=rp2040 PICO_BOARD=pico` config. Existing internal consumers (`pico_cyw43_driver`, `pico_crt0`, `pico_bootrom`, `cyw43_partition_firmware`) include picobin.h alongside `pico.h`/`pico/bootrom.h`, so they already pull in platform.h transitively and are unaffected.
- [ ] CI to confirm other board / RP2350 / RISC-V configurations.