### PR TITLE
Update to btstack v1.8.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -115,7 +115,7 @@ git_repository(
 git_repository(
     name = "btstack",
     build_file = "//src/rp2_common/pico_btstack:btstack.BUILD",
-    commit = "420dc137399796c88b0013ee09f157046018923e",  # keep-in-sync-with-submodule: lib/btstack
+    commit = "075a0780f0fad7ff67d58ac19f46e8953656a752",  # keep-in-sync-with-submodule: lib/btstack
     remote = "https://github.com/bluekitchen/btstack.git",
 )
 


### PR DESCRIPTION
This version enables security in the default configuration of the btstack examples. You will need to delete the device and repeat pairing every time as "bonding" is not enabled.

Disabling bonding helps to allow for repeated testing. It can be enabled by adding SM_AUTHREQ_BONDING to the authentication requirements like this:

sm_set_authentication_requirements(X | SM_AUTHREQ_BONDING)

Fixes #2964
