### PR TITLE
Add RP2350-only flash functions to Doxygen output

### DIFF
--- a/src/rp2_common/hardware_flash/include/hardware/flash.h
+++ b/src/rp2_common/hardware_flash/include/hardware/flash.h
@@ -169,7 +169,7 @@ static inline void flash_do_cmd(const uint8_t *txbuf, uint8_t *rxbuf, size_t cou
 
 void flash_flush_cache(void);
 
-#if !PICO_RP2040
+#if !PICO_RP2040 || PICO_COMBINED_DOCS
 typedef void (*qmi_setup_function_t)(void);
 
 /*! \brief Set the function to be called to setup the QMI CS1 configuration
@@ -303,7 +303,7 @@ uint flash_devinfo_get_cs_gpio(uint cs);
  */
 void flash_devinfo_set_cs_gpio(uint cs, uint gpio);
 
-#endif // !PICO_RP2040
+#endif // !PICO_RP2040 || PICO_COMBINED_DOCS
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes https://github.com/raspberrypi/documentation/issues/4304

This is what the generated HTML docs will look like after this PR is merged:
<img width="937" height="905" alt="Screenshot from 2026-07-20 18-28-27" src="https://github.com/user-attachments/assets/b7db5ae4-524f-4665-aec1-ac737dc2e31f" />

(and the same fix will also affect the [Pico C SDK PDF](https://pip.raspberrypi.com//documents/RP-009085-KB) too :slightly_smiling_face: )