### PR TITLE
Small clarifications to the PIO "pinhi" code

### DIFF
--- a/src/rp2_common/hardware_pio/include/hardware/pio.h
+++ b/src/rp2_common/hardware_pio/include/hardware/pio.h
@@ -73,7 +73,7 @@
  * instance either addresses pins 0-31 or 16-47 based on \ref pio_set_gpio_base). The
  * `pio_sm_` methods that directly affect the hardware always take _real_ pin numbers in the full range, however:
  *
- * * If `PICO_PIO_USE_GPIO_BASE != 1` then the 5th bit of the pin number is ignored. This is done so
+ * * If `PICO_PIO_USE_GPIO_BASE != 1` then bit 5 of the pin number is ignored. This is done so
  *   that programs compiled for boards with RP2350A do not incur the extra overhead of dealing with higher pins that don't exist.
  *   Effectively these functions behave exactly like RP2040 in this case.
  *   Note that `PICO_PIO_USE_GPIO_BASE` is defaulted to 0 if `PICO_RP2350A` is 1
@@ -271,7 +271,7 @@ static_assert(DREQ_PIO2_RX0 == DREQ_PIO2_TX0 + NUM_PIO_STATE_MACHINES, "");
  * instance either addresses pins 0-31 or 16-47 based on \ref pio_set_gpio_base). The
  * `sm_config_` state machine configuration always take _real_ pin numbers in the full range, however:
  *
- * * If `PICO_PIO_USE_GPIO_BASE != 1` then the 5th bit of the pin number is ignored. This is done so
+ * * If `PICO_PIO_USE_GPIO_BASE != 1` then bit 5 of the pin number is ignored. This is done so
  *   that programs compiled for boards with RP2350A do not incur the extra overhead of dealing with higher pins that don't exist.
  *   Effectively these functions behave exactly like RP2040 in this case.
  *   Note that `PICO_PIO_USE_GPIO_BASE` is defaulted to 0 if `PICO_RP2350A` is 1
@@ -309,8 +309,7 @@ typedef struct {
 // note we put the out_special pin starting at bit 20
 #define PINHI_EXECCTRL_LSB 20
 static_assert( (1u << PINHI_EXECCTRL_LSB) > (PINHI_ALL_PINCTRL_LSBS * 0x1f), "");
-#define PINHI_ALL_PIN_LSBS ((1u << PINHI_EXECCTRL_LSB) |(1u << PIO_SM0_PINCTRL_IN_BASE_LSB) | (1u << PIO_SM0_PINCTRL_OUT_BASE_LSB) | \
-                               (1u << PIO_SM0_PINCTRL_SET_BASE_LSB) | (1u << PIO_SM0_PINCTRL_SIDESET_BASE_LSB))
+#define PINHI_ALL_PIN_LSBS ((1u << PINHI_EXECCTRL_LSB) | PINHI_ALL_PINCTRL_LSBS)
     // each 5-bit field which would usually be used for the pin_base in pin_ctrl, is used for:
     // 0b11111 - corresponding field not specified
     // 0b00000 - pin is in range 0-15
@@ -640,8 +639,8 @@ static inline void sm_config_set_jmp_pin(pio_sm_config *c, uint pin) {
     c->execctrl = (c->execctrl & ~PIO_SM0_EXECCTRL_JMP_PIN_BITS) |
                   ((pin & 31) << PIO_SM0_EXECCTRL_JMP_PIN_LSB);
 #if PICO_PIO_USE_GPIO_BASE
-    c->pinhi = (c->pinhi & ~(31u << 20)) |
-               ((pin >> 4) << 20);
+    c->pinhi = (c->pinhi & ~(31u << PINHI_EXECCTRL_LSB)) |
+               ((pin >> 4) << PINHI_EXECCTRL_LSB);
 #endif
 }
 
@@ -827,11 +826,16 @@ static inline int pio_sm_set_config(PIO pio, uint sm, const pio_sm_config *confi
     pio->sm[sm].clkdiv = config->clkdiv;
     pio->sm[sm].shiftctrl = config->shiftctrl;
 #if PICO_PIO_USE_GPIO_BASE
-    uint used = (~config->pinhi >> 4) & PINHI_ALL_PIN_LSBS;
+    // definition of the 5-bit fields within config->pinhi:
+    // 0b11111 - corresponding field not specified
+    // 0b00000 - pin is in range 0-15
+    // 0b00001 - pin is in range 16-31
+    // 0b00010 - pin is in range 32-47
+    uint32_t used = (~config->pinhi >> 4) & PINHI_ALL_PIN_LSBS; // checks if bit 5 of any field is 0
     // configs that use pins 0-15
-    uint gpio_under_16 = (~config->pinhi) & (~config->pinhi >> 1) & used;
+    uint32_t gpio_under_16 = (~config->pinhi) & (~config->pinhi >> 1) & used; // checks if bits 0 and 1 of any field are both 0
     // configs that use pins 32-47
-    uint gpio_over_32 = (config->pinhi >> 1) & used;
+    uint32_t gpio_over_32 = (config->pinhi >> 1) & used; // checks if bit 1 of any field is 1
     uint gpio_base = pio_get_gpio_base(pio);
     invalid_params_if_and_return(PIO, gpio_under_16 && gpio_base, PICO_ERROR_BAD_ALIGNMENT);
     invalid_params_if_and_return(PIO, gpio_over_32 && !gpio_base, PICO_ERROR_BAD_ALIGNMENT);
@@ -839,7 +843,8 @@ static inline int pio_sm_set_config(PIO pio, uint sm, const pio_sm_config *confi
     // bit6(32) + 0-15  -> base(16) + 16-31
     // bit6(0)  + 16-31 -> base(16) + 0-15
     static_assert(PINHI_EXECCTRL_LSB == 20, ""); // we use shifts to mask off bits below
-    pio->sm[sm].execctrl = config->execctrl ^ (gpio_base ? ((used >> 20) << (PIO_SM0_EXECCTRL_JMP_PIN_LSB + 4)) : 0);
+    pio->sm[sm].execctrl = config->execctrl ^ (gpio_base ? ((used >> PINHI_EXECCTRL_LSB) << (PIO_SM0_EXECCTRL_JMP_PIN_LSB + 4)) : 0);
+    // the "12" here is a result of "sizeof(used) - PINHI_EXECCTRL_LSB" (i.e. 32 - 20) and is used to shift off the execctrl bits
     pio->sm[sm].pinctrl = config->pinctrl ^ (gpio_base ? ((used << 12) >> 8) : 0);
 #else
     pio->sm[sm].execctrl = config->execctrl;


### PR DESCRIPTION
I changed "5th bit" to "bit 5" to remove any ambiguity with zero-based indexing (personally I'd consider "bit 0" to be "the first bit").

I removed the "magic number" in `sm_config_set_jmp_pin`.

I added some explanatory comments.

I changed `used` from `uint` to an explicit `uint32_t`, because I believe the bit-shifting on line 848 won't work correctly if it's not 32-bits? (`pinhi` itself is also declared as `uint32_t`)