### PR TITLE
Fix flash_cs_force

### DIFF
--- a/src/rp2_common/hardware_flash/flash.c
+++ b/src/rp2_common/hardware_flash/flash.c
@@ -263,7 +263,7 @@ void __no_inline_not_in_flash_func(flash_range_program)(uint32_t flash_offs, con
 
 // Bitbanging the chip select using IO overrides, in case RAM-resident IRQs
 // are still running, and the FIFO bottoms out. (the bootrom does the same)
-static __force_inline void flash_cs_force(bool high, uint8_t cs) {
+static __force_inline void flash_cs_force(bool high, uint cs) {
 #if PICO_RP2040
     (void)cs;
     uint32_t field_val = high ?


### PR DESCRIPTION
The picotool CI build of pico-examples was failing with this error:

```
/home/runner/work/picotool/picotool/pico-sdk/src/rp2_common/hardware_flash/flash.c: In function 'flash_do_cmd_cs':
/home/runner/work/picotool/picotool/pico-sdk/src/rp2_common/hardware_flash/flash.c:299:23: error: conversion from 'uint' {aka 'unsigned int'} to 'uint8_t' {aka 'unsigned char'} may change value [-Werror=conversion]
  299 |     flash_cs_force(0, cs);
      |                       ^~
```

This was broken by https://github.com/raspberrypi/pico-sdk/pull/2919/changes/15fd99682fcc65bc0f4cf779bafd4e48b2f8366d which updated `flash_do_cmd_cs` to take a `uint` but left `flash_cs_force` expecting a `uint8_t` - this fixes that