### PR TITLE
RISC-V: Test whether toolchain has both assembler and compiler support for Zcmp

### DIFF
--- a/cmake/preload/toolchains/pico_riscv_gcc.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc.cmake
@@ -7,4 +7,18 @@ set(PICO_COMMON_LANG_FLAGS_LIST
         " -mcpu=hazard3-rp2350"
         " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32"
         " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32")
+
+# C file used to test the flags listed above. There needs to be an equal number
+# of entries in PICO_COMMON_LANG_FLAGS_LIST and PICO_COMMON_LANG_FLAGS_TEST_FILES.
+set(PICO_COMMON_LANG_FLAGS_TEST_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/util/riscv_zcmp_test.c"
+        "${CMAKE_CURRENT_LIST_DIR}/util/riscv_zcmp_test.c"
+        "${CMAKE_CURRENT_LIST_DIR}/util/empty.c")
+
+# For context when we look back and wonder why this exists: there was a period where riscv-gnu-toolchain
+# shipped a version of GCC with full Zcmp support, but a version of binutils which lacked support for some 
+# Zcmp instructions (I think just cm.mvsa01 and cm.mva01s), so the assembler choked on the compiler output 
+# if you actually tried to compile anything significant. Hence testing specifically for these instructions
+# when checking the supported flags.
+
 include(${CMAKE_CURRENT_LIST_DIR}/util/pico_riscv_gcc_common.cmake)

--- a/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc_zcb_zcmp.cmake
@@ -1,3 +1,7 @@
+# This file exists for reproducing the RP2350 bootrom build, which depends on the CORE-V development toolchain, as mainline support for Zcmp did not exist at the time.
+
+# Do not use this file for new development. The default toolchain file supports Zcmp.
+
 # todo there is probably a more "cmake" way of doing this going thru the standard path with our "PICO" platform
 #  i.e. CMake<Lang>Information and whatnot
 

--- a/cmake/preload/toolchains/util/find_compiler.cmake
+++ b/cmake/preload/toolchains/util/find_compiler.cmake
@@ -46,7 +46,7 @@ endfunction()
 # Assuming the single flag variable is not already set, each of the flag_var_list flags are tried in order.
 # If the flags don't cause an error the single flag variable is set to the good flag value. If no valid flags
 # are found, a fatal error is raised.
-function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_lang_flags_var_list)
+function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_lang_flags_var_list test_files_var)
     # simplify logic by not complaining if both set, since CMake calls compiler setup repeatedly
     if (NOT ${common_lang_flags_var})
         if (${common_lang_flags_var_list})
@@ -55,8 +55,18 @@ function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_l
             else()
                 set(NULL_DEVICE "/dev/null")
             endif()
+
+            set(idx 0)
             foreach(flags IN LISTS ${common_lang_flags_var_list})
-                separate_arguments(COMPILER_CMD NATIVE_COMMAND "${compiler_path} ${flags} -x c -c \"${CMAKE_CURRENT_LIST_DIR}/empty.c\" -o ${NULL_DEVICE}")
+                # Use per-entry test file if provided, otherwise empty.c
+                if (${test_files_var})
+                    list(GET ${test_files_var} ${idx} test_file)
+                else()
+                    set(test_file "${CMAKE_CURRENT_LIST_DIR}/empty.c")
+                endif()
+
+                separate_arguments(COMPILER_CMD NATIVE_COMMAND
+                    "${compiler_path} ${flags} -x c -c \"${test_file}\" -o ${NULL_DEVICE}")
                 execute_process(
                         COMMAND ${COMPILER_CMD}
                         RESULT_VARIABLE COMPILE_FAILED
@@ -67,6 +77,7 @@ function(pico_choose_compiler_flags compiler_path common_lang_flags_var common_l
                     set(${common_lang_flags_var} ${flags} PARENT_SCOPE)
                     return()
                 endif()
+                math(EXPR idx "${idx} + 1")
             endforeach()
             message(FATAL_ERROR "No compiler found that supports required compiler flags")
         else()

--- a/cmake/preload/toolchains/util/pico_gcc_common.cmake
+++ b/cmake/preload/toolchains/util/pico_gcc_common.cmake
@@ -23,7 +23,7 @@ set(ENV{_SAVED_PICO_GCC_TRIPLE} "${PICO_GCC_TRIPLE}")
 
 # Find GCC
 pico_find_compiler_with_triples(PICO_COMPILER_CC "${PICO_GCC_TRIPLE}" gcc)
-pico_choose_compiler_flags(${PICO_COMPILER_CC} PICO_COMMON_LANG_FLAGS PICO_COMMON_LANG_FLAGS_LIST)
+pico_choose_compiler_flags(${PICO_COMPILER_CC} PICO_COMMON_LANG_FLAGS PICO_COMMON_LANG_FLAGS_LIST PICO_COMMON_LANG_FLAGS_TEST_FILES)
 pico_find_compiler_with_triples(PICO_COMPILER_CXX "${PICO_GCC_TRIPLE}" g++)
 set(PICO_COMPILER_ASM "${PICO_COMPILER_CC}" CACHE INTERNAL "")
 pico_find_compiler_with_triples(PICO_OBJCOPY "${PICO_GCC_TRIPLE}" objcopy)

--- a/cmake/preload/toolchains/util/riscv_zcmp_test.c
+++ b/cmake/preload/toolchains/util/riscv_zcmp_test.c
@@ -1,0 +1,4 @@
+/* Test that the toolchain can assemble Zcmp instructions */
+void _start(void) {
+    asm volatile ("cm.mvsa01 s0, s1" : : : "s0", "s1");
+}


### PR DESCRIPTION
This solves the issue where GCC 14.1.0 claims it supports zcmp in the arch flags but does not actually support it when you compile it. This results in compile errors on release. See this multi-gcc exhaustive run for an example of the failure:

https://github.com/raspberrypi/pico-sdk/actions/runs/28577860556/job/84731730132

Note: multi-gcc works on all RISC-V compilers with this patch