### PR TITLE
RP2350 bootrom rom_reboot() does not actually reboot for delay_ms of 0 so call it with 1 instead

### DIFF
--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -519,6 +519,10 @@ static inline int rom_set_bootrom_stack(bootrom_stack_t *stack) {
  * \param p1 parameter 1, depends on flags
  */
 static inline int rom_reboot(uint32_t flags, uint32_t delay_ms, uint32_t p0, uint32_t p1) {
+#if PICO_RP2350
+    // work around bootrom bug with 0 timeout
+    if (!delay_ms) delay_ms = 1;
+#endif
     rom_reboot_fn func = (rom_reboot_fn) rom_func_lookup_inline(ROM_FUNC_REBOOT);
     return func(flags, delay_ms, p0, p1);
 }


### PR DESCRIPTION
fixes #2994 (or at least works around it)