### PR TITLE
Small doxygen tweak to pico_divider_headers

### DIFF
--- a/src/common/pico_divider_headers/include/pico/divider.h
+++ b/src/common/pico_divider_headers/include/pico/divider.h
@@ -157,7 +157,7 @@ uint64_t divmod_u64u64_rem(uint64_t a, uint64_t b, uint64_t *rem);
 
 #if PICO_RP2040 && !LIB_PICO_DIVIDER_COMPILER
 /**
- * \brief Integer divide of two signed 64-bit values
+ * \brief Integer divide of two unsigned 64-bit values
  * \ingroup pico_divider
  *
  * \param a Dividend
@@ -198,7 +198,7 @@ int32_t div_s32s32_unsafe(int32_t a, int32_t b);
 int32_t divmod_s32s32_rem_unsafe(int32_t a, int32_t b, int32_t *rem);
 
 /**
- * \brief Unsafe integer divide of two unsigned 32-bit values
+ * \brief Unsafe integer divide of two signed 32-bit values
  * \ingroup pico_divider
  *
  * \param a Dividend
@@ -309,7 +309,7 @@ uint64_t div_u64u64_unsafe(uint64_t a, uint64_t b);
 uint64_t divmod_u64u64_rem_unsafe(uint64_t a, uint64_t b, uint64_t *rem);
 
 /**
- * \brief Unsafe integer divide of two signed 64-bit values
+ * \brief Unsafe integer divide of two unsigned 64-bit values
  * \ingroup pico_divider
  *
  * \param a Dividend


### PR DESCRIPTION
The overall doxygen-description for the file also says "Optimized 32 and 64 bit division functions accelerated by the RP2040 hardware divider" which implies that the entire file is RP2040-only, but in the source-code only a couple of functions are wrapped with `#if PICO_RP2040` which kinda implies that this is also usable by RP2350? :thinking: 
@kilograham or @will-v-pi Please feel free to push more appropriate wording to this PR :slightly_smiling_face:  (assuming of course that I haven't just grabbed the wrong end of the stick! :joy: )