### PR TITLE
Add low_power_set_pins_low_leakage function

### DIFF
--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -140,21 +140,21 @@ typedef void (*low_power_pstate_resume_func)(pstate_bitset_t *pstate);
  *
  * \param exclude_mask Mask of the pins to exclude from this
  */
-void low_power_set_pins_low_leakage(uint32_t exclude_mask);
+void low_power_set_all_pins_low_leakage(uint32_t exclude_mask);
 
 /*! \brief  Set all pins to a low leakage state (64-bit mask version)
  *  \ingroup pico_low_power
  *
- * \see low_power_set_pins_low_leakage
+ * \see low_power_set_all_pins_low_leakage
  *
  * \param exclude_mask Mask of the pins to exclude from this
  */
 #if NUM_BANK0_GPIOS <= 32
-static inline void low_power_set_pins_low_leakage64(uint64_t exclude_mask) {
-    low_power_set_pins_low_leakage((uint32_t)exclude_mask);
+static inline void low_power_set_all_pins_low_leakage64(uint64_t exclude_mask) {
+    low_power_set_all_pins_low_leakage((uint32_t)exclude_mask);
 }
 #else
-void low_power_set_pins_low_leakage64(uint64_t exclude_mask);
+void low_power_set_all_pins_low_leakage64(uint64_t exclude_mask);
 #endif
 
 /*! \brief  Sleep until an interrupt occurs

--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -142,7 +142,7 @@ typedef void (*low_power_pstate_resume_func)(pstate_bitset_t *pstate);
  */
 void low_power_set_pins_low_leakage(uint32_t exclude_mask);
 
-/*! \brief  Set all pins to a low leakage state (64-bit version)
+/*! \brief  Set all pins to a low leakage state (64-bit mask version)
  *  \ingroup pico_low_power
  *
  * \see low_power_set_pins_low_leakage

--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -133,7 +133,7 @@ typedef void (*low_power_pstate_resume_func)(pstate_bitset_t *pstate);
 /*! \brief  Set all pins to a low leakage state
  *  \ingroup pico_low_power
  *
- * Disables pulls & inputs on the pads, and sets the IO function to GPIO_FUNC_SIO
+ * Disables pulls & inputs on the pads, and disables the IO output
  * with all pins set to inputs. This results in the lowest leakage current.
  * 
  * Does not change the state of pins in the exclude_mask

--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -130,6 +130,12 @@ typedef enum {
 typedef void (*low_power_pstate_resume_func)(pstate_bitset_t *pstate);
 #endif
 
+/*! \brief  Set all pins to a low leakage state
+ *  \ingroup pico_low_power
+ *
+ * \param exclude_mask The pins to exclude from this
+ */
+void low_power_set_pins_low_leakage(uint32_t exclude_mask);
 
 /*! \brief  Sleep until an interrupt occurs
  *  \ingroup pico_low_power

--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -136,7 +136,7 @@ typedef void (*low_power_pstate_resume_func)(pstate_bitset_t *pstate);
  * Disables pulls & inputs on the pads, and disables the IO output
  * with all pins set to inputs. This results in the lowest leakage current.
  * 
- * Does not change the state of pins in the exclude_mask
+ * Does not change the state of pins in the exclude_mask.
  *
  * \param exclude_mask Mask of the pins to exclude from this
  */

--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -133,9 +133,29 @@ typedef void (*low_power_pstate_resume_func)(pstate_bitset_t *pstate);
 /*! \brief  Set all pins to a low leakage state
  *  \ingroup pico_low_power
  *
- * \param exclude_mask The pins to exclude from this
+ * Disables pulls & inputs on the pads, and sets the IO function to GPIO_FUNC_SIO
+ * with all pins set to inputs. This results in the lowest leakage current.
+ * 
+ * Does not change the state of pins in the exclude_mask
+ *
+ * \param exclude_mask Mask of the pins to exclude from this
  */
 void low_power_set_pins_low_leakage(uint32_t exclude_mask);
+
+/*! \brief  Set all pins to a low leakage state (64-bit version)
+ *  \ingroup pico_low_power
+ *
+ * \see low_power_set_pins_low_leakage
+ *
+ * \param exclude_mask Mask of the pins to exclude from this
+ */
+#if NUM_BANK0_GPIOS <= 32
+static inline void low_power_set_pins_low_leakage64(uint64_t exclude_mask) {
+    low_power_set_pins_low_leakage((uint32_t)exclude_mask);
+}
+#else
+void low_power_set_pins_low_leakage64(uint64_t exclude_mask);
+#endif
 
 /*! \brief  Sleep until an interrupt occurs
  *  \ingroup pico_low_power

--- a/src/rp2_common/pico_low_power/include/pico/low_power.h
+++ b/src/rp2_common/pico_low_power/include/pico/low_power.h
@@ -140,21 +140,21 @@ typedef void (*low_power_pstate_resume_func)(pstate_bitset_t *pstate);
  *
  * \param exclude_mask Mask of the pins to exclude from this
  */
-void low_power_set_all_pins_low_leakage(uint32_t exclude_mask);
+void low_power_set_pins_low_leakage_exclude_mask(uint32_t exclude_mask);
 
 /*! \brief  Set all pins to a low leakage state (64-bit mask version)
  *  \ingroup pico_low_power
  *
- * \see low_power_set_all_pins_low_leakage
+ * \see low_power_set_pins_low_leakage_exclude_mask
  *
  * \param exclude_mask Mask of the pins to exclude from this
  */
 #if NUM_BANK0_GPIOS <= 32
-static inline void low_power_set_all_pins_low_leakage64(uint64_t exclude_mask) {
-    low_power_set_all_pins_low_leakage((uint32_t)exclude_mask);
+static inline void low_power_set_pins_low_leakage_exclude_mask64(uint64_t exclude_mask) {
+    low_power_set_pins_low_leakage_exclude_mask((uint32_t)exclude_mask);
 }
 #else
-void low_power_set_all_pins_low_leakage64(uint64_t exclude_mask);
+void low_power_set_pins_low_leakage_exclude_mask64(uint64_t exclude_mask);
 #endif
 
 /*! \brief  Sleep until an interrupt occurs

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -224,7 +224,7 @@ int low_power_set_external_clock_source(uint src_hz, uint gpio_pin) {
 }
 #endif  // inline in header for other platforms
 
-void low_power_set_all_pins_low_leakage(uint32_t exclude_mask) {
+void low_power_set_pins_low_leakage_exclude_mask(uint32_t exclude_mask) {
     for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1u << i)) continue;
         gpio_disable_pulls(i);
@@ -235,7 +235,7 @@ void low_power_set_all_pins_low_leakage(uint32_t exclude_mask) {
 
 // this function is provided (in low_power.h) as an inlined call to the 32 bit version if we have <= 32 GPIOs
 #if NUM_BANK0_GPIOS > 32
-void low_power_set_all_pins_low_leakage64(uint64_t exclude_mask) {
+void low_power_set_pins_low_leakage_exclude_mask64(uint64_t exclude_mask) {
     for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1ull << i)) continue;
         gpio_disable_pulls(i);

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -225,26 +225,22 @@ int low_power_set_external_clock_source(uint src_hz, uint gpio_pin) {
 #endif  // inline in header for other platforms
 
 void low_power_set_pins_low_leakage(uint32_t exclude_mask) {
-    uint32_t include_mask = ~exclude_mask;
-    gpio_set_dir_masked(include_mask, 0);
     for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1u << i)) continue;
-        gpio_set_function(i, GPIO_FUNC_SIO);
         gpio_disable_pulls(i);
         gpio_set_input_enabled(i, false);
+        gpio_set_oeover(i, IO_BANK0_GPIO0_CTRL_OEOVER_VALUE_DISABLE);
     }
 }
 
 // this function is provided (in low_power.h) as an inlined call to the 32 bit version if we have <= 32 GPIOs
 #if NUM_BANK0_GPIOS > 32
 void low_power_set_pins_low_leakage64(uint64_t exclude_mask) {
-    uint64_t include_mask = ~exclude_mask;
-    gpio_set_dir_masked64(include_mask, 0);
     for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1ull << i)) continue;
-        gpio_set_function(i, GPIO_FUNC_SIO);
         gpio_disable_pulls(i);
         gpio_set_input_enabled(i, false);
+        gpio_set_oeover(i, IO_BANK0_GPIO0_CTRL_OEOVER_VALUE_DISABLE);
     }
 }
 #endif

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -227,7 +227,7 @@ int low_power_set_external_clock_source(uint src_hz, uint gpio_pin) {
 void low_power_set_pins_low_leakage(uint32_t exclude_mask) {
     uint32_t include_mask = ~exclude_mask;
     gpio_set_dir_masked(include_mask, 0);
-    for (int i=0; i < NUM_BANK0_GPIOS; i++) {
+    for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1u << i)) continue;
         gpio_set_function(i, GPIO_FUNC_SIO);
         gpio_disable_pulls(i);
@@ -240,7 +240,7 @@ void low_power_set_pins_low_leakage(uint32_t exclude_mask) {
 void low_power_set_pins_low_leakage64(uint64_t exclude_mask) {
     uint64_t include_mask = ~exclude_mask;
     gpio_set_dir_masked64(include_mask, 0);
-    for (int i=0; i < NUM_BANK0_GPIOS; i++) {
+    for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1u << i)) continue;
         gpio_set_function(i, GPIO_FUNC_SIO);
         gpio_disable_pulls(i);

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -224,6 +224,17 @@ int low_power_set_external_clock_source(uint src_hz, uint gpio_pin) {
 }
 #endif  // inline in header for other platforms
 
+void low_power_set_pins_low_leakage(uint32_t exclude_mask) {
+    uint32_t include_mask = ~exclude_mask;
+    gpio_set_dir_masked(include_mask, 0);
+    for (int i=0; i < NUM_BANK0_GPIOS; i++) {
+        if (exclude_mask & (1u << i)) continue;
+        gpio_set_function(i, GPIO_FUNC_SIO);
+        gpio_disable_pulls(i);
+        gpio_set_input_enabled(i, false);
+    }
+}
+
 int low_power_sleep_until_irq(const clock_dest_bitset_t *keep_enabled) {
     clock_dest_bitset_t local_keep_enabled;
     replace_null_enable_values(keep_enabled, &local_keep_enabled);

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -241,7 +241,7 @@ void low_power_set_pins_low_leakage64(uint64_t exclude_mask) {
     uint64_t include_mask = ~exclude_mask;
     gpio_set_dir_masked64(include_mask, 0);
     for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
-        if (exclude_mask & (1u << i)) continue;
+        if (exclude_mask & (1ull << i)) continue;
         gpio_set_function(i, GPIO_FUNC_SIO);
         gpio_disable_pulls(i);
         gpio_set_input_enabled(i, false);

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -224,7 +224,7 @@ int low_power_set_external_clock_source(uint src_hz, uint gpio_pin) {
 }
 #endif  // inline in header for other platforms
 
-void low_power_set_pins_low_leakage(uint32_t exclude_mask) {
+void low_power_set_all_pins_low_leakage(uint32_t exclude_mask) {
     for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1u << i)) continue;
         gpio_disable_pulls(i);
@@ -235,7 +235,7 @@ void low_power_set_pins_low_leakage(uint32_t exclude_mask) {
 
 // this function is provided (in low_power.h) as an inlined call to the 32 bit version if we have <= 32 GPIOs
 #if NUM_BANK0_GPIOS > 32
-void low_power_set_pins_low_leakage64(uint64_t exclude_mask) {
+void low_power_set_all_pins_low_leakage64(uint64_t exclude_mask) {
     for (uint i=0; i < NUM_BANK0_GPIOS; i++) {
         if (exclude_mask & (1ull << i)) continue;
         gpio_disable_pulls(i);

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -235,6 +235,20 @@ void low_power_set_pins_low_leakage(uint32_t exclude_mask) {
     }
 }
 
+// this function is provided (in low_power.h) as an inlined call to the 32 bit version if we have <= 32 GPIOs
+#if NUM_BANK0_GPIOS > 32
+void low_power_set_pins_low_leakage64(uint64_t exclude_mask) {
+    uint64_t include_mask = ~exclude_mask;
+    gpio_set_dir_masked64(include_mask, 0);
+    for (int i=0; i < NUM_BANK0_GPIOS; i++) {
+        if (exclude_mask & (1u << i)) continue;
+        gpio_set_function(i, GPIO_FUNC_SIO);
+        gpio_disable_pulls(i);
+        gpio_set_input_enabled(i, false);
+    }
+}
+#endif
+
 int low_power_sleep_until_irq(const clock_dest_bitset_t *keep_enabled) {
     clock_dest_bitset_t local_keep_enabled;
     replace_null_enable_values(keep_enabled, &local_keep_enabled);

--- a/test/pico_low_power_test/low_power_test_common.h
+++ b/test/pico_low_power_test/low_power_test_common.h
@@ -22,6 +22,8 @@
 // On RP2040 this must be a GPIO that supports clock output, see the GPIO function table in the datasheet.
 #define RTC_GPIO_OUT 21
 
+#define USED_PIN_MASK ((1u << SLEEP_MONITOR_PIN)|(1u << WAKE_UP_PIN)|(1u << PICO_DEFAULT_UART_TX_PIN)|(1u << PICO_DEFAULT_UART_RX_PIN))
+
 
 static inline void init_external_gpios(void) {
     gpio_init(SLEEP_MONITOR_PIN);

--- a/test/pico_low_power_test/low_power_test_gpio.c
+++ b/test/pico_low_power_test/low_power_test_gpio.c
@@ -127,7 +127,7 @@ int main() {
     init_powman_ext_ctrl();
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << WAKE_UP_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
+    low_power_set_pins_low_leakage(USED_PIN_MASK);
     ret = low_power_pstate_until_gpio_pin_state(WAKE_UP_PIN, true, false, NULL, pstate_resume_func);
 
     printf("ERROR: %d returned by low_power_pstate_until_gpio_pin_state\n", ret);

--- a/test/pico_low_power_test/low_power_test_gpio.c
+++ b/test/pico_low_power_test/low_power_test_gpio.c
@@ -127,6 +127,7 @@ int main() {
     init_powman_ext_ctrl();
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
+    low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << WAKE_UP_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
     ret = low_power_pstate_until_gpio_pin_state(WAKE_UP_PIN, true, false, NULL, pstate_resume_func);
 
     printf("ERROR: %d returned by low_power_pstate_until_gpio_pin_state\n", ret);

--- a/test/pico_low_power_test/low_power_test_gpio.c
+++ b/test/pico_low_power_test/low_power_test_gpio.c
@@ -127,7 +127,7 @@ int main() {
     init_powman_ext_ctrl();
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_pins_low_leakage(USED_PIN_MASK);
+    low_power_set_all_pins_low_leakage(USED_PIN_MASK);
     ret = low_power_pstate_until_gpio_pin_state(WAKE_UP_PIN, true, false, NULL, pstate_resume_func);
 
     printf("ERROR: %d returned by low_power_pstate_until_gpio_pin_state\n", ret);

--- a/test/pico_low_power_test/low_power_test_gpio.c
+++ b/test/pico_low_power_test/low_power_test_gpio.c
@@ -127,7 +127,7 @@ int main() {
     init_powman_ext_ctrl();
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_all_pins_low_leakage(USED_PIN_MASK);
+    low_power_set_pins_low_leakage_exclude_mask(USED_PIN_MASK);
     ret = low_power_pstate_until_gpio_pin_state(WAKE_UP_PIN, true, false, NULL, pstate_resume_func);
 
     printf("ERROR: %d returned by low_power_pstate_until_gpio_pin_state\n", ret);

--- a/test/pico_low_power_test/low_power_test_simple.c
+++ b/test/pico_low_power_test/low_power_test_simple.c
@@ -59,7 +59,7 @@ int main() {
         // Setup ext_ctrl0 to output on the SLEEP_MONITOR_PIN
         init_powman_ext_ctrl();
         gpio_put(SLEEP_MONITOR_PIN, 0);
-        low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
+        low_power_set_pins_low_leakage(USED_PIN_MASK);
         ret = low_power_pstate_for_ms(SLEEP_TIME_MS, NULL, NULL);
         if (ret != PICO_OK) {
             printf("%d ERROR: low_power_pstate_for_ms returned\n", ret);

--- a/test/pico_low_power_test/low_power_test_simple.c
+++ b/test/pico_low_power_test/low_power_test_simple.c
@@ -59,7 +59,7 @@ int main() {
         // Setup ext_ctrl0 to output on the SLEEP_MONITOR_PIN
         init_powman_ext_ctrl();
         gpio_put(SLEEP_MONITOR_PIN, 0);
-        low_power_set_all_pins_low_leakage(USED_PIN_MASK);
+        low_power_set_pins_low_leakage_exclude_mask(USED_PIN_MASK);
         ret = low_power_pstate_for_ms(SLEEP_TIME_MS, NULL, NULL);
         if (ret != PICO_OK) {
             printf("%d ERROR: low_power_pstate_for_ms returned\n", ret);

--- a/test/pico_low_power_test/low_power_test_simple.c
+++ b/test/pico_low_power_test/low_power_test_simple.c
@@ -59,6 +59,7 @@ int main() {
         // Setup ext_ctrl0 to output on the SLEEP_MONITOR_PIN
         init_powman_ext_ctrl();
         gpio_put(SLEEP_MONITOR_PIN, 0);
+        low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
         ret = low_power_pstate_for_ms(SLEEP_TIME_MS, NULL, NULL);
         if (ret != PICO_OK) {
             printf("%d ERROR: low_power_pstate_for_ms returned\n", ret);

--- a/test/pico_low_power_test/low_power_test_simple.c
+++ b/test/pico_low_power_test/low_power_test_simple.c
@@ -59,7 +59,7 @@ int main() {
         // Setup ext_ctrl0 to output on the SLEEP_MONITOR_PIN
         init_powman_ext_ctrl();
         gpio_put(SLEEP_MONITOR_PIN, 0);
-        low_power_set_pins_low_leakage(USED_PIN_MASK);
+        low_power_set_all_pins_low_leakage(USED_PIN_MASK);
         ret = low_power_pstate_for_ms(SLEEP_TIME_MS, NULL, NULL);
         if (ret != PICO_OK) {
             printf("%d ERROR: low_power_pstate_for_ms returned\n", ret);

--- a/test/pico_low_power_test/low_power_test_timers.c
+++ b/test/pico_low_power_test/low_power_test_timers.c
@@ -296,7 +296,7 @@ int main() {
     my_number = 67890;
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
+    low_power_set_pins_low_leakage(USED_PIN_MASK);
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     ret = low_power_pstate_until_aon_timer(wakeup_time, NULL, pstate_resume_func);
@@ -342,7 +342,7 @@ post_pstate_sram_on:
     printf("Going to PSTATE with SRAM off for %d seconds\n", SLEEP_TIME_S);
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
+    low_power_set_pins_low_leakage(USED_PIN_MASK);
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     // store in scratch, as not persisting memory over this reboot

--- a/test/pico_low_power_test/low_power_test_timers.c
+++ b/test/pico_low_power_test/low_power_test_timers.c
@@ -296,6 +296,7 @@ int main() {
     my_number = 67890;
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
+    low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     ret = low_power_pstate_until_aon_timer(wakeup_time, NULL, pstate_resume_func);
@@ -341,6 +342,7 @@ post_pstate_sram_on:
     printf("Going to PSTATE with SRAM off for %d seconds\n", SLEEP_TIME_S);
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
+    low_power_set_pins_low_leakage((1u << SLEEP_MONITOR_PIN) | (1u << PICO_DEFAULT_UART_TX_PIN));
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     // store in scratch, as not persisting memory over this reboot

--- a/test/pico_low_power_test/low_power_test_timers.c
+++ b/test/pico_low_power_test/low_power_test_timers.c
@@ -296,7 +296,7 @@ int main() {
     my_number = 67890;
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_all_pins_low_leakage(USED_PIN_MASK);
+    low_power_set_pins_low_leakage_exclude_mask(USED_PIN_MASK);
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     ret = low_power_pstate_until_aon_timer(wakeup_time, NULL, pstate_resume_func);
@@ -342,7 +342,7 @@ post_pstate_sram_on:
     printf("Going to PSTATE with SRAM off for %d seconds\n", SLEEP_TIME_S);
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_all_pins_low_leakage(USED_PIN_MASK);
+    low_power_set_pins_low_leakage_exclude_mask(USED_PIN_MASK);
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     // store in scratch, as not persisting memory over this reboot

--- a/test/pico_low_power_test/low_power_test_timers.c
+++ b/test/pico_low_power_test/low_power_test_timers.c
@@ -296,7 +296,7 @@ int main() {
     my_number = 67890;
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_pins_low_leakage(USED_PIN_MASK);
+    low_power_set_all_pins_low_leakage(USED_PIN_MASK);
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     ret = low_power_pstate_until_aon_timer(wakeup_time, NULL, pstate_resume_func);
@@ -342,7 +342,7 @@ post_pstate_sram_on:
     printf("Going to PSTATE with SRAM off for %d seconds\n", SLEEP_TIME_S);
 
     gpio_put(SLEEP_MONITOR_PIN, 0);
-    low_power_set_pins_low_leakage(USED_PIN_MASK);
+    low_power_set_all_pins_low_leakage(USED_PIN_MASK);
     start_time = aon_timer_get_absolute_time();
     wakeup_time = delayed_by_ms(start_time, SLEEP_TIME_MS);
     // store in scratch, as not persisting memory over this reboot


### PR DESCRIPTION
This sets the pins to what I think is the lowest leakage state (pads_bank0 have pulls & input disabled, io_bank0 has output override set to disabled)