### PR TITLE
pio_encoding fixes + added PIO_VERSION to platform_defs.h

### DIFF
--- a/src/rp2040/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2040/hardware_regs/include/hardware/platform_defs.h
@@ -41,6 +41,7 @@
 #define NUM_QSPI_GPIOS _u(6)
 
 #define PIO_INSTRUCTION_COUNT _u(32)
+#define PIO_VERSION _u(0)
 
 #define USBCTRL_DPRAM_SIZE _u(4096)
 

--- a/src/rp2040/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2040/hardware_regs/include/hardware/platform_defs.h
@@ -41,7 +41,7 @@
 #define NUM_QSPI_GPIOS _u(6)
 
 #define PIO_INSTRUCTION_COUNT _u(32)
-#define PIO_VERSION _u(0)
+#define PICO_PIO_VERSION _u(0)
 
 #define USBCTRL_DPRAM_SIZE _u(4096)
 

--- a/src/rp2350/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2350/hardware_regs/include/hardware/platform_defs.h
@@ -57,6 +57,7 @@
 #define NUM_OTP_ROWS (NUM_OTP_PAGES * NUM_OTP_PAGE_ROWS)
 
 #define PIO_INSTRUCTION_COUNT _u(32)
+#define PIO_VERSION _u(1)
 
 #define NUM_MPU_REGIONS _u(8)
 #define NUM_SAU_REGIONS _u(8)

--- a/src/rp2350/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2350/hardware_regs/include/hardware/platform_defs.h
@@ -57,7 +57,7 @@
 #define NUM_OTP_ROWS (NUM_OTP_PAGES * NUM_OTP_PAGE_ROWS)
 
 #define PIO_INSTRUCTION_COUNT _u(32)
-#define PIO_VERSION _u(1)
+#define PICO_PIO_VERSION _u(1)
 
 #define NUM_MPU_REGIONS _u(8)
 #define NUM_SAU_REGIONS _u(8)

--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -23,11 +23,6 @@
 #endif
 #endif
 
-// PICO_CONFIG: PICO_PIO_VERSION, PIO hardware version, type=int, default=0 on RP2040 and 1 on RP2350, group=hardware_pio
-#ifndef PICO_PIO_VERSION
-#define PICO_PIO_VERSION PIO_VERSION
-#endif
-
 // PICO_CONFIG: PICO_PIO_CLKDIV_ROUND_NEAREST, True if floating point PIO clock divisors should be rounded to the nearest possible clock divisor rather than rounding down, type=bool, default=PICO_CLKDIV_ROUND_NEAREST, group=hardware_pio
 #ifndef PICO_PIO_CLKDIV_ROUND_NEAREST
 #define PICO_PIO_CLKDIV_ROUND_NEAREST PICO_CLKDIV_ROUND_NEAREST

--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -25,11 +25,7 @@
 
 // PICO_CONFIG: PICO_PIO_VERSION, PIO hardware version, type=int, default=0 on RP2040 and 1 on RP2350, group=hardware_pio
 #ifndef PICO_PIO_VERSION
-#if PIO_GPIOBASE_BITS
-#define PICO_PIO_VERSION 1
-#else
-#define PICO_PIO_VERSION 0
-#endif
+#define PICO_PIO_VERSION PIO_VERSION
 #endif
 
 // PICO_CONFIG: PICO_PIO_CLKDIV_ROUND_NEAREST, True if floating point PIO clock divisors should be rounded to the nearest possible clock divisor rather than rounding down, type=bool, default=PICO_CLKDIV_ROUND_NEAREST, group=hardware_pio

