### PR TITLE
Fix `async_context` `core_num`/worker affinity mismatch under FreeRTOS SMP

### DIFF
--- a/src/rp2_common/pico_async_context/async_context_freertos.c
+++ b/src/rp2_common/pico_async_context/async_context_freertos.c
@@ -109,7 +109,18 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
     memset(self, 0, sizeof(*self));
     self->core.type = &template;
     self->core.flags = ASYNC_CONTEXT_FLAG_CALLBACK_FROM_NON_IRQ;
+#if configNUMBER_OF_CORES > 1
+    // sample the core once: core_num must match the core the task is pinned to
+    UBaseType_t core_id = config->task_core_id;
+    if (core_id == (UBaseType_t)-1) {
+        core_id = portGET_CORE_ID();
+    }
+    assert(core_id < configNUMBER_OF_CORES);
+    self->core.core_num = (uint8_t)core_id;
+    const UBaseType_t core_affinity_mask = 1u << core_id;
+#else
     self->core.core_num = get_core_num();
+#endif
 #if configSUPPORT_STATIC_ALLOCATION
     assert(config->task_stack);
     self->lock_mutex = xSemaphoreCreateRecursiveMutexStatic(&self->lock_mutex_buf);
@@ -121,6 +132,17 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
                                              self,
                                              timer_handler,
                                              &self->timer_buf);
+#if configNUMBER_OF_CORES > 1
+    // create the task pre-pinned so it can't run on the wrong core first
+    self->task_handle = xTaskCreateStaticAffinitySet( async_context_task,
+                                                      "async_context_task",
+                                                      config->task_stack_size,
+                                                      self,
+                                                      config->task_priority,
+                                                      config->task_stack,
+                                                      &self->task_buf,
+                                                      core_affinity_mask);
+#else
     self->task_handle = xTaskCreateStatic( async_context_task,
                                            "async_context_task",
                                            config->task_stack_size,
@@ -128,6 +150,7 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
                                            config->task_priority,
                                            config->task_stack,
                                            &self->task_buf);
+#endif
 #else
     self->lock_mutex = xSemaphoreCreateRecursiveMutex();
     self->work_needed_sem = xSemaphoreCreateBinary();
@@ -144,6 +167,9 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
         !self->timer_handle ||
 #if configSUPPORT_STATIC_ALLOCATION
         !self->task_handle
+#elif configNUMBER_OF_CORES > 1
+        pdPASS != xTaskCreateAffinitySet(async_context_task, "async_context_task", config->task_stack_size, self,
+                config->task_priority, core_affinity_mask, &self->task_handle)
 #else
         pdPASS != xTaskCreate(async_context_task, "async_context_task", config->task_stack_size, self,
                 config->task_priority, &self->task_handle)
@@ -152,14 +178,6 @@ bool async_context_freertos_init(async_context_freertos_t *self, async_context_f
         async_context_deinit(&self->core);
         return false;
     }
-#if configNUMBER_OF_CORES > 1
-    UBaseType_t core_id = config->task_core_id;
-    if (core_id == (UBaseType_t)-1) {
-        core_id = portGET_CORE_ID();
-    }
-    // we must run on a single core
-    vTaskCoreAffinitySet(self->task_handle, 1u << core_id);
-#endif
     return true;
 }
 


### PR DESCRIPTION
Fixes #3080

## Problem

Under FreeRTOS SMP, `async_context_freertos_init()` sampled the current core twice: once at the top for `self->core.core_num`, and again after creating the semaphores/timer/worker task to pick the worker's affinity. An unpinned caller can migrate cores between the two samples, so `core_num` and the worker's actual affinity could disagree — breaking the invariant `async_context_core_num() == worker's pinned core` that the four asserts in `cyw43_driver.c` rely on, and silently misreporting the core through the public `async_context_core_num()` accessor in `NDEBUG` builds.

## Change

Resolve the worker's core exactly once at the top of the function (from `task_core_id`, falling back to the current core), set `core_num` from it, and create the worker task already pinned to that core via `xTaskCreate[Static]AffinitySet()` — the same APIs `pico_flash` already uses — dropping the separate `vTaskCoreAffinitySet()` call. This also removes the window where the freshly created task could briefly run on an arbitrary core before its affinity was set. An assert on `task_core_id` validity is added (an out-of-range value previously produced an unschedulable task). Single-core builds are unaffected.

## Testing

Pico W, FreeRTOS-Kernel V11.1.0 SMP (`configNUMBER_OF_CORES=2`, `configUSE_CORE_AFFINITY=1`), `pico_cyw43_arch_lwip_sys_freertos`, with both `configSUPPORT_STATIC_ALLOCATION=0` and `=1`, using an extended version of the repro from #3080 (posted in the comments below): 100 unpinned `cyw43_arch_init()`/`cyw43_arch_deinit()` cycles followed by a successful STA connection, then another 100 cycles using a user-provided context with a randomized `task_core_id` each cycle, again followed by a successful STA connection. The same setup asserts within a handful of cycles on unpatched code. Note the STA phases require current `develop` (with #3097), which fixed lwIP re-initialization after a deinit.