### PR TITLE
Add support for LLVM Embedded Toolchain for Arm 21

### DIFF
--- a/cmake/preload/toolchains/pico_arm_cortex_m0plus_clang.cmake
+++ b/cmake/preload/toolchains/pico_arm_cortex_m0plus_clang.cmake
@@ -1,7 +1,7 @@
 set(CMAKE_SYSTEM_PROCESSOR cortex-m0plus)
 
 # these are all the directories under LLVM embedded toolchain for ARM (newlib or pibolibc) and under llvm_libc
-set(PICO_CLANG_RUNTIMES armv6m_soft_nofp armv6m-unknown-none-eabi)
+set(PICO_CLANG_RUNTIMES armv6m_soft_nofp armv6m_soft_nofp_size armv6m-unknown-none-eabi)
 
 set(PICO_COMMON_LANG_FLAGS "--target=armv6m-none-eabi -mfloat-abi=soft -march=armv6m")
 

--- a/cmake/preload/toolchains/pico_arm_cortex_m33_clang.cmake
+++ b/cmake/preload/toolchains/pico_arm_cortex_m33_clang.cmake
@@ -8,11 +8,11 @@ if (PICO_HARD_FLOAT_ABI)
     set(PICO_COMMON_LANG_FLAGS "${PICO_COMMON_LANG_FLAGS} -mfloat-abi=hard")
     # todo - doesn't seem to be a hard_fp variant for google atm?
     # these are all the directories under LLVM embedded toolchain for ARM (newlib or pibolibc)
-    set(PICO_CLANG_RUNTIMES armv8m.main_hard_fp armv8m.main_hard_fp_unaligned)
+    set(PICO_CLANG_RUNTIMES armv8m.main_hard_fp armv8m.main_hard_fp_unaligned armv8m.main_hard_fp_unaligned_size)
 else()
     set(PICO_COMMON_LANG_FLAGS "${PICO_COMMON_LANG_FLAGS} -mfloat-abi=softfp")
     # these are all the directories under LLVM embedded toolchain for ARM (newlib or pibolibc) and under llvm_libc
-    set(PICO_CLANG_RUNTIMES armv8m.main_soft_nofp armv8m.main_soft_nofp_unaligned armv8m.main-unknown-none-eabi)
+    set(PICO_CLANG_RUNTIMES armv8m.main_soft_nofp armv8m.main_soft_nofp_unaligned armv8m.main_soft_nofp_unaligned_size armv8m.main-unknown-none-eabi)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/util/pico_arm_clang_common.cmake)

--- a/cmake/preload/toolchains/util/pico_arm_clang_common.cmake
+++ b/cmake/preload/toolchains/util/pico_arm_clang_common.cmake
@@ -43,39 +43,34 @@ endforeach()
 
 list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES PICO_CLIB)
 
-foreach(PICO_CLANG_RUNTIME IN LISTS PICO_CLANG_RUNTIMES)
-    # LLVM embedded-toolchain for ARM style
-    find_path(PICO_COMPILER_SYSROOT NAMES include/stdio.h
-            HINTS
-            ${PICO_COMPILER_DIR}/../lib/clang-runtimes/arm-none-eabi/${PICO_CLANG_RUNTIME}
-            ${PICO_COMPILER_DIR}/../lib/clang-runtimes/${PICO_CLANG_RUNTIME}
-    )
+if (NOT PICO_COMPILER_SYSROOT)
+    # Note we explicitly look for the correct libraries, because we don't necessarily trust multilib (even
+    # in newer Arm LLVM ETfA to correctly pick the right one
+    foreach(PICO_CLANG_RUNTIME IN LISTS PICO_CLANG_RUNTIMES)
+        # LLVM embedded-toolchain for ARM style
+        find_path(PICO_COMPILER_SYSROOT NAMES lib
+                HINTS
+                ${PICO_COMPILER_DIR}/../lib/clang-runtimes/arm-none-eabi/${PICO_CLANG_RUNTIME}
+                ${PICO_COMPILER_DIR}/../lib/clang-runtimes/${PICO_CLANG_RUNTIME}
+        )
 
-    if (PICO_COMPILER_SYSROOT)
-        if (NOT PICO_CLIB)
-            # this is a bit of a hack; to try to autodetect the C library used:
-            # `picolibc.h` seems to exist on the newer versions of LLVM embedded toolchain for ARM using picolibc whereas
-            # `newlib.h` appears in all versions, so isn't very useful
-            if (EXISTS "${PICO_COMPILER_SYSROOT}/include/picolibc.h")
-                message("Setting default C library to picolibc as LLVM appears to be using it")
-                set(PICO_CLIB "picolibc" CACHE INTERNAL "")
+        if (PICO_COMPILER_SYSROOT)
+            break()
+        endif()
+        # llvm_libc style
+        find_path(PICO_COMPILER_SYSROOT NAMES stdio.h
+                HINTS
+                ${PICO_COMPILER_DIR}/../include/${PICO_CLANG_RUNTIME}
+        )
+        if (PICO_COMPILER_SYSROOT)
+            if (NOT PICO_CLIB)
+                message("Setting default C library to llvm_libc as LLVM appears to be using it")
+                set(PICO_CLIB "llvm_libc" CACHE INTERNAL "")
             endif()
+            break()
         endif()
