### PR TITLE
pico_binary_info: avoid uint in standalone header

### DIFF
--- a/src/common/pico_binary_info/include/pico/binary_info/structure.h
+++ b/src/common/pico_binary_info/include/pico/binary_info/structure.h
@@ -42,7 +42,7 @@ typedef struct _binary_info_core binary_info_t;
 // note plan is to reserve c1 = 0->31 for "collision tags"; i.e.
 // for which you should always use random IDs with the binary_info,
 // giving you 4 + 8 + 32 = 44 bits to avoid collisions
-#define BINARY_INFO_MAKE_TAG(c1, c2) ((((uint)c2&0xffu)<<8u)|((uint)c1&0xffu))
+#define BINARY_INFO_MAKE_TAG(c1, c2) ((((unsigned int)c2&0xffu)<<8u)|((unsigned int)c1&0xffu))
 
 // Raspberry Pi defined. do not use
 #define BINARY_INFO_TAG_RASPBERRY_PI BINARY_INFO_MAKE_TAG('R','P')


### PR DESCRIPTION
﻿## Summary

Fixes raspberrypi/pico-sdk#3028.

`pico/binary_info/structure.h` documents that it may be included by non-SDK code and therefore should not depend on SDK includes. `BINARY_INFO_MAKE_TAG()` currently casts through `uint`, which is not a standard C type and is only available when another header has already provided that typedef.

## Changes

- Replace the `uint` casts in `BINARY_INFO_MAKE_TAG()` with standard `unsigned int` casts.
- Keep the macro value and header dependencies unchanged.

## Testing

- `git diff --check origin/master..HEAD`
- `rg -n "BINARY_INFO_MAKE_TAG|\\buint\\b" src/common/pico_binary_info/include/pico/binary_info/structure.h`
- `git diff --stat origin/master..HEAD`

Build not run locally: this Windows environment does not currently have a C compiler, CMake, Ninja, or Make available in PATH.
