### PR TITLE
cyw43_tcpip_link_status when not using lwip

### DIFF
--- a/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
+++ b/src/rp2_common/pico_cyw43_driver/cyw43_driver.c
@@ -291,4 +291,8 @@ void __attribute__((weak)) cyw43_cb_tcpip_set_link_down(__unused cyw43_t *self, 
 void __attribute__((weak)) cyw43_cb_process_ethernet(__unused void *cb_data, __unused int itf, __unused size_t len, __unused const uint8_t *buf) {
     no_lwip_fail();
 }
+int __attribute__((weak)) cyw43_tcpip_link_status(cyw43_t *self, int itf) {
+    no_lwip_fail();
+    return 0;
+}
 #endif


### PR DESCRIPTION
This function is implemented by cyw43_driver using lwip to determine when the link is up and an IP address has been assigned.

If you are not using lwip you get a link error as it's used in cyw43_arch_wifi_connect_bssid_until

As with other cyw43 lwip functions we need a weak implementation that panics as we expect the app to provide their own implementation if not using lwip.

Fixes #2704