-        break()
-    endif()
-    # llvm_libc style
-    find_path(PICO_COMPILER_SYSROOT NAMES stdio.h
-            HINTS
-            ${PICO_COMPILER_DIR}/../include/${PICO_CLANG_RUNTIME}
-    )
-    if (PICO_COMPILER_SYSROOT)
-        if (NOT PICO_CLIB)
-            message("Setting default C library to llvm_libc as LLVM appears to be using it")
-            set(PICO_CLIB "llvm_libc" CACHE INTERNAL "")
-        endif()
-        break()
-    endif()
-endforeach()
+    endforeach()
+endif()
 
 # moving this here as a reminder from pico_standard_link; it was commented out theee, but if ever needed,
 # it belongs here as part of LINKER_FLAGS_INIT
@@ -91,9 +86,22 @@ if (PICO_CLIB STREQUAL "llvm_libc")
     endforeach()
 else()
     if (NOT PICO_COMPILER_SYSROOT)
-        message(FATAL_ERROR "Could not find an llvm runtime for '${PICO_CLANG_RUNTIME}'")
+        message(FATAL_ERROR "Could not find an llvm runtime")
     endif()
-
     set(PICO_COMMON_LANG_FLAGS "${PICO_COMMON_LANG_FLAGS} --sysroot ${PICO_COMPILER_SYSROOT}")
+
+    find_path(_CLANG_HEADERS_DIR NAMES include/stdio.h
+            HINTS
+            ${PICO_COMPILER_SYSROOT}
+            ${PICO_COMPILER_SYSROOT}/.. # new style LLVM ETfA (21+)
+    )
+    if (NOT _CLANG_HEADERS_DIR)
+        message(FATAL_ERROR "Could not find llvm headers (searched ${PICO_COMPILER_SYSROOT}/include and ${PICO_COMPILER_SYSROOT}/../include)")
+    else()
+        if (NOT _CLANG_HEADERS_DIR STREQUAL PICO_COMPILER_SYSROOT)
+            # LLVM ETfA moves the headers out of the multilib so we need to explicitly add C++/C headers (in that order)
+            set(PICO_COMMON_LANG_FLAGS "${PICO_COMMON_LANG_FLAGS} -isystem ${_CLANG_HEADERS_DIR}/include/c++/v1 -isystem ${_CLANG_HEADERS_DIR}/include")
+        endif()
+    endif()
 endif()
 include(${CMAKE_CURRENT_LIST_DIR}/set_flags.cmake)

--- a/cmake/preload/toolchains/util/pico_arm_clang_common.cmake
+++ b/cmake/preload/toolchains/util/pico_arm_clang_common.cmake
@@ -45,7 +45,7 @@ list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES PICO_CLIB)
 
 if (NOT PICO_COMPILER_SYSROOT)
     # Note we explicitly look for the correct libraries, because we don't necessarily trust multilib (even
-    # in newer Arm LLVM ETfA to correctly pick the right one
+    # in newer Arm LLVM ATfE to correctly pick the right one
     foreach(PICO_CLANG_RUNTIME IN LISTS PICO_CLANG_RUNTIMES)
         # LLVM embedded-toolchain for ARM style
         find_path(PICO_COMPILER_SYSROOT NAMES lib
@@ -93,13 +93,13 @@ else()
     find_path(_CLANG_HEADERS_DIR NAMES include/stdio.h
             HINTS
             ${PICO_COMPILER_SYSROOT}
-            ${PICO_COMPILER_SYSROOT}/.. # new style LLVM ETfA (21+)
+            ${PICO_COMPILER_SYSROOT}/.. # new style LLVM ATfE (21+)
     )
     if (NOT _CLANG_HEADERS_DIR)
         message(FATAL_ERROR "Could not find llvm headers (searched ${PICO_COMPILER_SYSROOT}/include and ${PICO_COMPILER_SYSROOT}/../include)")
     else()
         if (NOT _CLANG_HEADERS_DIR STREQUAL PICO_COMPILER_SYSROOT)
-            # LLVM ETfA moves the headers out of the multilib so we need to explicitly add C++/C headers (in that order)
+            # LLVM ATfE 21+ moves the headers out of the multilib so we need to explicitly add C++/C headers (in that order)
             set(PICO_COMMON_LANG_FLAGS "${PICO_COMMON_LANG_FLAGS} -isystem ${_CLANG_HEADERS_DIR}/include/c++/v1 -isystem ${_CLANG_HEADERS_DIR}/include")
         endif()
     endif()

--- a/src/rp2_common/pico_clib_interface/llvm_libc_interface.c
+++ b/src/rp2_common/pico_clib_interface/llvm_libc_interface.c
@@ -73,7 +73,7 @@ ssize_t __llvm_libc_stdio_write(__unused void *cookie, const char *buf, size_t s
 }
 
 bool __llvm_libc_timespec_get_utc(struct timespec *ts) {
-    int64_t absolute_time = (int64_t)get_absolute_time();
+    int64_t absolute_time = to_us_since_boot(get_absolute_time());
     ts->tv_sec = (time_t)(absolute_time / 1000000);
     ts->tv_nsec = (long)(absolute_time % 1000000 * 1000);
     return true;


### PR DESCRIPTION
they moved headers and libraries around a bit

also removed the `picolibc` detection which is now handled better in `pico_clib_interface` (so depends on #2935)