### PR TITLE
Add weak powman_timer_get_lposc_calib_freq function

### DIFF
--- a/src/rp2350/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2350/hardware_regs/include/hardware/platform_defs.h
@@ -85,6 +85,14 @@
 #define FPGA_CLK_REF_HZ (12 * MHZ)
 #endif
 
+#ifndef LPOSC_MIN_EXPECTED_HZ
+#define LPOSC_MIN_EXPECTED_HZ _u(26000)
+#endif
+
+#ifndef LPOSC_MAX_EXPECTED_HZ
+#define LPOSC_MAX_EXPECTED_HZ _u(40000)
+#endif
+
 // PICO_CONFIG: XOSC_HZ, Crystal oscillator frequency in Hz, type=int, default=12000000, advanced=true, group=hardware_base
 // NOTE:  The system and USB clocks are generated from the frequency using two PLLs.
 // If you override this define, or SYS_CLK_HZ/USB_CLK_HZ below, you will *also* need to add your own adjusted PLL set-up defines to

--- a/src/rp2_common/hardware_powman/include/hardware/powman.h
+++ b/src/rp2_common/hardware_powman/include/hardware/powman.h
@@ -32,25 +32,40 @@ extern "C" {
 #define PICO_POWMAN_CALIBRATE_LPOSC_FROM_OTP 1
 #endif
 
+/*! \brief Get the calibrated frequency of the low power oscillator
+ *  \ingroup hardware_powman
+ *
+ * The frequency returned is the value stored in the OTP, or 0 if there is no OTP value
+ * set, the OTP value is out of range, or PICO_POWMAN_CALIBRATE_LPOSC_FROM_OTP is 0
+ *
+ * \note This is a weak function, so can be overriden to provide a custom calibration
+ * method (for example using \ref frequency_count_khz)
+ *
+ * \return The LPOSC frequency, or 0 if unknown
+ */
+uint32_t powman_timer_get_lposc_calib_freq(void);
+
 /*! \brief Use the ~32KHz low power oscillator as the powman timer source
  *  \ingroup hardware_powman
- *  \note The frequency is set to the value stored in the OTP, or the reset value if
- *  there is no OTP value set or PICO_POWMAN_CALIBRATE_LPOSC_FROM_OTP is 0
+ *
+ * \note The frequency is set to the value returned by \ref powman_timer_get_lposc_calib_freq
  */
 void powman_timer_set_1khz_tick_source_lposc(void);
 
 /*! \brief Use the low power oscillator (specifying frequency) as the powman timer source
  *  \ingroup hardware_powman
- *  \param lposc_freq_hz specify an exact lposc freq to trim it, or 0 to use the reset values
+ *  \param lposc_freq_hz specify an exact lposc freq to trim it, or 0 to use the existing value
  */
 void powman_timer_set_1khz_tick_source_lposc_with_hz(uint32_t lposc_freq_hz);
 
 /*! \brief Use the crystal oscillator as the powman timer source
  *  \ingroup hardware_powman
+ *
+ * \note The frequency is set to the value of XOSC_HZ
  */
 void powman_timer_set_1khz_tick_source_xosc(void);
 
-/*! \brief Use the crystal oscillator as the powman timer source
+/*! \brief Use the crystal oscillator (specifying frequency) as the powman timer source
  *  \ingroup hardware_powman
  *  \param xosc_freq_hz specify a crystal frequency
  */

--- a/src/rp2_common/hardware_powman/powman.c
+++ b/src/rp2_common/hardware_powman/powman.c
@@ -70,7 +70,7 @@ uint32_t __weak powman_timer_get_lposc_calib_freq(void) {
     if (*lposc_calib_data == 0) {
         return 0;
 #if PICO_RP2350
-    } else if (*lposc_calib_data > (40 * 1000) || *lposc_calib_data < (26 * 1000)) {
+    } else if (*lposc_calib_data > LPOSC_MAX_EXPECTED_HZ || *lposc_calib_data < LPOSC_MIN_EXPECTED_HZ) {
         // Ignore OTP value if it is out of range
         return 0;
 #endif

--- a/src/rp2_common/hardware_powman/powman.c
+++ b/src/rp2_common/hardware_powman/powman.c
@@ -64,24 +64,33 @@ uint64_t powman_timer_get_ms(void) {
     return ((uint64_t) hi << 32u) | lo;
 }
 
-void powman_timer_set_1khz_tick_source_lposc(void) {
+uint32_t __weak powman_timer_get_lposc_calib_freq(void) {
 #if PICO_POWMAN_CALIBRATE_LPOSC_FROM_OTP
     uint16_t* lposc_calib_data = (uint16_t*)OTP_DATA_BASE + OTP_DATA_LPOSC_CALIB_ROW;
     if (*lposc_calib_data == 0) {
-        powman_timer_set_1khz_tick_source_lposc_with_hz(0);
+        return 0;
+#if PICO_RP2350
+    } else if (*lposc_calib_data > (40 * 1000) || *lposc_calib_data < (26 * 1000)) {
+        // Ignore OTP value if it is out of range
+        return 0;
+#endif
     } else {
-        powman_timer_set_1khz_tick_source_lposc_with_hz(*lposc_calib_data);
+        return *lposc_calib_data;
     }
 #else
-    powman_timer_set_1khz_tick_source_lposc_with_hz(0);
+    return 0;
 #endif
+}
+
+void powman_timer_set_1khz_tick_source_lposc(void) {
+    powman_timer_set_1khz_tick_source_lposc_with_hz(powman_timer_get_lposc_calib_freq());
 }
 
 void powman_timer_set_1khz_tick_source_lposc_with_hz(uint32_t lposc_freq_hz) {
     bool was_running = powman_timer_is_running();
-    uint32_t lposc_freq_khz = lposc_freq_hz == 0 ? POWMAN_LPOSC_FREQ_KHZ_INT_RESET : lposc_freq_hz / 1000;
-    uint32_t lposc_freq_khz_frac16 = lposc_freq_hz == 0 ? POWMAN_LPOSC_FREQ_KHZ_FRAC_RESET : (lposc_freq_hz % 1000) * 65536 / 1000;
-    if (lposc_freq_khz != powman_hw->lposc_freq_khz_int || lposc_freq_khz_frac16 != powman_hw->lposc_freq_khz_frac) {
+    uint32_t lposc_freq_khz = lposc_freq_hz / 1000;
+    uint32_t lposc_freq_khz_frac16 = (lposc_freq_hz % 1000) * 65536 / 1000;
+    if (lposc_freq_hz && (lposc_freq_khz != powman_hw->lposc_freq_khz_int || lposc_freq_khz_frac16 != powman_hw->lposc_freq_khz_frac)) {
         // Frequency change needed, so need to stop the timer, set the frequency, and start the timer with USE_LPOSC
         if (was_running) powman_timer_pause();
         powman_write(&powman_hw->lposc_freq_khz_int, lposc_freq_khz);


### PR DESCRIPTION
By default this function reads from valid OTP if PICO_POWMAN_CALIBRATE_LPOSC_FROM_OTP is set (like before), but it is weak so can be overridden by the user (eg to use frequency_count_khz instead)

The existing behaviour of `powman_timer_set_1khz_tick_source_lposc` is unchanged, other than the addition of ignoring out-of-range OTP values on RP2350.