### PR TITLE
pico_stdio_usb: fix overlap between activity-LED GPIO and active_low bit

### DIFF
--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -129,7 +129,7 @@ static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_
             //   bits 0-1  : forwarded as the bootrom disable_interface_mask
             //   bit 7     : 1 if the activity-LED GPIO is active-low
             //   bit 8     : 1 if an activity-LED GPIO is being specified
-            //   bits 9-15 : activity-LED GPIO number (0-63
+            //   bits 9-15 : activity-LED GPIO number (0-63)
             if (request->wValue & 0x100) {
                 gpio = request->wValue >> 9u;
                 active_low = request->wValue & 0x80;

--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -125,8 +125,18 @@ static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_
             bool active_low = false;
 #endif
 #if !PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
+            // wValue layout:
+            //   bits 0-6  : forwarded as the bootrom disable_interface_mask
+            //   bit 8     : 1 if an activity-LED GPIO is being specified
+            //   bit 9     : 1 if the activity-LED GPIO is active-low
+            //   bits 10-15: activity-LED GPIO number (0-63; enough for RP2040
+            //               and RP2350 which have at most 48 GPIOs)
+            // Previously the GPIO was extracted as (wValue >> 9), which made
+            // its low bit alias the active_low flag at bit 9 - any odd-numbered
+            // GPIO would force active_low and any active_low request would
+            // round the GPIO down. See #2713.
             if (request->wValue & 0x100) {
-                gpio = request->wValue >> 9u;
+                gpio = request->wValue >> 10u;
             }
             active_low = request->wValue & 0x200;
 #endif

--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -126,21 +126,16 @@ static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_
 #endif
 #if !PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
             // wValue layout:
-            //   bits 0-6  : forwarded as the bootrom disable_interface_mask
+            //   bits 0-1  : forwarded as the bootrom disable_interface_mask
+            //   bit 7     : 1 if the activity-LED GPIO is active-low
             //   bit 8     : 1 if an activity-LED GPIO is being specified
-            //   bit 9     : 1 if the activity-LED GPIO is active-low
-            //   bits 10-15: activity-LED GPIO number (0-63; enough for RP2040
-            //               and RP2350 which have at most 48 GPIOs)
-            // Previously the GPIO was extracted as (wValue >> 9), which made
-            // its low bit alias the active_low flag at bit 9 - any odd-numbered
-            // GPIO would force active_low and any active_low request would
-            // round the GPIO down. See #2713.
+            //   bits 9-15 : activity-LED GPIO number (0-63
             if (request->wValue & 0x100) {
-                gpio = request->wValue >> 10u;
+                gpio = request->wValue >> 9u;
+                active_low = request->wValue & 0x80;
             }
-            active_low = request->wValue & 0x200;
 #endif
-            rom_reset_usb_boot_extra(gpio, (request->wValue & 0x7f) | PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, active_low);
+            rom_reset_usb_boot_extra(gpio, (request->wValue & 0x3) | PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, active_low);
             // does not return, otherwise we'd return true
         }
 #endif

--- a/src/rp2_common/pico_stdio_usb/reset_interface.c
+++ b/src/rp2_common/pico_stdio_usb/reset_interface.c
@@ -129,7 +129,7 @@ static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_
             //   bits 0-1  : forwarded as the bootrom disable_interface_mask
             //   bit 7     : 1 if the activity-LED GPIO is active-low
             //   bit 8     : 1 if an activity-LED GPIO is being specified
