### PR TITLE
Don't place libc.a in RAM

### DIFF
--- a/src/rp2_common/pico_standard_link/script_include/default_rodata_excludes.incl
+++ b/src/rp2_common/pico_standard_link/script_include/default_rodata_excludes.incl
@@ -1,1 +1,1 @@
-*(EXCLUDE_FILE(*libgcc.a: *lib*_a-mem*.o *libm.a:) .rodata*)
+*(EXCLUDE_FILE(*libgcc.a: *libm.a:) .rodata*)

--- a/src/rp2_common/pico_standard_link/script_include/default_rodata_excludes.incl
+++ b/src/rp2_common/pico_standard_link/script_include/default_rodata_excludes.incl
@@ -1,1 +1,1 @@
-*(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib*_a-mem*.o *libm.a:) .rodata*)
+*(EXCLUDE_FILE(*libgcc.a: *lib*_a-mem*.o *libm.a:) .rodata*)

--- a/src/rp2_common/pico_standard_link/script_include/default_text_excludes.incl
+++ b/src/rp2_common/pico_standard_link/script_include/default_text_excludes.incl
@@ -1,1 +1,1 @@
-*(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib*_a-mem*.o *libm.a:) .text*)
+*(EXCLUDE_FILE(*libgcc.a: *lib*_a-mem*.o *libm.a:) .text*)

--- a/src/rp2_common/pico_standard_link/script_include/default_text_excludes.incl
+++ b/src/rp2_common/pico_standard_link/script_include/default_text_excludes.incl
@@ -1,1 +1,1 @@
-*(EXCLUDE_FILE(*libgcc.a: *lib*_a-mem*.o *libm.a:) .text*)
+*(EXCLUDE_FILE(*libgcc.a: *libm.a:) .text*)


### PR DESCRIPTION
As part of a bugfix to place `mem` functions in RAM as intended (https://github.com/raspberrypi/pico-sdk/commit/dc3a2e861adebdff1b7009f950580f1f719366d1), now all of `libc.a` gets placed in RAM too which takes up a lot of extra space. This fixes that to only place the `mem` functions in RAM, and leave `libc.a` in Flash.

It looks like this may have been missed because on some (possibly most) toolchains (e.g. Debian arm-none-eabi-gcc 14.2.1) if there are any `-g` flags passed, the toolchain uses `libg.a` instead of `libc.a`, and `PICO_DEBUG_INFO_IN_RELEASE` (which defaults to 1) passes `-g`. Therefore there was no `libc.a` to place in RAM, so the size increase doesn't occur.

Reproduced the issue from #3070 with `PICO_DEBUG_INFO_IN_RELEASE=0` and the `kitchen_sink_printf_compiler` test, which shows the increase in RAM usage due to placing `libc.a` in Flash

Fixes #3070