### PR TITLE
Use raw regex strings in Python tools

### DIFF
--- a/.github/workflows/scripts/generate_multi_gcc_workflow.py
+++ b/.github/workflows/scripts/generate_multi_gcc_workflow.py
@@ -56,7 +56,7 @@ for toolchain in toolchains:
     assert(len(stderr) == 0)
     # Version should be on first line
     version_line = stdout.split("\n")[0]
-    m = re.search("(\d+\.\d+\.\d+)", version_line)
+    m = re.search(r"(\d+\.\d+\.\d+)", version_line)
     assert(m is not None)
     version = m.group(1)
 

--- a/tools/compare_build_systems.py
+++ b/tools/compare_build_systems.py
@@ -215,7 +215,7 @@ def FindKnownOptions(option_pattern_matcher, file_paths):
     for p in file_paths:
         with open(p, "r") as f:
             for line in f:
-                if re.match("\s*#\s*#", line):
+                if re.match(r"\s*#\s*#", line):
                     # Ignore commented out defines
                     continue
 

--- a/tools/copro_dis.py
+++ b/tools/copro_dis.py
@@ -306,13 +306,13 @@ for pat, rep in replacements:
         mid = pat.split('\t')[1]
         left, right = mid.split(' ')[0:2]
         if len(right) > 6:
-            new_pat = f"([0-9a-f]{{8}}:\s*{left[2:]} {left[0:2]} {right[4:]} {right[:4]} \s*).*"
+            new_pat = rf"([0-9a-f]{{8}}:\s*{left[2:]} {left[0:2]} {right[4:]} {right[:4]} \s*).*"
             new_rep = rep.replace('3', '7')
             new_rep = new_rep.replace('4', '3')
             new_rep = new_rep.replace('7', '4')
             replacements.append((new_pat, new_rep))
         else:
-            replacements.append((f"([0-9a-f]{{8}}:\s*{left[2:]} {left[0:2]} {right[-2:]} {right[:-2]} \s*).*", rep))
+            replacements.append((rf"([0-9a-f]{{8}}:\s*{left[2:]} {left[0:2]} {right[-2:]} {right[:-2]} \s*).*", rep))
 
 for pat, rep in replacements:
     contents = re.sub(pat, rep, contents)

--- a/tools/extract_configs.py
+++ b/tools/extract_configs.py
@@ -75,7 +75,7 @@ def get_first_dict_key(some_dict):
 
 def look_for_integer_define(config_name, attr_name, attr_str, file_path, linenum, applicable):
     defined_str = None
-    if re.match('^\w+$', attr_str):
+    if re.match(r'^\w+$', attr_str):
         # See if we have a matching define
         all_defines = chips_all_defines[applicable]
         if attr_str in all_defines:


### PR DESCRIPTION
## Summary
- use raw regex strings in Python 3 tools where the regex value is unchanged
- remove invalid escape sequence `SyntaxWarning`s from SDK-owned Python files outside `lib/`

## Duplicate check
- No open PR or issue found for `SyntaxWarning`.
- No open PR or issue found for `invalid escape`.
- No open PR or issue found for `extract_configs`.

## Validation
- `python -W error::SyntaxWarning -m py_compile .github/workflows/scripts/generate_multi_gcc_workflow.py tools/compare_build_systems.py tools/copro_dis.py tools/extract_configs.py`
- repository SDK-owned Python warning-as-error compile scan excluding `lib/` reports `TOTAL 0`
- `git diff --check`
- `git ls-files --eol .github/workflows/scripts/generate_multi_gcc_workflow.py tools/compare_build_systems.py tools/copro_dis.py tools/extract_configs.py`