### PR TITLE
hardware_pio: clarify pio_sm_restart docs (PC, running state)

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -1108,11 +1108,19 @@ static inline void pio_set_sm_multi_mask_enabled(PIO pio, uint32_t mask_prev, ui
 }
 #endif
 
-/*! \brief Restart a state machine with a known state
+/*! \brief Restart a state machine with a known internal state
  *  \ingroup hardware_pio
  *
- * This method clears the ISR, shift counters, clock divider counter
- * pin write flags, delay counter, latched EXEC instruction, and IRQ wait condition.
+ * Clears the following on the selected state machine: input and output shift
+ * counters, the contents of the input shift register, the delay counter, the
+ * waiting-on-IRQ state, any stalled instruction written to `SMx_INSTR` or run
+ * by `OUT/MOV EXEC`, and any pin write left asserted due to `OUT_STICKY`.
+ *
+ * Not affected: the state machine's enable/running state (see
+ * \ref pio_sm_set_enabled), its program counter, the contents of its output
+ * shift register, and its X and Y scratch registers. To restart the clock
+ * divider use \ref pio_sm_clkdiv_restart; to set the program counter to a
+ * specific value, follow this call with a `JMP` via \ref pio_sm_exec.
  *
  * \param pio The PIO instance; e.g. \ref pio0, \ref pio1 etc.
  * \param sm State machine index (0..3)
@@ -1123,14 +1131,16 @@ static inline void pio_sm_restart(PIO pio, uint sm) {
     hw_set_bits(&pio->ctrl, 1u << (PIO_CTRL_SM_RESTART_LSB + sm));
 }
 
-/*! \brief Restart multiple state machine with a known state
+/*! \brief Restart multiple state machines with a known internal state
  *  \ingroup hardware_pio
  *
- * This method clears the ISR, shift counters, clock divider counter
- * pin write flags, delay counter, latched EXEC instruction, and IRQ wait condition.
+ * Performs the same operation as \ref pio_sm_restart for each state machine
+ * selected in \p mask. See \ref pio_sm_restart for the exact list of internal
+ * state that is cleared and what is left untouched (notably, the enable/running
+ * state and program counter are preserved).
  *
  * \param pio The PIO instance; e.g. \ref pio0, \ref pio1 etc.
- * \param mask bit mask of state machine indexes to modify the enabled state of
+ * \param mask bit mask of state machine indexes to restart (bit 0 = state machine 0, etc.)
  */
 static inline void pio_restart_sm_mask(PIO pio, uint32_t mask) {
     check_pio_param(pio);


### PR DESCRIPTION
## Summary

Per #2844, the doxygen for `pio_sm_restart()` doesn't mention the program counter or the state machine's enable/running state, and includes a couple of inaccuracies.

This PR rewrites the doxygen for `pio_sm_restart` and its multi-SM sibling `pio_restart_sm_mask` against the authoritative wording from the `PIO_CTRL.SM_RESTART` field description in `hardware/regs/pio.h` (same text on both RP2040 and RP2350):

**Fixed inaccuracies:**
- The clock divider counter is NOT cleared by `SM_RESTART` — that's a separate bit (`CLKDIV_RESTART`, exposed via `pio_sm_clkdiv_restart`). The old doc claimed it was cleared.
- "ISR" was ambiguous (input shift register vs interrupt service routine); now spelled out.
- The `@param mask` description on `pio_restart_sm_mask` said "modify the enabled state of", but the function does not touch `SM_ENABLE`.

**Filled in:**
- Explicit note that the state machine's enable/running state is preserved (the issue's main ask — the `_restart` suffix is misleading without this).
- Explicit note that the program counter is preserved, with a pointer to `pio_sm_exec` for the "set PC after restart" use case.

PC behavior is documented as "not affected" on RP2040 in the datasheet; the RP2350 datasheet's SM_RESTART description omits the PC from its not-affected list, but the underlying hardware bit is identical and the rest of the description matches. Happy to soften the wording if maintainers know of a behavior difference on RP2350.

Fixes #2844.

## Test plan

- [x] `cmake --build build --target docs` produces no new warnings; specifically nothing on the changed block in `src/rp2_common/hardware_pio/include/hardware/pio.h`.
- [x] Rendered HTML inspected: cross-references to `pio_sm_set_enabled`, `pio_sm_clkdiv_restart`, `pio_sm_exec` resolve; backtick code spans render as `<code>`.
- [x] Full SDK build still succeeds (`cmake --build build`); no code change.
- [ ] CI to confirm broader configurations (RP2350 / RISC-V / etc.).