### PR TITLE
`sem_init` `initial_permits` parameter doc comment minor correction

### DIFF
--- a/src/common/pico_sync/include/pico/sem.h
+++ b/src/common/pico_sync/include/pico/sem.h
@@ -45,7 +45,7 @@ typedef struct semaphore {
  *  \ingroup sem
  *
  * \param sem Pointer to semaphore structure
- * \param initial_permits How many permits are initially released
+ * \param initial_permits How many permits are initially available
  * \param max_permits  Total number of permits allowed for this semaphore
  */
 void sem_init(semaphore_t *sem, int16_t initial_permits, int16_t max_permits);

--- a/src/common/pico_sync/include/pico/sem.h
+++ b/src/common/pico_sync/include/pico/sem.h
@@ -45,7 +45,7 @@ typedef struct semaphore {
  *  \ingroup sem
  *
  * \param sem Pointer to semaphore structure
- * \param initial_permits How many permits are initially acquired
+ * \param initial_permits How many permits are initially released
  * \param max_permits  Total number of permits allowed for this semaphore
  */
 void sem_init(semaphore_t *sem, int16_t initial_permits, int16_t max_permits);


### PR DESCRIPTION
A semaphore initialized as below starts with one initial permit _released_. Not _acquired_, as the doc comment would leave users to believe.

```c
sem_init(&sem, 1, 1);
```