### PR TITLE
pico_btstack: use PICO_BTSTACK_PATH for compile_gatt.py

### DIFF
--- a/src/rp2_common/pico_btstack/CMakeLists.txt
+++ b/src/rp2_common/pico_btstack/CMakeLists.txt
@@ -339,7 +339,7 @@ if (EXISTS ${PICO_BTSTACK_PATH}/${BTSTACK_TEST_PATH})
                     DEPENDS ${GATT_FILE}
                     WORKING_DIRECTORY ${GATT_PATH}
                     COMMAND ${CMAKE_COMMAND} -E make_directory ${GATT_BINARY_DIR} &&
-                            ${Python3_EXECUTABLE} ${PICO_SDK_PATH}/lib/btstack/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ARGN}
+                            ${Python3_EXECUTABLE} ${PICO_BTSTACK_PATH}/tool/compile_gatt.py ${GATT_FILE} ${GATT_HEADER} ${ARGN}
                     VERBATIM)
             add_dependencies(${TARGET_LIB}
                     ${TARGET_GATT}


### PR DESCRIPTION
## Summary

Fixes #2901. `pico_btstack_make_gatt_header()` in `src/rp2_common/pico_btstack/CMakeLists.txt` was invoking the bundled `compile_gatt.py` via `${PICO_SDK_PATH}/lib/btstack/tool/...` even when the user had supplied an out-of-tree BTstack via `-DPICO_BTSTACK_PATH=...`. The rest of the file already routes everything (sources, include dirs, suppress-warnings list, etc.) through `PICO_BTSTACK_PATH`; only this one invocation didn't.

Switch the `add_custom_command` at line 342 to use `${PICO_BTSTACK_PATH}/tool/compile_gatt.py` to match.

## Compatibility

In the default case, `PICO_BTSTACK_PATH` is set to `${PICO_SDK_PATH}/lib/btstack` (line 9 of the same file), so `${PICO_BTSTACK_PATH}/tool/compile_gatt.py` resolves to exactly the same path the old code produced. The change is therefore a no-op for builds that don't override the variable.

For builds that *do* override it (the case the issue is about), the user's `compile_gatt.py` is now used as intended.

## Test plan

- [x] `grep -n 'PICO_SDK_PATH' src/rp2_common/pico_btstack/CMakeLists.txt`: only line 9 (default for `PICO_BTSTACK_PATH`) and line 12 (submodule-init hint message) remain. No other stray references.
- [x] Full SDK build clean: `cmake --build build` for `PICO_PLATFORM=rp2040 PICO_BOARD=pico`. The SDK itself doesn't ship a GATT-using example, so the function definition is exercised only by configure; no in-tree behaviour change.
- [x] End-to-end test with an out-of-tree BTstack: details below.

### End-to-end verification with an out-of-tree BTstack

Set up a separate BTstack root (`/tmp/btstack-oot`), a minimal consumer project that calls `pico_btstack_make_gatt_header()` on a tiny `.gatt` file, and configured with `PICO_BOARD=pico2_w -DPICO_BTSTACK_PATH=/tmp/btstack-oot`.

Configured **twice**: once with the file at `origin/develop` (no fix), once with this branch. The generated `gatt_consumer_gatt_header` build rule encodes the literal `python3 <path>/compile_gatt.py ...` command, so the path used is visible without running the command.

| | Generated command (compile_gatt.py path) |
|---|---|
| `origin/develop` (no fix) | `/home/andrii/pico-sdk/lib/btstack/tool/compile_gatt.py` ← bundled, override ignored |
| this branch (fix) | `/tmp/btstack-oot/tool/compile_gatt.py` ← user's `PICO_BTSTACK_PATH` respected |

Then built the target on the fix branch: `python3` runs from the override path, produces `test.h`, and the generated header self-documents the invocation in a comment - `// To generate test.h: /tmp/btstack-oot/tool/compile_gatt.py ...`.
