### PR TITLE
Add crt0 support for booting no_flash binaries using the bootrom

### DIFF
--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -440,7 +440,7 @@ _entry_point:
         // scratch 5 = magic number xored with -(magic number) == -2
         subs r5, r6, #5 // 3 - 5 = -2
         // load the watchdog registers
-        stm r1, {r2, r3, r4, r5, r6, r7}
+        stm r1!, {r2, r3, r4, r5, r6, r7}
     #endif
 
     // Go back through bootrom to finish the boot.

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -21,12 +21,12 @@
 #define PICO_CRT0_NEAR_CALLS 0
 #endif
 
-// PICO_CONFIG: PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM, Whether crt0 should always reset through the bootrom when loaded using a debugger - not supported on RP2040, default=1, type=bool, advanced=true, group=pico_crt0
+// PICO_CONFIG: PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM, Whether crt0 should reset through the bootrom when loaded using a debugger - defining this variable is not supported on RP2040, default=1, type=bool, advanced=true, group=pico_crt0
 #if PICO_RP2040
-#define PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM 0
+#define PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM (!PICO_NO_FLASH)
 #else
-#ifndef PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
-#define PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM 1
+#ifndef PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM
+#define PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM 1
 #endif
 #endif
 
@@ -392,7 +392,7 @@ binary_info_header:
 .global _entry_point
 _entry_point:
 
-#if PICO_NO_FLASH && !PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
+#if !PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM
     // in the NO_FLASH case, we do not do a rest thru bootrom below, so the RCP may or may not have been initialized:
     //
     // in the normal case (UF2 download, etc.), we will have passed thru bootrom initialization, but if
@@ -424,8 +424,10 @@ _entry_point:
     ldr r0, =__vectors
     // Vector through our own table (SP, VTOR will not have been set up at
     // this point). Same path for debugger entry and bootloader entry.
-#else // PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM or !PICO_NOFLASH
-    #if PICO_NO_FLASH // PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM is always 0 on RP2040, so this code doesn't support RP2040
+#else // PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM
+    #if PICO_NO_FLASH
+        // PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM is always !PICO_NO_FLASH on RP2040, so this code doesn't support RP2040,
+        // because RP2040 doesn't have special watchdog boot types
         // Launch this no_flash binary using a RAM image boot
         ldr r1, =(WATCHDOG_BASE + WATCHDOG_SCRATCH2_OFFSET) // registers start from here
         // scratch 2 = __logical_binary_start
@@ -440,7 +442,7 @@ _entry_point:
         // scratch 5 = magic number xored with -(magic number) == -2
         subs r5, r6, #5 // 3 - 5 = -2
         // load the watchdog registers
-        stm r1!, {r2, r3, r4, r5, r6, r7}
+        stmia r1!, {r2, r3, r4, r5, r6, r7}
     #endif
 
     // Go back through bootrom to finish the boot.

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -444,11 +444,7 @@ _entry_point:
     #endif
 
     // Go back through bootrom to finish the boot.
-    #if BOOTROM_VTABLE_OFFSET < 255 // fits in 8-bit immediate
-        movs r0, #BOOTROM_VTABLE_OFFSET
-    #else
-        ldr r0, =BOOTROM_VTABLE_OFFSET
-    #endif
+    movs r0, #BOOTROM_VTABLE_OFFSET
 #endif
 
 _enter_vtable_in_r0:
@@ -484,11 +480,7 @@ _reset_handler:
 #endif
 hold_non_core0_in_bootrom:
     // Send back to the ROM to wait for core 0 to launch it.
-    #if BOOTROM_VTABLE_OFFSET < 255 // fits in 8-bit immediate
-        movs r0, #BOOTROM_VTABLE_OFFSET
-    #else
-        ldr r0, =BOOTROM_VTABLE_OFFSET
-    #endif
+    movs r0, #BOOTROM_VTABLE_OFFSET
     b _enter_vtable_in_r0
 1:
 

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -11,6 +11,7 @@
 
 #include "hardware/regs/addressmap.h"
 #include "hardware/regs/sio.h"
+#include "hardware/regs/watchdog.h"
 #include "pico/binary_info/defs.h"
 #include "boot/picobin.h"
 #include "pico/bootrom.h"
@@ -18,6 +19,15 @@
 // PICO_CONFIG: PICO_CRT0_NEAR_CALLS, Whether calls from crt0 into the binary are near (<16M away) - ignored for PICO_COPY_TO_RAM, default=0, type=bool, group=pico_crt0
 #ifndef PICO_CRT0_NEAR_CALLS
 #define PICO_CRT0_NEAR_CALLS 0
+#endif
+
+// PICO_CONFIG: PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM, Whether crt0 should always reset through the bootrom when loaded using a debugger - not supported on RP2040, default=1, type=bool, advanced=true, group=pico_crt0
+#if PICO_RP2040
+#define PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM 0
+#else
+#ifndef PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
+#define PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM 1
+#endif
 #endif
 
 #ifdef NDEBUG
