### PR TITLE
pico_cyw43_arch FreeRTOS+lwIP: route errno through newlib (LWIP_ERRNO_STDINCLUDE)

### DIFF
--- a/src/rp2_common/pico_cyw43_arch/CMakeLists.txt
+++ b/src/rp2_common/pico_cyw43_arch/CMakeLists.txt
@@ -67,7 +67,13 @@ if (PICO_CYW43_SUPPORTED) # set by BOARD=pico-w
                     pico_cyw43_arch_sys_freertos)
             target_compile_definitions(pico_cyw43_arch_lwip_sys_freertos_headers INTERFACE
                     CYW43_LWIP=1
-                    LWIP_PROVIDE_ERRNO=1
+                    # FreeRTOS+lwIP uses newlib, which provides a thread-local errno
+                    # via <errno.h>. LWIP_PROVIDE_ERRNO=1 would declare lwIP's own
+                    # `extern int errno` global, diverging from newlib's storage and
+                    # silently breaking mbedTLS BIO shims (and any code reading errno
+                    # via <errno.h>) that miss the EWOULDBLOCK lwIP wrote.
+                    # LWIP_ERRNO_STDINCLUDE=1 routes lwIP through <errno.h> instead.
+                    LWIP_ERRNO_STDINCLUDE=1
                     # now the default
                     #PICO_LWIP_CUSTOM_LOCK_TCPIP_CORE=1 # we want to override the lwip locking mechanism to use our mutex
                     )


### PR DESCRIPTION
Fixes #2973.

## What

Swap `LWIP_PROVIDE_ERRNO=1` for `LWIP_ERRNO_STDINCLUDE=1` on the `pico_cyw43_arch_lwip_sys_freertos` variant. Single hunk in `src/rp2_common/pico_cyw43_arch/CMakeLists.txt`.

## Why

`LWIP_PROVIDE_ERRNO=1` is correct for bare-metal builds (no libc owns `errno`), but the FreeRTOS+lwIP variant always ships with newlib, which already provides a thread-local `errno` via `<errno.h>`. The unconditional `LWIP_PROVIDE_ERRNO=1` makes lwIP declare its own `extern int errno` global, diverging from newlib's storage. Any code reading `errno` via `<errno.h>` — including the standard mbedTLS `library/net_sockets.c` BIO — misses the `EWOULDBLOCK` lwIP wrote, treats every non-blocking `recv()` poll as fatal, and tears the TLS session down right after handshake.

`LWIP_ERRNO_STDINCLUDE=1` keeps lwIP's `E*` constants available but routes them via `<errno.h>`, so lwIP and the rest of the program share newlib's thread-local storage. Issue #2973 has the full diagnosis and an observable symptom description (TLS handshake completes → application sends e.g. MQTT `CONNECT` → server queues `CONNACK` → client immediately FINs without reading the response → loop forever at the application's backoff cadence).

## Scope

- Only `pico_cyw43_arch_lwip_sys_freertos_headers` is touched.
- `pico_cyw43_arch_lwip_threadsafe_background` (bare-metal) does not currently set `LWIP_PROVIDE_ERRNO=1`, so no change needed there.
- Comment block added inline explaining the choice for future maintainers.

## Compatibility

Behaviour-preserving for users who don't touch `errno` directly — lwIP's `E*` constants still resolve, just through `<errno.h>`. Correcting for users on the stock mbedTLS BIO pattern (or any equivalent POSIX-style errno shim).

## Test

I verified the equivalent fix locally as a project-side override in `lwipopts.h`: cancelling the SDK's `-D LWIP_PROVIDE_ERRNO=1` and setting `LWIP_ERRNO_STDINCLUDE=1` resolved a persistent MQTT `CONNECT/CONNACK/close` storm on Pico 2W (FreeRTOS + lwIP + mbedTLS + coreMQTT). This PR moves that fix from a per-project workaround to the SDK default for the variant.