### PR TITLE
Fix stdio_usb_deinit in debug builds

### DIFF
--- a/src/rp2_common/pico_stdio_usb/stdio_usb.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb.c
@@ -279,7 +279,6 @@ bool stdio_usb_deinit(void) {
 
 #if PICO_STDIO_USB_ENABLE_IRQ_BACKGROUND_TASK
     if (irq_has_shared_handler(USBCTRL_IRQ)) {
-        spin_lock_unclaim(spin_lock_get_num(one_shot_timer_crit_sec.spin_lock));
         critical_section_deinit(&one_shot_timer_crit_sec);
         // we can use a shared handler to notice when there may be work to do
         irq_remove_handler(USBCTRL_IRQ, usb_irq);


### PR DESCRIPTION
Was unclaiming the spin_lock before `critical_section_deinit` tried to unclaim it again, triggering an assertion failure

Fixes #2982