### PR TITLE
Use non-scheduling CYW43 driver delays

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
@@ -267,11 +267,15 @@ void cyw43_await_background_or_timeout_us(uint32_t timeout_us) {
 }
 
 void cyw43_delay_ms(uint32_t ms) {
-    async_context_wait_until(cyw43_async_context, make_timeout_time_ms(ms));
+    // The low-level CYW43 driver calls this while holding the async-context lock.
+    // Do not use async_context_wait_until()/sleep_ms() here; background work is
+    // intentionally blocked until the lock is released.
+    busy_wait_ms(ms);
 }
 
 void cyw43_delay_us(uint32_t us) {
-    async_context_wait_until(cyw43_async_context, make_timeout_time_us(us));
+    // See cyw43_delay_ms().
+    busy_wait_us(us);
 }
 
 #if !CYW43_LWIP


### PR DESCRIPTION
Relates to #3001.

This changes the CYW43 HAL delay hooks to use `busy_wait_ms()` / `busy_wait_us()` instead of routing through `async_context_wait_until()`.

On Pico W with SDK 2.2.0, the BLE examples hang during initial CYW43 Bluetooth bring-up at the first `cyw43_delay_ms(20)` in `cyw43_ensure_up()`. With these hooks implemented as non-scheduling busy waits, the BLE GATT counter example completes bring-up and begins advertising.

Tested locally with:

- `PICO_BOARD=pico_w`
- `BTSTACK_EXAMPLE_TYPE=background`
- `picow_bt_example_gatt_counter_background`
