### PR TITLE
hardware_pio: document struct pio_program (#2686)

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -948,7 +948,7 @@ static inline uint pio_get_dreq(PIO pio, uint sm, bool is_tx) {
 typedef struct pio_program {
     const uint16_t *instructions;   ///< the array of \ref length encoded instructions that make up the program
     uint8_t length;                 ///< the number of instructions in \ref instructions (also the amount of instruction memory the program occupies)
-    int8_t origin;                  ///< the required load offset in PIO instruction memory, or -1 if the program is relocatable and may be loaded at any free offset
+    int8_t origin;                  ///< the required load offset in PIO instruction memory, or -1 if the program is relocatable and may be loaded at any offset
     uint8_t pio_version;            ///< the minimum PIO hardware version the program requires (0 for any PIO); loading a program that requires a newer version than the target PIO fails with \ref PICO_ERROR_VERSION_MISMATCH
 #if PICO_PIO_VERSION > 0
     uint8_t used_gpio_ranges;       ///< bitmap of the 16-pin GPIO ranges the program uses (bit 0 = pins 0-15, bit 1 = pins 16-31, bit 2 = pins 32-47), checked against the PIO instance's GPIO base (see \ref pio_set_gpio_base) so that an incompatible program is rejected

--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -936,13 +936,22 @@ static inline uint pio_get_dreq(PIO pio, uint sm, bool is_tx) {
     return PIO_DREQ_NUM(pio, sm, is_tx);
 }
 
+/** \brief PIO program definition
+ *  \ingroup hardware_pio
+ *
+ * This structure describes a PIO program: the array of encoded instructions plus the
+ * metadata needed to load it onto a PIO instance. It is the type emitted by the `pioasm`
+ * tool (as `<program_name>_program`) and consumed by \ref pio_add_program, \ref
+ * pio_can_add_program and related functions. It may also be populated by hand when
+ * assembling programs at runtime with the helpers in `pio_instructions.h`.
+ */
 typedef struct pio_program {
-    const uint16_t *instructions;
-    uint8_t length;
-    int8_t origin; // required instruction memory origin or -1
-    uint8_t pio_version;
+    const uint16_t *instructions;   ///< the array of \ref length encoded instructions that make up the program
+    uint8_t length;                 ///< the number of instructions in \ref instructions (also the amount of instruction memory the program occupies)
+    int8_t origin;                  ///< the required load offset in PIO instruction memory, or -1 if the program is relocatable and may be loaded at any free offset
+    uint8_t pio_version;            ///< the minimum PIO hardware version the program requires (0 for any PIO); loading a program that requires a newer version than the target PIO fails with \ref PICO_ERROR_VERSION_MISMATCH
 #if PICO_PIO_VERSION > 0
-    uint8_t used_gpio_ranges; // bitmap with one bit per 16 pins
+    uint8_t used_gpio_ranges;       ///< bitmap of the 16-pin GPIO ranges the program uses (bit 0 = pins 0-15, bit 1 = pins 16-31, bit 2 = pins 32-47), checked against the PIO instance's GPIO base (see \ref pio_set_gpio_base) so that an incompatible program is rejected
 #endif
 } pio_program_t;
 


### PR DESCRIPTION
## Summary

`struct pio_program` / `pio_program_t` is passed to a large part of the PIO API (`pio_add_program`, `pio_can_add_program`, …) but carried no doxygen, and several of its fields aren't self-explanatory — `origin`, `pio_version`, and (on PIO v1) `used_gpio_ranges`. #2686 asks for it to be documented.

This adds a `\brief` for the struct plus per-member `///<` descriptions:

- **`instructions`** / **`length`** — the encoded instruction array and its size (also the instruction-memory footprint).
- **`origin`** — required load offset, or `-1` if relocatable.
- **`pio_version`** — minimum required PIO hardware version (`0` = any); loading on too-old hardware fails with `PICO_ERROR_VERSION_MISMATCH` (matches the check in `pio.c`).
- **`used_gpio_ranges`** — bitmap of 16-pin GPIO ranges the program uses (bit 0 = pins 0-15, bit 1 = 16-31, bit 2 = 32-47), checked against the instance's GPIO base (`pio_set_gpio_base`). Bit layout and the compatibility rule are taken directly from `is_gpio_compatible()` in `pio.c`.

Documentation only — no functional change.

## Test plan

- [x] Built `hardware_pio` on RP2350 (`PICO_PIO_VERSION > 0`, so the `used_gpio_ranges` member is compiled) — header parses cleanly, no warnings from the new comments.
- [x] All `\ref` targets verified to exist: `pio_add_program`, `pio_can_add_program`, `pio_set_gpio_base`, `PICO_ERROR_VERSION_MISMATCH`.

Closes #2686.
