### PR TITLE
Don't use s0 in Risc-V zcmp test compile

### DIFF
--- a/cmake/preload/toolchains/util/riscv_zcmp_test.c
+++ b/cmake/preload/toolchains/util/riscv_zcmp_test.c
@@ -1,4 +1,5 @@
 /* Test that the toolchain can assemble Zcmp instructions */
 void _start(void) {
-    asm volatile ("cm.mvsa01 s0, s1" : : : "s0", "s1");
+    // Cannot use s0 as it is also fp, so use s1 & s2 instead
+    asm volatile ("cm.mvsa01 s1, s2" : : : "s1", "s2");
 }


### PR DESCRIPTION
This file currently fails to compile with any compilers, resulting in `pico_riscv_gcc` always falling through to the non-zcmp arch string

The fix is to change the registers used to `s1` and `s2` instead