### PR TITLE
Add irq_is_pending() accessor for checking IRQ line state from foregr…

### DIFF
--- a/src/host/hardware_irq/include/hardware/irq.h
+++ b/src/host/hardware_irq/include/hardware/irq.h
@@ -310,6 +310,26 @@ void irq_clear(uint int_num);
  */
 void irq_set_pending(uint num);
 
+/*! \brief Check whether an IRQ is pending on the current core.
+ *  \ingroup hardware_irq
+ *
+ * Returns true if the external system IRQ line is currently asserted, or if
+ * the IRQ has been forced high inside the core using irq_set_pending().
+ *
+ * This function can be used to poll IRQ flags that are currently disabled
+ * (via a previous call to irq_set_enabled(num, false);).
+ *
+ * Do not use this function for an IRQ that is enabled at any priority that
+ * might preempt the core; it is useless in such cases because the core may
+ * enter the IRQ handler without this function ever returning true.
+ *
+ * When polling for external IRQ assertion on an Arm core equipped with an
+ * NVIC, it's recommended to call irq_clear() once before calling this
+ * function, to clear any stale assertions from the internal pending latch.
+ *
+ * \param num Interrupt number \ref interrupt_nums
+ */
+bool irq_is_pending(uint num);
 
 /*! \brief Perform IRQ priority initialization for the current core
  *

--- a/src/host/hardware_irq/irq.c
+++ b/src/host/hardware_irq/irq.c
@@ -46,6 +46,11 @@ void PICO_WEAK_FUNCTION_IMPL_NAME(irq_set_pending)(uint num) {
     panic_unsupported();
 }
 
+PICO_WEAK_FUNCTION_DEF(irq_is_pending)
+bool PICO_WEAK_FUNCTION_IMPL_NAME(irq_is_pending)(uint num) {
+    panic_unsupported();
+}
+
 PICO_WEAK_FUNCTION_DEF(irq_has_shared_handler)
 bool PICO_WEAK_FUNCTION_IMPL_NAME(irq_has_shared_handler)(uint irq_num) {
     return false;

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -142,7 +142,7 @@ void irq_set_pending(uint num) {
     hazard3_irqarray_set(RVCSR_MEIFA_OFFSET, num / 16, 1u << (num % 16));
 #else
 #if PICO_RP2040
-    *((io_rw_32 *) (PPB_BASE + M0PLUS_NVIC_ISPR_OFFSET)) = 1u << num;
+    nvic_hw->ispr = 1u << num;
 #else
     nvic_hw->ispr[num/32] = 1 << (num % 32);
 #endif
@@ -150,10 +150,15 @@ void irq_set_pending(uint num) {
 }
 
 bool irq_is_pending(uint num) {
+    check_irq_param(num);
 #ifdef __riscv
     return hazard3_irqarray_read(RVCSR_MEIPA_OFFSET, num / 16u) & (1u << (num % 16u));
 #else
+#if PICO_RP2040
+    return nvic_hw->ispr & (1u << num);
+#else
     return nvic_hw->ispr[num / 32u] & (1u << (num % 32u));
+#endif
 #endif
 }
 

--- a/src/rp2_common/hardware_irq/irq.c
+++ b/src/rp2_common/hardware_irq/irq.c
@@ -149,6 +149,14 @@ void irq_set_pending(uint num) {
 #endif
 }
 
+bool irq_is_pending(uint num) {
+#ifdef __riscv
+    return hazard3_irqarray_read(RVCSR_MEIPA_OFFSET, num / 16u) & (1u << (num % 16u));
+#else
+    return nvic_hw->ispr[num / 32u] & (1u << (num % 32u));
+#endif
+}
+
 #if !PICO_NO_RAM_VECTOR_TABLE
 static void set_raw_irq_handler_and_unlock(uint num, irq_handler_t handler, uint32_t save) {
     // update vtable (vtable_handler may be same or updated depending on cases, but we do it anyway for compactness)


### PR DESCRIPTION
We've accumulated a few copies of this accessor in test code, so it seems like a useful pattern (albeit situational).