### PR TITLE
Fixup tests for hardware

### DIFF
--- a/test/pico_low_power_test/low_power_test_simple.c
+++ b/test/pico_low_power_test/low_power_test_simple.c
@@ -17,6 +17,7 @@ int main() {
     status_led_init();
 
     init_external_gpios();
+    sleep_ms(10);
 
 #if HAS_POWMAN_TIMER
     // quick test for https://github.com/raspberrypi/pico-sdk/issues/2824

--- a/test/pico_xip_sram_test/pico_xip_sram_test.c
+++ b/test/pico_xip_sram_test/pico_xip_sram_test.c
@@ -11,6 +11,6 @@ int main(void) {
         sleep_ms(500);
     }
 
-    printf("pico_xip_sram_test ends\n");
+    printf("PASSED\n");
     return 0;
 }


### PR DESCRIPTION
Print `PASSED` at end of `pico_xip_sram_test`

Sleep after GPIO init in `low_power_test_simple` - this improves the ability for `external_sleep_timer` to detect the wakeup from pstates