### PR TITLE
Minor fix to status_led error handling

### DIFF
--- a/src/rp2_common/pico_status_led/status_led.c
+++ b/src/rp2_common/pico_status_led/status_led.c
@@ -202,6 +202,8 @@ static bool status_led_init_internal(__unused struct async_context *context) {
                 async_context_deinit(&status_led_owned_context.core);
                 return false;
             }
+        } else {
+            return false;
         }
     }
     status_led_context = context;


### PR DESCRIPTION
Return false if async_context_threadsafe_background_init fails.

Fixes #2672