@@ -382,7 +392,7 @@ binary_info_header:
 .global _entry_point
 _entry_point:
 
-#if PICO_NO_FLASH
+#if PICO_NO_FLASH && !PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
     // on the NO_FLASH case, we do not do a rest thru bootrom below, so the RCP may or may not have been initialized:
     //
     // in the normal (e.g. UF2 download etc. case) we will have passed thru bootrom initialization, but if
@@ -414,9 +424,28 @@ _entry_point:
     ldr r0, =__vectors
     // Vector through our own table (SP, VTOR will not have been set up at
     // this point). Same path for debugger entry and bootloader entry.
-#else
-    // Debugger tried to run code after loading, so SSI is in 03h-only mode.
-    // Go back through bootrom + boot2 to properly initialise flash.
+#else // PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM or !PICO_NOFLASH
+    #if PICO_NO_FLASH // PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM is always 0 on RP2040, so this code doesn't support RP2040
+        // Launch this no_flash binary using a RAM image boot
+        ldr r1, =(WATCHDOG_BASE + WATCHDOG_SCRATCH2_OFFSET) // offsets start from here, to fit in str immediate
+        // scratch 2 = __logical_binary_start
+        ldr r0, =__logical_binary_start
+        str r0, [r1, #0]
+        // scratch 3 = size
+        ldr r0, =(SRAM_END - SRAM_BASE) // assume maximum size for block loop
+        str r0, [r1, #4]
+        // scratch 4&7 = magic number
+        ldr r0, =0xb007c0d3
+        str r0, [r1, #8]
+        str r0, [r1, #20]
+        // scratch 5 = magic number xored with -(magic number) == -2
+        ldr r0, =(-2)
+        str r0, [r1, #12]
+        // scratch 6 = ram image boot == 3
+        ldr r0, =3
+        str r0, [r1, #16]
+    #endif
+    // Go back through bootrom to finish the boot.
     ldr r0, =BOOTROM_VTABLE_OFFSET
 #endif
 

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -393,9 +393,9 @@ binary_info_header:
 _entry_point:
 
 #if PICO_NO_FLASH && !PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
-    // on the NO_FLASH case, we do not do a rest thru bootrom below, so the RCP may or may not have been initialized:
+    // in the NO_FLASH case, we do not do a rest thru bootrom below, so the RCP may or may not have been initialized:
     //
-    // in the normal (e.g. UF2 download etc. case) we will have passed thru bootrom initialization, but if
+    // in the normal case (UF2 download, etc.), we will have passed thru bootrom initialization, but if
     // a NO_FLASH binary is loaded by the debugger, and run directly after a reset, then we won't have.
     //
     // we must therefore initialize the RCP if it hasn't already been

--- a/src/rp2_common/pico_crt0/crt0.S
+++ b/src/rp2_common/pico_crt0/crt0.S
@@ -427,26 +427,28 @@ _entry_point:
 #else // PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM or !PICO_NOFLASH
     #if PICO_NO_FLASH // PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM is always 0 on RP2040, so this code doesn't support RP2040
         // Launch this no_flash binary using a RAM image boot
-        ldr r1, =(WATCHDOG_BASE + WATCHDOG_SCRATCH2_OFFSET) // offsets start from here, to fit in str immediate
+        ldr r1, =(WATCHDOG_BASE + WATCHDOG_SCRATCH2_OFFSET) // registers start from here
         // scratch 2 = __logical_binary_start
-        ldr r0, =__logical_binary_start
-        str r0, [r1, #0]
+        ldr r2, =__logical_binary_start
         // scratch 3 = size
-        ldr r0, =(SRAM_END - SRAM_BASE) // assume maximum size for block loop
-        str r0, [r1, #4]
+        ldr r3, =(SRAM_END - SRAM_BASE) // assume maximum size for block loop
         // scratch 4&7 = magic number
-        ldr r0, =0xb007c0d3
-        str r0, [r1, #8]
-        str r0, [r1, #20]
-        // scratch 5 = magic number xored with -(magic number) == -2
-        ldr r0, =(-2)
-        str r0, [r1, #12]
+        ldr r4, =0xb007c0d3
+        mov r7, r4
         // scratch 6 = ram image boot == 3
-        ldr r0, =3
-        str r0, [r1, #16]
+        movs r6, #3
+        // scratch 5 = magic number xored with -(magic number) == -2
+        subs r5, r6, #5 // 3 - 5 = -2
+        // load the watchdog registers
+        stm r1, {r2, r3, r4, r5, r6, r7}
     #endif
+
     // Go back through bootrom to finish the boot.
-    ldr r0, =BOOTROM_VTABLE_OFFSET
+    #if BOOTROM_VTABLE_OFFSET < 255 // fits in 8-bit immediate
+        movs r0, #BOOTROM_VTABLE_OFFSET
+    #else
+        ldr r0, =BOOTROM_VTABLE_OFFSET
+    #endif
 #endif
 
 _enter_vtable_in_r0:
@@ -482,7 +484,11 @@ _reset_handler:
 #endif
 hold_non_core0_in_bootrom:
     // Send back to the ROM to wait for core 0 to launch it.
-    ldr r0, =BOOTROM_VTABLE_OFFSET
+    #if BOOTROM_VTABLE_OFFSET < 255 // fits in 8-bit immediate
+        movs r0, #BOOTROM_VTABLE_OFFSET
+    #else
+        ldr r0, =BOOTROM_VTABLE_OFFSET
+    #endif
     b _enter_vtable_in_r0
 1:
 

--- a/src/rp2_common/pico_crt0/crt0_riscv.S
+++ b/src/rp2_common/pico_crt0/crt0_riscv.S
@@ -295,9 +295,8 @@ binary_info_header:
 _entry_point:
 
 #if PICO_NO_FLASH && !PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
-    // Go through our own reset handler. Same path for debugger entry and
+    // Fall through to _reset_handler. Same path for debugger entry and
     // bootloader entry.
-    j _reset_handler
 #else
     #if PICO_NO_FLASH
         // Launch this no_flash binary using a RAM image boot

--- a/src/rp2_common/pico_crt0/crt0_riscv.S
+++ b/src/rp2_common/pico_crt0/crt0_riscv.S
@@ -31,8 +31,8 @@
 #define PICO_CRT0_INCLUDE_PICOBIN_END_BLOCK (PICO_CRT0_INCLUDE_PICOBIN_BLOCK && !PICO_NO_FLASH)
 #endif
 
-#ifndef PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
-#define PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM 1
+#ifndef PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM
+#define PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM 1
 #endif
 
 // If vectors are in RAM, we put them in the .data section, so that they are
@@ -294,7 +294,7 @@ binary_info_header:
 .global _entry_point
 _entry_point:
 
-#if PICO_NO_FLASH && !PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
+#if !PICO_CRT0_DEBUG_ENTRY_RESETS_VIA_BOOTROM
     // Fall through to _reset_handler. Same path for debugger entry and
     // bootloader entry.
 #else

--- a/src/rp2_common/pico_crt0/crt0_riscv.S
+++ b/src/rp2_common/pico_crt0/crt0_riscv.S
@@ -8,6 +8,7 @@
 
 #include "hardware/regs/addressmap.h"
 #include "hardware/regs/rvcsr.h"
+#include "hardware/regs/watchdog.h"
 #include "pico/binary_info/defs.h"
 #include "boot/picobin.h"
 #include "pico/bootrom_constants.h"
@@ -28,6 +29,10 @@
 
 #ifndef PICO_CRT0_INCLUDE_PICOBIN_END_BLOCK
 #define PICO_CRT0_INCLUDE_PICOBIN_END_BLOCK (PICO_CRT0_INCLUDE_PICOBIN_BLOCK && !PICO_NO_FLASH)
+#endif
+
+#ifndef PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
+#define PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM 1
 #endif
 
 // If vectors are in RAM, we put them in the .data section, so that they are
@@ -289,11 +294,31 @@ binary_info_header:
 .global _entry_point
 _entry_point:
 
-#if PICO_NO_FLASH
+#if PICO_NO_FLASH && !PICO_CRT0_ALWAYS_RESET_THROUGH_BOOTROM
     // Go through our own reset handler. Same path for debugger entry and
     // bootloader entry.
     j _reset_handler
 #else
+    #if PICO_NO_FLASH
+        // Launch this no_flash binary using a RAM image boot
+        la a1, WATCHDOG_BASE + WATCHDOG_SCRATCH2_OFFSET // offsets start from here, to fit in sw immediate
+        // scratch 2 = __logical_binary_start
+        la a0, __logical_binary_start
+        sw a0, 0(a1)
+        // scratch 3 = size
+        li a0, SRAM_END - SRAM_BASE // assume maximum size for block loop
+        sw a0, 4(a1)
+        // scratch 4&7 = magic number
+        li a0, 0xb007c0d3
+        sw a0, 8(a1)
+        sw a0, 20(a1)
+        // scratch 5 = magic number xored with -(magic number) == -2
+        li a0, -2
+        sw a0, 12(a1)
+        // scratch 6 = ram image boot == 3
+        li a0, 3
+        sw a0, 16(a1)
+    #endif
     // Debugger tried to run code after loading, so SSI is in 03h-only mode.
     // Go back through bootrom + boot2 to properly initialise flash.
     j reenter_bootrom


### PR DESCRIPTION
Add crt0 support for running through the bootrom when using no_flash binaries with a debugger, by programming the watchdog scratch for a RAM image boot before calling into the bootrom.

This allows using load_maps to load code under the debugger (eg xip_sram pinning, or copying around stuff), just as they would work from any other boot. No support is added for RP2040, as it doesn't have magic watchdog reboot types, and the existing entry_point works fine anyway.

This PR enables this by default, but that can be changed if desired - there is code size decrease on Arm (0x8) as it would need to setup RCP and SP anyway, but an increase on Risc-V (0x2a)