### PR TITLE
Fix reversed p0/p1 description in REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL doc

### DIFF
--- a/src/common/boot_picoboot_headers/include/boot/picoboot_constants.h
+++ b/src/common/boot_picoboot_headers/include/boot/picoboot_constants.h
@@ -12,7 +12,7 @@
 // --- note these match BOOT_TYPE_ constants in pico/bootrom_constants.h
 // values 0-7 are secure/non-secure
 #define REBOOT2_FLAG_REBOOT_TYPE_NORMAL       0x0 // param0 = diagnostic partition
-#define REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL      0x2 // param0 = gpio_pin_number, param1 = flags
+#define REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL      0x2 // param0 = flags, param1 = gpio_pin_number
 #define REBOOT2_FLAG_REBOOT_TYPE_RAM_IMAGE    0x3 // param0 = image_region_base, param1 = image_region_size
 #define REBOOT2_FLAG_REBOOT_TYPE_FLASH_UPDATE 0x4 // param0 = update_base
 // values 8-15 are secure only

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -467,12 +467,12 @@ static inline int rom_set_bootrom_stack(bootrom_stack_t *stack) {
  * \ref REBOOT2_FLAG_REBOOT_TYPE_NORMAL - reboot into the normal boot path.
  * 
  * \ref REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL - reboot into BOOTSEL mode.
- *  p0 - the GPIO number to use as an activity indicator (enabled by flag in p1).
- *  p1 - a set of flags:
+ *  p0 - a set of flags:
  *   0x01 : DISABLE_MSD_INTERFACE - Disable the BOOTSEL USB drive (see <<section_bootrom_mass_storage>>)
  *   0x02 : DISABLE_PICOBOOT_INTERFACE - Disable the {picoboot} interface (see <<section_bootrom_picoboot>>).
- *   0x10 : GPIO_PIN_ACTIVE_LOW - The GPIO in p0 is active low.
+ *   0x10 : GPIO_PIN_ACTIVE_LOW - The GPIO in p1 is active low.
  *   0x20 : GPIO_PIN_ENABLED - Enable the activity indicator on the specified GPIO.
+ *  p1 - the GPIO number to use as an activity indicator (enabled by GPIO_PIN_ENABLED flag in p0).
  * 
  * \ref REBOOT2_FLAG_REBOOT_TYPE_RAM_IMAGE - reboot into an image in RAM. The region of RAM or XIP RAM is searched for an image to run. This is the type
  * of reboot used when a RAM UF2 is dragged onto the BOOTSEL USB drive.

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -470,8 +470,8 @@ static inline int rom_set_bootrom_stack(bootrom_stack_t *stack) {
  *  p0 - a set of flags:
  *   0x01 : DISABLE_MSD_INTERFACE - Disable the BOOTSEL USB drive (see <<section_bootrom_mass_storage>>)
  *   0x02 : DISABLE_PICOBOOT_INTERFACE - Disable the {picoboot} interface (see <<section_bootrom_picoboot>>).
- *   0x10 : GPIO_PIN_ACTIVE_LOW - The GPIO in p1 is active low.
- *   0x20 : GPIO_PIN_ENABLED - Enable the activity indicator on the specified GPIO.
+ *   0x10 : GPIO_PIN_ACTIVE_LOW - The GPIO specified in p1 is active low (GPIO_PIN_SPECIFIED must also be set).
+ *   0x20 : GPIO_PIN_SPECIFIED - Enable the activity indicator on the GPIO specified in p1.
  *  p1 - the GPIO number to use as an activity indicator (enabled by GPIO_PIN_ENABLED flag in p0).
  * 
  * \ref REBOOT2_FLAG_REBOOT_TYPE_RAM_IMAGE - reboot into an image in RAM. The region of RAM or XIP RAM is searched for an image to run. This is the type


### PR DESCRIPTION
## Summary

Two places in the SDK described the bootrom's BOOTSEL reboot ABI with `p0` and `p1` swapped relative to what the bootrom actually accepts:

- `src/common/boot_picoboot_headers/include/boot/picoboot_constants.h:15`
- `src/rp2_common/pico_bootrom/include/pico/bootrom.h:469-475`

`rom_reset_usb_boot_extra()` has always passed `(p0 = flags, p1 = gpio_pin_number)`. The doc said the opposite (`p0 = gpio, p1 = flags`). Swap the descriptions; no code change.

## Why we know which side is right

When I filed #2949 I suspected the SDK was passing the args in the wrong order. Hardware testing on RP2350 today flipped that conclusion:

A minimal firmware calling

```c
rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL | REBOOT2_FLAG_NO_RETURN_ON_SUCCESS,
           10, /* p0 */ 25, /* p1 */ 0x30 /* GPIO_PIN_SPECIFIED|ACTIVE_LOW per doc */)
```

re-enters BOOTSEL with the **MSD interface disabled** (no `/media/$USER/RP2350/`, no `/dev/sd*`), only the PICOBOOT interface up.

- Under the doc-correct interpretation, those args mean `gpio = 25` (valid) and `flags = 0x30` with **no disable bits** — MSD should be up.
- Under the SDK-correct interpretation, they mean `flags = 25 = 0x19` — bit 0 is `DISABLE_MSD_INTERFACE`. That matches what's actually observed.

The only way the bootrom could disable MSD from those args is by reading `p0` as flags. So the SDK code is right; the doc is reversed. Reproduced with a second test (`p1 = 0x20`, same `p0 = 25`, identical observable outcome).

Full reasoning and observations: https://github.com/raspberrypi/pico-sdk/issues/2949#issuecomment-4491368535

## Test plan

- [x] Verified by inspecting both files that the swapped pairs are internally consistent (the `0x10 GPIO_PIN_ACTIVE_LOW` cross-reference in `bootrom.h` now points at `p1`, where the GPIO actually lives).
- [x] Hardware test as described above (RP2350 / Pico 2).
- [x] (Out of scope of this PR) Followed up on the "activity LED never lights up" subplot separately — it's a real, independent bug. Filed as #2957.

Closes #2949.
