### PR TITLE
Handle GOT sections gracefully

### DIFF
--- a/src/rp2_common/pico_standard_link/script_include/section_copy_to_ram_data.incl
+++ b/src/rp2_common/pico_standard_link/script_include/section_copy_to_ram_data.incl
@@ -29,6 +29,8 @@ SECTIONS
 
         *(.data*)
         *(.sdata*)
+        *(.got)
+        *(.got.*)
 
         . = ALIGN(4);
         PROVIDE_HIDDEN (__emutls_array_start = .);

--- a/src/rp2_common/pico_standard_link/script_include/section_copy_to_ram_data.incl
+++ b/src/rp2_common/pico_standard_link/script_include/section_copy_to_ram_data.incl
@@ -29,8 +29,6 @@ SECTIONS
 
         *(.data*)
         *(.sdata*)
-        *(.got)
-        *(.got.*)
 
         . = ALIGN(4);
         PROVIDE_HIDDEN (__emutls_array_start = .);

--- a/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
+++ b/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
@@ -30,7 +30,7 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
-	  /* if linked against non PIC archives, ARM targets may generate dynamic data relocations via got sections */
+	    /* if linked against non PIC archives, ARM targets may generate dynamic data relocations via got sections */
         *(.got)
         *(.got.*)
 

--- a/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
+++ b/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
@@ -30,6 +30,10 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+	/* if linked against non PIC archives, ARM targets may generate dynamic data relocations via got sections */
+	*(.got)
+        *(.got.*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
+++ b/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
@@ -31,7 +31,7 @@ SECTIONS
         *(.sdata*)
 
 	/* if linked against non PIC archives, ARM targets may generate dynamic data relocations via got sections */
-	*(.got)
+        *(.got)
         *(.got.*)
 
         . = ALIGN(4);

--- a/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
+++ b/src/rp2_common/pico_standard_link/script_include/section_default_data.incl
@@ -30,7 +30,7 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
-	/* if linked against non PIC archives, ARM targets may generate dynamic data relocations via got sections */
+	  /* if linked against non PIC archives, ARM targets may generate dynamic data relocations via got sections */
         *(.got)
         *(.got.*)
 


### PR DESCRIPTION
If any of the libraries linked against is built as position independent code, weak undefined symbols and comdat symbols may have GOT relocations. We observed this in the LLVM runtime libraries (libc.a/libm.a) but this behavior is not specific to Clang/LLVM toolchains. Including the GOT sections into the data section to handle them gracefully.

Fixes https://github.com/raspberrypi/pico-sdk/issues/3064