--- a/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
@@ -66,12 +66,13 @@ enum pio_src_dest {
     pio_x = 1u,
     pio_y = 2u,
     pio_null = 3u | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
-#if PIO_VERSION > 0
+#if PICO_PIO_VERSION > 0
     pio_pindirs_mov = 3u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC,
     pio_pindirs = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC,
 #else
     pio_pindirs = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
 #endif
+    pio_pindirs_out = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
     pio_exec_mov = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
     pio_status = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
     pio_pc = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
@@ -316,7 +317,7 @@ static inline uint pio_encode_wait_irq(bool polarity, bool relative, uint irq) {
     return _pio_encode_instr_and_args(pio_instr_bits_wait, 2u | (polarity ? 4u : 0u), _pio_encode_irq(relative, irq));
 }
 
-#if PICO_PIO_VERSION > 0
+#if PICO_PICO_PIO_VERSION > 0
 /*! \brief Encode a WAIT for jmppin instruction
  *  \ingroup pio_instructions
  *
@@ -360,6 +361,8 @@ static inline uint pio_encode_in(enum pio_src_dest src, uint count) {
  */
 static inline uint pio_encode_out(enum pio_src_dest dest, uint count) {
     valid_params_if(PIO_INSTRUCTIONS, !(dest & _PIO_INVALID_OUT_DEST));
+    static_assert((pio_pindirs & 7) == (pio_pindirs_out & 7), ""); // no need to convert
+    static_assert((pio_exec & 7) == (pio_exec_out & 7), ""); // no need to convert
     return _pio_encode_instr_and_src_dest(pio_instr_bits_out, dest, count);
 }
 
@@ -406,7 +409,7 @@ static inline uint pio_encode_mov(enum pio_src_dest dest, enum pio_src_dest src)
     valid_params_if(PIO_INSTRUCTIONS, !(src & _PIO_INVALID_MOV_SRC));
     // generic constants aren't the same as the MOV ones
     if (dest == pio_exec) dest = pio_exec_mov;
-#if PIO_VERSION > 0
+#if PICO_PIO_VERSION > 0
     if (dest == pio_pindirs) dest = pio_pindirs_mov;
 #endif
     return _pio_encode_instr_and_src_dest(pio_instr_bits_mov, dest, src & 7u);

--- a/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
@@ -9,7 +9,7 @@
 
 #include "pico.h"
 
-/** \brief PIO instruction encoding 
+/** \brief PIO instruction encoding
  *  \defgroup pio_instructions pio_instructions
  *  \ingroup hardware_pio
  * 
@@ -66,13 +66,19 @@ enum pio_src_dest {
     pio_x = 1u,
     pio_y = 2u,
     pio_null = 3u | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
+#if PIO_VERSION > 0
+    pio_pindirs_mov = 3u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC,
+    pio_pindirs = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC,
+#else
     pio_pindirs = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
+#endif
     pio_exec_mov = 4u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
     pio_status = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_DEST,
     pio_pc = 5u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
     pio_isr = 6u | _PIO_INVALID_SET_DEST,
     pio_osr = 7u | _PIO_INVALID_OUT_DEST | _PIO_INVALID_SET_DEST,
     pio_exec_out = 7u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC | _PIO_INVALID_MOV_DEST,
+    pio_exec = 7u | _PIO_INVALID_IN_SRC | _PIO_INVALID_SET_DEST | _PIO_INVALID_MOV_SRC,
 };
 
 static inline uint _pio_major_instr_bits(uint instr) {
@@ -398,6 +404,11 @@ static inline uint pio_encode_pull(bool if_empty, bool block) {
 static inline uint pio_encode_mov(enum pio_src_dest dest, enum pio_src_dest src) {
     valid_params_if(PIO_INSTRUCTIONS, !(dest & _PIO_INVALID_MOV_DEST));
     valid_params_if(PIO_INSTRUCTIONS, !(src & _PIO_INVALID_MOV_SRC));
+    // generic constants aren't the same as the MOV ones
+    if (dest == pio_exec) dest = pio_exec_mov;
+#if PIO_VERSION > 0
+    if (dest == pio_pindirs) dest = pio_pindirs_mov;
+#endif
     return _pio_encode_instr_and_src_dest(pio_instr_bits_mov, dest, src & 7u);
 }
 

--- a/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio_instructions.h
@@ -317,7 +317,7 @@ static inline uint pio_encode_wait_irq(bool polarity, bool relative, uint irq) {
     return _pio_encode_instr_and_args(pio_instr_bits_wait, 2u | (polarity ? 4u : 0u), _pio_encode_irq(relative, irq));
 }
 
-#if PICO_PICO_PIO_VERSION > 0
+#if PICO_PIO_VERSION > 0
 /*! \brief Encode a WAIT for jmppin instruction
  *  \ingroup pio_instructions
  *


### PR DESCRIPTION
* `pio_encode_mov(pio_pindirs)` was wrong because the `mov` destination for pindirs is a different value
* Noticed that `pio_instructions.h` is included before `PICO_PIO_VERSION` is set; didn't want to make a circular include, and previously pio_instructions.h is somewhat standalone include-able, so decided to add `PIO_VERSION` to `platform_defs.h`... TBH it should have been there already as the init of `PICO_PIO_VERSION` was a bit of a hack. I doubt anyone wants to override PICO_PIO_VERSION anyway
* I saw that we have `pio_exec_mov` and `pio_exec_out` - kept these for backwards compatibility, but decided to just allow `pio_exec` and have `pio_encode_mov` take care of it. as i imagine most of uses of `pio_encode_mov` take a constant arg, this isn't much of an overhead (the alternative would have been to encode the two different values in the enum value, which is fine, but likely going to lead to more code if done at runtime vs just the ifs)