-            //   bits 9-15 : activity-LED GPIO number (0-63)
+            //   bits 9-15 : activity-LED GPIO number (0-127)
             if (request->wValue & 0x100) {
                 gpio = request->wValue >> 9u;
                 active_low = request->wValue & 0x80;


### PR DESCRIPTION
## Summary

Fixes #2713. The bootsel-reset USB control transfer in `reset_interface.c` extracts the activity-LED GPIO and `active_low` flag from the same `wValue` bit (bit 9):

```c
if (request->wValue & 0x100) {
    gpio = request->wValue >> 9u;     // GPIO starts at bit 9...
}
active_low = request->wValue & 0x200; // ...but bit 9 is also active_low
```

Consequences:
- An odd-numbered activity-LED GPIO silently triggers active_low.
- A client wanting active_low has the GPIO number's LSB forced to 1.

History: the original encoding (commit 383e88e) used `gpio = wValue >> 9` with no active_low support. Commit 5a98889 (PR #2084, "add `rom_reset_usb_boot_extra`") added `active_low = wValue & 0x200` on top of the existing layout without shifting the GPIO over by an extra bit.

This PR changes `wValue >> 9` to `wValue >> 10`, giving the final layout:

| Bits | Meaning |
|---|---|
| 0-6 | bootrom `disable_interface_mask` (forwarded via `wValue & 0x7f`) |
| 7 | reserved |
| 8 | activity-LED GPIO is being specified |
| 9 | activity-LED is active-low |
| 10-15 | activity-LED GPIO number (0-63) |

6 bits is enough for both RP2040 (30 GPIOs) and RP2350 (48 GPIOs).

The protocol is also documented in a new comment block above the change so the layout is no longer implicit.

## Compatibility

I checked picotool's `main.cpp` for callers building `wValue`. The only `RESET_REQUEST_BOOTSEL` call sends `wValue = disable_mask` with only bits 0-1 set (`DISABLE_MSD_INTERFACE`); bit 8 is never set, so the GPIO-extraction code is never reached for the canonical client. The change therefore does not affect any in-tree behaviour. It is, strictly speaking, a wire-protocol change for out-of-tree clients that build `wValue` with the GPIO-specified bit (bit 8) set - but the previous behaviour was buggy, so any such client was either already producing wrong results or worked only by accident.

Happy to take a different approach if maintainers would rather preserve the broken-but-shipped layout (e.g. moving `active_low` to a different bit, or removing it in favour of the existing `BOOTSEL_FLAG_GPIO_PIN_ACTIVE_LOW` bit 4 in the disable_interface_mask path).

## Test plan

- [x] Code-read the only known client (picotool/main.cpp) to confirm no actual wire-protocol break.
- [x] Full SDK build clean for `PICO_PLATFORM=rp2040 PICO_BOARD=pico` and `PICO_PLATFORM=rp2350 PICO_BOARD=pico2`.
- [ ] CI to confirm broader configurations.

### Attempted end-to-end test on hardware (blocked by an unrelated SDK issue)

I built a minimal `pico_stdio_usb` firmware against this branch on a Pico 2 (RP2350) and sent `RESET_REQUEST_BOOTSEL` control transfers with `wValue = (25 << 10) | 0x300 = 0x6700` (gpio=25, active_low=true, MSD enabled). The board re-enumerates into BOOTSEL as expected (PID `2e8a:000f`, MSD enumerated, files browsable), but the activity LED on GPIO 25 stays steady-off in both `active_low=true` and `active_low=false` runs - i.e. the bootrom is not driving the activity GPIO at all.

The wValue parsing in `reset_interface.c` is correct after this patch (mechanically: shift amount only), so the visible-LED breakage is downstream of this change. While investigating I found what looks like a separate, pre-existing parameter-order mismatch between the documented `REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL` ABI (`p0 = gpio_pin_number, p1 = flags`) and the SDK's `rom_reset_usb_boot_extra()` wrapper (which calls `rom_reboot(..., flags, gpio)`). Filed separately as #2949 so it can be triaged independently.

Verification of this PR therefore rests on:
- the mechanical shift-amount change (`>> 9u` → `>> 10u`),
- the explicit bit-layout comment block added next to it,
- the picotool code-read that confirms no in-tree caller exercises bit 8 of `wValue`.

I'm happy to add a runtime print-based end-to-end test (or rerun the LED test) once #2949 is resolved, if that would help close out review.
