### PR TITLE
pico_bootrom: fix activity LED not lighting in BOOTSEL on RP2350

### DIFF
--- a/src/rp2_common/pico_bootrom/bootrom.c
+++ b/src/rp2_common/pico_bootrom/bootrom.c
@@ -32,18 +32,28 @@ bool rom_funcs_lookup(uint32_t *table, unsigned int count) {
 }
 
 
+// When REBOOT_TYPE is BOOTSEL, the bootrom requires bit 0x20 to be set in
+// the reboot-flags word (the first argument to rom_reboot) for the GPIO
+// number in p1 to be honoured for the activity indicator. Numerically this
+// is the same bit as REBOOT2_FLAG_REBOOT_TO_RISCV, which is overloaded by
+// reboot type and means "BOOTSEL GPIO info valid" in this context — see
+// pico-sdk issue #2957 for the empirical confirmation on RP2350.
+#define _REBOOT2_BOOTSEL_GPIO_INFO_VALID 0x20u
+
 void __attribute__((noreturn)) rom_reset_usb_boot(uint32_t usb_activity_gpio_pin_mask, uint32_t disable_interface_mask) {
 #ifdef ROM_FUNC_RESET_USB_BOOT
     rom_reset_usb_boot_fn func = (rom_reset_usb_boot_fn) rom_func_lookup(ROM_FUNC_RESET_USB_BOOT);
     func(usb_activity_gpio_pin_mask, disable_interface_mask);
 #elif defined(ROM_FUNC_REBOOT)
+    uint32_t reboot_flags = REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL | REBOOT2_FLAG_NO_RETURN_ON_SUCCESS;
     uint32_t flags = disable_interface_mask;
     if (usb_activity_gpio_pin_mask) {
         flags |= BOOTSEL_FLAG_GPIO_PIN_SPECIFIED;
+        reboot_flags |= _REBOOT2_BOOTSEL_GPIO_INFO_VALID;
         // the parameter is actually the gpio number, but we only care if BOOTSEL_FLAG_GPIO_PIN_SPECIFIED
         usb_activity_gpio_pin_mask = (uint32_t)__builtin_ctz(usb_activity_gpio_pin_mask);
     }
-    rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL | REBOOT2_FLAG_NO_RETURN_ON_SUCCESS, 10, flags, usb_activity_gpio_pin_mask);
+    rom_reboot(reboot_flags, 10, flags, usb_activity_gpio_pin_mask);
     __builtin_unreachable();
 #else
     panic_unsupported();
@@ -56,14 +66,16 @@ void __attribute__((noreturn)) rom_reset_usb_boot_extra(int usb_activity_gpio_pi
     rom_reset_usb_boot_fn func = (rom_reset_usb_boot_fn) rom_func_lookup(ROM_FUNC_RESET_USB_BOOT);
     func(usb_activity_gpio_pin < 0 ? 0 : (1u << usb_activity_gpio_pin), disable_interface_mask);
 #elif defined(ROM_FUNC_REBOOT)
+    uint32_t reboot_flags = REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL | REBOOT2_FLAG_NO_RETURN_ON_SUCCESS;
     uint32_t flags = disable_interface_mask;
     if (usb_activity_gpio_pin >= 0) {
         flags |= BOOTSEL_FLAG_GPIO_PIN_SPECIFIED;
+        reboot_flags |= _REBOOT2_BOOTSEL_GPIO_INFO_VALID;
         if (usb_activity_gpio_pin_active_low) {
             flags |= BOOTSEL_FLAG_GPIO_PIN_ACTIVE_LOW;
         }
     }
-    rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL | REBOOT2_FLAG_NO_RETURN_ON_SUCCESS, 10, flags, (uint)usb_activity_gpio_pin);
+    rom_reboot(reboot_flags, 10, flags, (uint)usb_activity_gpio_pin);
     __builtin_unreachable();
 #else
     panic_unsupported();


### PR DESCRIPTION
## Summary

`rom_reset_usb_boot()` and `rom_reset_usb_boot_extra()` in `src/rp2_common/pico_bootrom/bootrom.c` set `BOOTSEL_FLAG_GPIO_PIN_SPECIFIED` in the BOOTSEL flags word (`p0` of `rom_reboot`) but not the corresponding bit in the reboot-flags word (the first argument to `rom_reboot`). On RP2350 the bootrom requires bit `0x20` to be set in **both** positions before it will honour the GPIO number in `p1` as an activity indicator — without the bit in the reboot-flags word the LED stays dark even though every other parameter is correct.

This makes the activity-LED parameter on `rom_reset_usb_boot[_extra]()` a no-op on RP2350. Fixing it is a two-line change at the call sites.

## Why `0x20` in the reboot-flags word

`0x20` in the reboot-flags word is already defined in `picoboot_constants.h` as `REBOOT2_FLAG_REBOOT_TO_RISCV`. The bit is overloaded by reboot type: for `REBOOT_TYPE_NORMAL`/`RAM_IMAGE`/`FLASH_UPDATE` it selects the RISC-V core, but for `REBOOT_TYPE_BOOTSEL` it means "GPIO info is valid in `p0`/`p1`", matching the meaning of `BOOTSEL_FLAG_GPIO_PIN_SPECIFIED` in `p0`.

The patch names the bit locally as `_REBOOT2_BOOTSEL_GPIO_INFO_VALID` (leading underscore to flag that the BOOTSEL-context meaning is empirically derived, not from a published bootrom header). A maintainer may want to promote it into `picoboot_constants.h` once the official name is known.

## How this was found

Originally filed in #2957 after observing that the LED never lit during BOOTSEL even with `rom_reset_usb_boot_extra(25, 0, false)`. A later [comment on that issue](https://github.com/raspberrypi/pico-sdk/issues/2957#issuecomment-4499389416) pointed out that `BOOTSEL_FLAG_GPIO_PIN_SPECIFIED` needed to be set in **both** the reboot-flags word and `p0`. Confirmed on a Pico 2 with two tests:

1. Direct `rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL | REBOOT2_FLAG_NO_RETURN_ON_SUCCESS | 0x20, 10, BOOTSEL_FLAG_GPIO_PIN_SPECIFIED, 25)` — LED flickers on MSD activity. Without the `| 0x20` it doesn't.
2. With the patch applied, the high-level wrapper `rom_reset_usb_boot_extra(25, 0, false)` produces the same visible flicker. Unpatched, the same call leaves the LED dark.

## Test plan

- [x] Built and flashed `rom_reset_usb_boot_extra(25, 0, false)` on Pico 2 (RP2350) against the patched SDK — LED visibly flickers on `cat /media/$USER/RP2350/INFO_UF2.TXT > /dev/null`.
- [x] Behaviour without the patch reproduced as solid dark LED in the same test.
- [ ] (Out of scope) RP2040 path is unchanged — RP2040 uses the dedicated `ROM_FUNC_RESET_USB_BOOT` and never enters the `#elif defined(ROM_FUNC_REBOOT)` branch.

Closes #2957.
