### PR TITLE
Fix btstack flash bank in partitions

### DIFF
--- a/src/rp2_common/pico_btstack/btstack_flash_bank.c
+++ b/src/rp2_common/pico_btstack/btstack_flash_bank.c
@@ -90,7 +90,7 @@ static void pico_flash_bank_read(void *context, int bank, uint32_t offset, uint8
     if ((offset + size) > PICO_FLASH_BANK_SIZE) return;
 
     // Flash is xip
-    memcpy(buffer, (void *)(XIP_BASE + pico_flash_bank_get_storage_offset_func() + (PICO_FLASH_BANK_SIZE * bank) + offset), size);
+    memcpy(buffer, (void *)(XIP_NOCACHE_NOALLOC_NOTRANSLATE_BASE + pico_flash_bank_get_storage_offset_func() + (PICO_FLASH_BANK_SIZE * bank) + offset), size);
 }
 
 static void pico_flash_bank_write(void * context, int bank, uint32_t offset, const uint8_t *data, uint32_t size) {

--- a/src/rp2_common/pico_btstack/btstack_flash_bank.c
+++ b/src/rp2_common/pico_btstack/btstack_flash_bank.c
@@ -17,6 +17,12 @@ static_assert(PICO_FLASH_BANK_TOTAL_SIZE <= PICO_FLASH_SIZE_BYTES, "PICO_FLASH_B
 // Size of one bank
 #define PICO_FLASH_BANK_SIZE (PICO_FLASH_BANK_TOTAL_SIZE / 2)
 
+#if PICO_RP2040
+#define PICO_FLASH_BANK_READ_BASE XIP_BASE
+#else
+#define PICO_FLASH_BANK_READ_BASE XIP_NOCACHE_NOALLOC_NOTRANSLATE_BASE
+#endif
+
 #if 0
 #define DEBUG_PRINT(format,args...) printf(format, ## args)
 #else
@@ -90,11 +96,7 @@ static void pico_flash_bank_read(void *context, int bank, uint32_t offset, uint8
     if ((offset + size) > PICO_FLASH_BANK_SIZE) return;
 
     // Flash is xip
-#if PICO_RP2040
-    memcpy(buffer, (void *)(XIP_BASE + pico_flash_bank_get_storage_offset_func() + (PICO_FLASH_BANK_SIZE * bank) + offset), size);
-#else
-    memcpy(buffer, (void *)(XIP_NOCACHE_NOALLOC_NOTRANSLATE_BASE + pico_flash_bank_get_storage_offset_func() + (PICO_FLASH_BANK_SIZE * bank) + offset), size);
-#endif
+    memcpy(buffer, (void *)(PICO_FLASH_BANK_READ_BASE + pico_flash_bank_get_storage_offset_func() + (PICO_FLASH_BANK_SIZE * bank) + offset), size);
 }
 
 static void pico_flash_bank_write(void * context, int bank, uint32_t offset, const uint8_t *data, uint32_t size) {
@@ -135,14 +137,14 @@ static void pico_flash_bank_write(void * context, int bank, uint32_t offset, con
         // Copy data we're not going to overwrite in the first page
         if (page == first_page && offset > 0) {
             memcpy(page_data,
-                (void *)(XIP_BASE + bank_start_pos + (page * FLASH_PAGE_SIZE)),
+                (void *)(PICO_FLASH_BANK_READ_BASE + bank_start_pos + (page * FLASH_PAGE_SIZE)),
                 offset);
         }
 
         // Copy the data we're not going to overwrite in the last page
         if (page == last_page - 1 && (offset + size_left) < FLASH_PAGE_SIZE) {
             memcpy(page_data + offset + size_left,
-                (void *)(XIP_BASE + bank_start_pos + (page * FLASH_PAGE_SIZE) + offset + size_left),
+                (void *)(PICO_FLASH_BANK_READ_BASE + bank_start_pos + (page * FLASH_PAGE_SIZE) + offset + size_left),
                 FLASH_PAGE_SIZE - offset - size_left);
         }
 

--- a/src/rp2_common/pico_btstack/btstack_flash_bank.c
+++ b/src/rp2_common/pico_btstack/btstack_flash_bank.c
@@ -90,7 +90,11 @@ static void pico_flash_bank_read(void *context, int bank, uint32_t offset, uint8
     if ((offset + size) > PICO_FLASH_BANK_SIZE) return;
 
     // Flash is xip
+#if PICO_RP2040
+    memcpy(buffer, (void *)(XIP_BASE + pico_flash_bank_get_storage_offset_func() + (PICO_FLASH_BANK_SIZE * bank) + offset), size);
+#else
     memcpy(buffer, (void *)(XIP_NOCACHE_NOALLOC_NOTRANSLATE_BASE + pico_flash_bank_get_storage_offset_func() + (PICO_FLASH_BANK_SIZE * bank) + offset), size);
+#endif
 }
 
 static void pico_flash_bank_write(void * context, int bank, uint32_t offset, const uint8_t *data, uint32_t size) {


### PR DESCRIPTION
The code was writing to the untranslated addresses with `flash_range_program`, but reading from the translated `XIP_BASE`. This should fix that issue by reading from the untranslated alias.

A partition table that will reproduce this issue is [pt.uf2](https://github.com/user-attachments/files/29059300/pt.zip), generated from this JSON:
```json
{
    "$schema": "https://raw.githubusercontent.com/raspberrypi/picotool/master/json/schemas/partition-table-schema.json",
    "version": [1, 0],
    "unpartitioned": {
        "families": ["absolute"],
        "permissions": {
            "secure": "rw",
            "nonsecure": "rw",
            "bootloader": "rw"
        }
    },
    "partitions": [
        {
            "name": "A",
            "id": 0,
            "size": "2036K",
            "families": ["rp2350-arm-s", "rp2350-riscv"],
            "permissions": {
                "secure": "rw",
                "nonsecure": "rw",
                "bootloader": "rw"
            }
        },
        {
            "name": "B",
            "id": 1,
            "size": "2036K",
            "families": ["rp2350-arm-s", "rp2350-riscv"],
            "permissions": {
                "secure": "rw",
                "nonsecure": "rw",
                "bootloader": "rw"
            },
            "link": ["a", 0]
        }
    ]
}
```
The 2036K sizes are to ensure there is room for the flash bank after the partitions.