### PR TITLE
More doxygen fixups

### DIFF
--- a/src/combined-docs.cmake
+++ b/src/combined-docs.cmake
@@ -24,6 +24,7 @@ pico_add_doxygen_pre_define("PICO_RP2040=1")
 pico_add_doxygen_pre_define("PICO_RP2350=1")
 pico_add_doxygen_pre_define("PICO_COMBINED_DOCS=1")
 pico_add_doxygen_pre_define("NUM_DOORBELLS=1") # we have functions that are gated by this
+pico_add_doxygen_pre_define("HAS_POWMAN_TIMER=1") # we have functions that are gated by this
 pico_add_doxygen_enabled_section(combined_docs)
 pico_add_doxygen_enabled_section(rp2040_specific)
 pico_add_doxygen_enabled_section(rp2350_specific)

--- a/src/combined-docs.cmake
+++ b/src/combined-docs.cmake
@@ -24,6 +24,7 @@ pico_add_doxygen_pre_define("PICO_RP2040=1")
 pico_add_doxygen_pre_define("PICO_RP2350=1")
 pico_add_doxygen_pre_define("PICO_COMBINED_DOCS=1")
 pico_add_doxygen_pre_define("NUM_DOORBELLS=1") # we have functions that are gated by this
+pico_add_doxygen_pre_define("NUM_BOOT_LOCKS=1") # we have functions that are gated by this
 pico_add_doxygen_pre_define("HAS_POWMAN_TIMER=1") # we have functions that are gated by this
 pico_add_doxygen_enabled_section(combined_docs)
 pico_add_doxygen_enabled_section(rp2040_specific)

--- a/src/rp2350-arm-s.cmake
+++ b/src/rp2350-arm-s.cmake
@@ -13,6 +13,7 @@ set(PICO_DEFAULT_FLASH_SIZE_BYTES "4 * 1024 * 1024")
 pico_add_doxygen_pre_define("PICO_RP2040=0")
 pico_add_doxygen_pre_define("PICO_RP2350=1")
 pico_add_doxygen_pre_define("NUM_DOORBELLS=1") # we have functions that are gated by this
+pico_add_doxygen_pre_define("NUM_BOOT_LOCKS=1") # we have functions that are gated by this
 pico_add_doxygen_pre_define("HAS_POWMAN_TIMER=1") # we have functions that are gated by this
 pico_add_doxygen_enabled_section(rp2350_specific)
 

--- a/src/rp2350-arm-s.cmake
+++ b/src/rp2350-arm-s.cmake
@@ -13,6 +13,7 @@ set(PICO_DEFAULT_FLASH_SIZE_BYTES "4 * 1024 * 1024")
 pico_add_doxygen_pre_define("PICO_RP2040=0")
 pico_add_doxygen_pre_define("PICO_RP2350=1")
 pico_add_doxygen_pre_define("NUM_DOORBELLS=1") # we have functions that are gated by this
+pico_add_doxygen_pre_define("HAS_POWMAN_TIMER=1") # we have functions that are gated by this
 pico_add_doxygen_enabled_section(rp2350_specific)
 
 # for now we are building RISC-V into RP2350 docs, so document these too

--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -40,7 +40,7 @@ extern "C" {
  * - You can only wake up from dormant using the AON timer, or a GPIO interrupt configured using \ref gpio_set_dormant_irq_enabled.
  *   All other interrupts will be disabled during dormant.
  *
- * \if (!rp2040_specific)
+ * \if (!rp2040_specific || combined_docs)
  * In Pstate mode:
  * - Some power domains are switched off and don't retain state (eg specified SRAMs). By default, only the power domains
  *   required to keep persistent data powered on will be kept on.
@@ -212,7 +212,7 @@ static inline int low_power_set_external_clock_source(__unused uint src_hz, __un
  * If the external clock source is not set, or it is not running, this will return PICO_ERROR_PRECONDITION_NOT_MET.
  * \endif
  *
- * \if (!rp2040_specific)
+ * \if (!rp2040_specific || combined_docs)
  * If the clock source is set to DORMANT_CLOCK_SOURCE_LPOSC, clk_sys will be switched to the ROSC while dormant so
  * it can be stopped, while clk_ref will be run from the LPOSC so that it continues running for the timer.
  * \endif
@@ -230,7 +230,7 @@ int low_power_dormant_until_aon_timer(absolute_time_t until, dormant_clock_sourc
  * Go dormant until the given GPIO pin changes state.
  * The clocks specified in keep_enabled will be kept enabled during dormant, but XOSC and ROSC will be stopped.
  *
- * \if (!rp2040_specific)
+ * \if (!rp2040_specific || combined_docs)
  * If the clock source is set to DORMANT_CLOCK_SOURCE_LPOSC, clk_sys will be run from the ROSC while dormant so
  * it can be stopped, while clk_ref will be run from the LPOSC. For the lowest power consumption, you should use
  * DORMANT_CLOCK_SOURCE_ROSC instead, as the GPIO interrupt does not require a clock.

--- a/src/rp2_common/pico_unique_id/include/pico/unique_id.h
+++ b/src/rp2_common/pico_unique_id/include/pico/unique_id.h
@@ -55,8 +55,8 @@ extern "C" {
  *
  * Here is an example of C++ static initializers that will run before, and then after, pico_unique_id is loaded:
  *
- * [[gnu::init_priority(500)]] my_class before_instance;
- * [[gnu::init_priority(2000)]] my_class after_instance;
+ * 		[[gnu::init_priority(500)]] my_class before_instance;
+ * 		[[gnu::init_priority(2000)]] my_class after_instance;
  *
  */
 #ifndef PICO_UNIQUE_BOARD_ID_INIT_PRIORITY


### PR DESCRIPTION
Fix doxygen build so `pico_low_power` Pstate functions show up in combined build, along with functions in `boot_lock.h`

Also fix comment in `unique_id.h` so it renders as code, rather than as text