### PR TITLE
Remove duplicate wrapper linker commands in pico_mem_ops

### DIFF
--- a/src/rp2_common/pico_bit_ops/BUILD.bazel
+++ b/src/rp2_common/pico_bit_ops/BUILD.bazel
@@ -7,8 +7,6 @@ cc_library(
     srcs = ["bit_ops_aeabi.S"],
     linkopts = select({
         "//bazel/constraint:rp2040": [
-            "-Wl,--wrap=__clzsi2",
-            "-Wl,--wrap=__clzsi2",
             "-Wl,--wrap=__clzdi2",
             "-Wl,--wrap=__ctzsi2",
             "-Wl,--wrap=__popcountsi2",

--- a/src/rp2_common/pico_bit_ops/CMakeLists.txt
+++ b/src/rp2_common/pico_bit_ops/CMakeLists.txt
@@ -24,8 +24,6 @@ if (NOT TARGET pico_bit_ops)
     if (PICO_RP2040)
         target_link_libraries(pico_bit_ops_pico INTERFACE pico_bootrom)
         # gcc
-        pico_wrap_function(pico_bit_ops_pico __clzsi2)
-        pico_wrap_function(pico_bit_ops_pico __clzsi2)
         pico_wrap_function(pico_bit_ops_pico __clzdi2)
         pico_wrap_function(pico_bit_ops_pico __ctzsi2)
         pico_wrap_function(pico_bit_ops_pico __popcountsi2)


### PR DESCRIPTION
Fix duplicated wrapper functions definitions
