### PR TITLE
add 2 shared irq handlers when using stdio_usb

### DIFF
--- a/src/rp2_common/hardware_irq/include/hardware/irq.h
+++ b/src/rp2_common/hardware_irq/include/hardware/irq.h
@@ -10,7 +10,12 @@
 // These two config items are also used by assembler, so keeping separate
 // PICO_CONFIG: PICO_MAX_SHARED_IRQ_HANDLERS, Maximum number of shared IRQ handlers, default=4, advanced=true, group=hardware_irq
 #ifndef PICO_MAX_SHARED_IRQ_HANDLERS
-#define PICO_MAX_SHARED_IRQ_HANDLERS 4
+#define _PICO_MAX_SHARED_IRQ_HANDLERS 4
+#if LIB_PICO_STDIO_USB
+#define PICO_MAX_SHARED_IRQ_HANDLERS (_PICO_MAX_SHARED_IRQ_HANDLERS + 2)
+#else
+#define PICO_MAX_SHARED_IRQ_HANDLERS _PICO_MAX_SHARED_IRQ_HANDLERS
+#endif
 #endif
 
 // PICO_CONFIG: PICO_DISABLE_SHARED_IRQ_HANDLERS, Disable shared IRQ handlers, type=bool, default=0, group=hardware_irq

--- a/src/rp2_common/hardware_irq/include/hardware/irq.h
+++ b/src/rp2_common/hardware_irq/include/hardware/irq.h
@@ -8,7 +8,7 @@
 #define _HARDWARE_IRQ_H
 
 // These two config items are also used by assembler, so keeping separate
-// PICO_CONFIG: PICO_MAX_SHARED_IRQ_HANDLERS, Maximum number of shared IRQ handlers, default=4, advanced=true, group=hardware_irq
+// PICO_CONFIG: PICO_MAX_SHARED_IRQ_HANDLERS, Maximum number of shared IRQ handlers, default=6 if using stdio_usb otherwise 4, advanced=true, group=hardware_irq
 #ifndef PICO_MAX_SHARED_IRQ_HANDLERS
 #define _PICO_MAX_SHARED_IRQ_HANDLERS 4
 #if LIB_PICO_STDIO_USB


### PR DESCRIPTION
note i didn't add a new config option to turn this off, since you can just set PICO_MAX_SHARED_IRQ_HANDLERS if you actually really care

