### PR TITLE
resolve inconsistent use of PICO_PIO_VERSION > 0 and PICO_PIO_USE_GPIO_BASE

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -151,6 +151,8 @@ typedef pio_hw_t *PIO;
 // PICO_CONFIG: PICO_PIO_USE_GPIO_BASE, Enable code for handling more than 32 PIO pins, type=bool, default=true when supported and when the device has more than 32 pins, group=hardware_pio
 #define PICO_PIO_USE_GPIO_BASE ((NUM_BANK0_GPIOS) > 32)
 #endif
+#else
+#define PICO_PIO_USE_GPIO_BASE 0
 #endif
 
 /**
@@ -784,7 +786,7 @@ static inline pio_sm_config pio_get_default_sm_config(void) {
  * \return the current GPIO base for the PIO instance
   */
 static inline uint pio_get_gpio_base(PIO pio) {
-#if PICO_PIO_VERSION > 0
+#if PICO_PIO_USE_GPIO_BASE
     return pio->gpiobase;
 #else
     ((void)pio);

--- a/src/rp2_common/hardware_pio/pio.c
+++ b/src/rp2_common/hardware_pio/pio.c
@@ -83,7 +83,7 @@ static int find_offset_for_program(PIO pio, const pio_program_t *program) {
 
 static int pio_set_gpio_base_unsafe(PIO pio, uint gpio_base) {
     invalid_params_if_and_return(HARDWARE_PIO, gpio_base != 0 && (!PICO_PIO_VERSION || gpio_base != 16), PICO_ERROR_BAD_ALIGNMENT);
-#if PICO_PIO_VERSION > 0
+#if PICO_PIO_USE_GPIO_BASE
     uint32_t used_mask = _used_instruction_space[pio_get_index(pio)];
     invalid_params_if_and_return(HARDWARE_PIO, used_mask, PICO_ERROR_INVALID_STATE);
     pio->gpiobase = gpio_base;
@@ -96,7 +96,7 @@ static int pio_set_gpio_base_unsafe(PIO pio, uint gpio_base) {
 
 int pio_set_gpio_base(PIO pio, uint gpio_base) {
     int rc = PICO_OK;
-#if PICO_PIO_VERSION > 0
+#if PICO_PIO_USE_GPIO_BASE
     uint32_t save = hw_claim_lock();
     rc = pio_set_gpio_base_unsafe(pio, gpio_base);
     hw_claim_unlock(save);
@@ -108,7 +108,7 @@ int pio_set_gpio_base(PIO pio, uint gpio_base) {
 }
 
 static bool is_gpio_compatible(PIO pio, uint32_t used_gpio_ranges) {
-#if PICO_PIO_VERSION > 0
+#if PICO_PIO_USE_GPIO_BASE
     bool gpio_base = pio_get_gpio_base(pio);
     return !((gpio_base && (used_gpio_ranges & 1)) ||
              (!gpio_base && (used_gpio_ranges & 4)));


### PR DESCRIPTION
`PICO_PIO_VERSION > 0` applies to any RP2350, however `PICO_PIO_USE_GPIO_BASE=1` is only set by default for variants with >32 GPIOs

When `PICO_PIO_USE_GPIO_BASE= 0` we omit any setting/logic related to gpio_base (i.e. the SDK assumes it is always 0, and never sets it), so we replace old uses of `PICO_PIO_VERSION > 0` with `PICO_PUO_USE_GPIO_BASE` when gating gpio_base code

fixes #2712