### PR TITLE
Remove unecessary bits from pad_checksum on RP2350

### DIFF
--- a/src/rp2350/boot_stage2/BUILD.bazel
+++ b/src/rp2350/boot_stage2/BUILD.bazel
@@ -118,14 +118,14 @@ objcopy_to_bin(
 # WORKAROUND: Python rules always require a .py extension.
 copy_file(
     name = "copy_tool_to_py",
-    src = "pad_checksum",
-    out = "pad_checksum_tool.py",
+    src = "pad",
+    out = "pad_tool.py",
     target_compatible_with = ["//bazel/constraint:host"],
 )
 
 py_binary(
-    name = "pad_checksum_tool",
-    srcs = ["pad_checksum_tool.py"],
+    name = "pad_tool",
+    srcs = ["pad_tool.py"],
     target_compatible_with = ["//bazel/constraint:host"],
 )
 
@@ -134,12 +134,11 @@ run_binary(
     srcs = [":boot_stage2_bin"],
     outs = ["boot_stage2.S"],
     args = [
-        "-s 0xffffffff",
         "$(location boot_stage2_bin)",
         "$(location boot_stage2.S)",
     ],
     target_compatible_with = ["//bazel/constraint:rp2350"],
-    tool = ":pad_checksum_tool",
+    tool = ":pad_tool",
 )
 
 cc_library(

--- a/src/rp2350/boot_stage2/CMakeLists.txt
+++ b/src/rp2350/boot_stage2/CMakeLists.txt
@@ -67,7 +67,7 @@ function(pico_define_boot_stage2 NAME SOURCES)
     pico_add_map_output(${NAME})
 
     set(ORIGINAL_BIN ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.bin)
-    set(PADDED_CHECKSUMMED_ASM ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_padded_checksummed.S)
+    set(PADDED_ASM ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_padded.S)
 
     find_package (Python3 REQUIRED COMPONENTS Interpreter)
 
@@ -75,11 +75,11 @@ function(pico_define_boot_stage2 NAME SOURCES)
     add_custom_command(OUTPUT ${ORIGINAL_BIN} DEPENDS ${NAME} COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${NAME}> ${ORIGINAL_BIN}
         VERBATIM)
 
-    add_custom_command(OUTPUT ${PADDED_CHECKSUMMED_ASM} DEPENDS ${ORIGINAL_BIN}
-            COMMAND ${Python3_EXECUTABLE} ${PICO_BOOT_STAGE2_DIR}/pad_checksum -s 0xffffffff -a $<IF:${PICO_RISCV},riscv,arm> ${ORIGINAL_BIN} ${PADDED_CHECKSUMMED_ASM}
+    add_custom_command(OUTPUT ${PADDED_ASM} DEPENDS ${ORIGINAL_BIN}
+            COMMAND ${Python3_EXECUTABLE} ${PICO_BOOT_STAGE2_DIR}/pad ${ORIGINAL_BIN} ${PADDED_ASM}
             VERBATIM)
 
-    add_library(${NAME}_library OBJECT ${PADDED_CHECKSUMMED_ASM})
+    add_library(${NAME}_library OBJECT ${PADDED_ASM})
     target_link_libraries(${NAME}_library INTERFACE "$<TARGET_OBJECTS:${NAME}_library>")
     target_link_libraries(${NAME}_library INTERFACE boot_stage2_headers)
 

--- a/src/rp2350/boot_stage2/boot_stage2.ld
+++ b/src/rp2350/boot_stage2/boot_stage2.ld
@@ -1,7 +1,7 @@
 MEMORY {
-    /* We are loaded to the top 256 bytes of SRAM, which is above the bootrom
-       stack. */
-    SRAM(rx) : ORIGIN = 0x20081f00, LENGTH = 256
+    /* We don't know where we'll be loaded, so use an invalid address as code
+       should be location invariant */
+    SRAM(rx) : ORIGIN = 0x0, LENGTH = 256
 }
 
 SECTIONS {

--- a/src/rp2350/boot_stage2/pad
+++ b/src/rp2350/boot_stage2/pad
@@ -11,18 +11,11 @@ def any_int(x):
         raise argparse.ArgumentTypeError("expected an integer, not '{!r}'".format(x))
 
 
-def bitrev(x, width):
-    return int("{:0{w}b}".format(x, w=width)[::-1], 2)
-
-
 parser = argparse.ArgumentParser()
 parser.add_argument("ifile", help="Input file (binary)")
 parser.add_argument("ofile", help="Output file (assembly)")
-parser.add_argument("-p", "--pad", help="Padded size (bytes), including 4-byte checksum, default 256",
+parser.add_argument("-p", "--pad", help="Padded size (bytes), default 256",
                     type=any_int, default=256)
-parser.add_argument("-s", "--seed", help="Checksum seed value, default 0",
-                    type=any_int, default=0)
-parser.add_argument("-a", "--arch", default="arm", choices=["arm", "riscv"])
 args = parser.parse_args()
 
 try:
@@ -35,17 +28,12 @@ if len(idata) > args.pad:
 
 odata = idata + bytes(args.pad - len(idata))
 
-# No CRC, as "boot2" is entered by crt0 rather than the bootrom. The bootrom
-# can optionally perform a SHA-256 hash check of the entire image, and will
-# always at least check for a metadata block which is a valid IMAGE_DEF, so
-# the boot2 CRC is redundant.
+# No CRC on RP2350, as "boot2" is just a generic function that can be copied
+# anywhere and used
 
 # try:
 with open(args.ofile, "w") as ofile:
-    ofile.write("// Padded and checksummed version of: {}\n\n".format(args.ifile))
-    if args.arch == "arm":
-        ofile.write(".cpu cortex-m0plus\n")
-        ofile.write(".thumb\n\n")
+    ofile.write("// Padded version of: {}\n\n".format(args.ifile))
     ofile.write(".section .boot2, \"ax\"\n\n")
     ofile.write(".global __boot2_entry_point\n")
     ofile.write("__boot2_entry_point:\n")

--- a/test/kitchen_sink/BUILD.bazel
+++ b/test/kitchen_sink/BUILD.bazel
@@ -104,6 +104,14 @@ cc_binary(
 )
 
 cc_binary(
+    name = "kitchen_sink_embed_xip_setup",
+    testonly = True,
+    srcs = ["kitchen_sink.c"],
+    defines = ["PICO_EMBED_XIP_SETUP=1"],
+    deps = [":kitchen_sink_common"],
+)
+
+cc_binary(
     name = "kitchen_sink_cpp",
     testonly = True,
     srcs = ["kitchen_sink_cpp.cpp"],

--- a/test/kitchen_sink/CMakeLists.txt
+++ b/test/kitchen_sink/CMakeLists.txt
@@ -259,6 +259,12 @@ if (NOT KITCHEN_SINK_NO_BINARY_TYPE_VARIANTS)
     pico_add_extra_outputs(kitchen_sink_ram_section)
     target_compile_definitions(kitchen_sink_ram_section PRIVATE KITCHEN_SINK_ID="ram section binary" EXTRA_DATA_SECTION=1)
 
+    add_executable(kitchen_sink_embed_xip_setup ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c)
+    target_link_libraries(kitchen_sink_embed_xip_setup kitchen_sink_libs kitchen_sink_options)
+    target_compile_definitions(kitchen_sink_embed_xip_setup PRIVATE PICO_EMBED_XIP_SETUP=1)
+    pico_add_extra_outputs(kitchen_sink_embed_xip_setup)
+    target_compile_definitions(kitchen_sink_embed_xip_setup PRIVATE KITCHEN_SINK_ID="embed xip setup")
+
     if (NOT PICO_C_COMPILER_IS_CLANG)
         # Clang does not support overlay sections
         add_executable(kitchen_sink_simple_overlay ${CMAKE_CURRENT_LIST_DIR}/kitchen_sink.c)

--- a/tools/bazel_build.py
+++ b/tools/bazel_build.py
@@ -36,6 +36,7 @@ BUILD_CONFIGURATIONS = (
                 "//test/hardware_pwm_test:hardware_pwm_test",
                 "//test/hardware_sync_spin_lock_test:hardware_sync_spin_lock_test",
                 "//test/kitchen_sink:kitchen_sink",
+                "//test/kitchen_sink:kitchen_sink_embed_xip_setup",
                 "//test/kitchen_sink:kitchen_sink_cpp",
                 "//test/kitchen_sink:kitchen_sink_copy_to_ram",
                 "//test/kitchen_sink:kitchen_sink_no_flash",


### PR DESCRIPTION
Remove unecessary bits from pad_checksum (now just called pad), and fixup references and comments

Should now describe what actually happens with boot2 on RP2350

Also add a kitchen sink variant with PICO_EMBED_XIP_SETUP=1 to check it still works

Fixes #2334