### PR TITLE
Standardise usage of rom_get_sys_info function

### DIFF
--- a/src/rp2_common/boot_bootrom_headers/include/boot/bootrom_constants.h
+++ b/src/rp2_common/boot_bootrom_headers/include/boot/bootrom_constants.h
@@ -239,25 +239,25 @@ typedef int (*bootrom_api_callback_generic_t)(uint32_t r0, uint32_t r1, uint32_t
 // items are returned in order
 // 3 words package_id, device_id_lo, device_id_hi
 #define SYS_INFO_CHIP_INFO                      0x0001
-#define SYS_INFO_CHIP_INFO_WORDS_RETURNED       _u(3)
+#define SYS_INFO_CHIP_INFO_WORD_COUNT           _u(3)
 // 1 word: chip specific critical bits
 #define SYS_INFO_CRITICAL                       0x0002
-#define SYS_INFO_CRITICAL_WORDS_RETURNED        _u(1)
+#define SYS_INFO_CRITICAL_WORD_COUNT            _u(1)
 // 1 word: bytes: cpu_type, supported_cpu_type_bitfield
 #define SYS_INFO_CPU_INFO                       0x0004
-#define SYS_INFO_CPU_INFO_WORDS_RETURNED        _u(1)
+#define SYS_INFO_CPU_INFO_WORD_COUNT            _u(1)
 // 1 word: same as FLASH_DEVINFO row in OTP
 #define SYS_INFO_FLASH_DEV_INFO                 0x0008
-#define SYS_INFO_FLASH_DEV_INFO_WORDS_RETURNED  _u(1)
+#define SYS_INFO_FLASH_DEV_INFO_WORD_COUNT      _u(1)
 // 4 words
 #define SYS_INFO_BOOT_RANDOM                    0x0010
-#define SYS_INFO_BOOT_RANDOM_WORDS_RETURNED     _u(4)
+#define SYS_INFO_BOOT_RANDOM_WORD_COUNT         _u(4)
 // 2 words lsb first
 #define SYS_INFO_NONCE                          0x0020
-#define SYS_INFO_NONCE_WORDS_RETURNED           _u(2)
+#define SYS_INFO_NONCE_WORD_COUNT              _u(2)
 // 4 words boot_info, boot_diagnostic, boot_param0, boot_param1
 #define SYS_INFO_BOOT_INFO                      0x0040
-#define SYS_INFO_BOOT_INFO_WORDS_RETURNED       _u(4)
+#define SYS_INFO_BOOT_INFO_WORD_COUNT           _u(4)
 
 #define BOOTROM_NS_API_get_sys_info 0
 #define BOOTROM_NS_API_checked_flash_op 1

--- a/src/rp2_common/boot_bootrom_headers/include/boot/bootrom_constants.h
+++ b/src/rp2_common/boot_bootrom_headers/include/boot/bootrom_constants.h
@@ -239,18 +239,25 @@ typedef int (*bootrom_api_callback_generic_t)(uint32_t r0, uint32_t r1, uint32_t
 // items are returned in order
 // 3 words package_id, device_id_lo, device_id_hi
 #define SYS_INFO_CHIP_INFO                      0x0001
+#define SYS_INFO_CHIP_INFO_WORDS_RETURNED       _u(3)
 // 1 word: chip specific critical bits
 #define SYS_INFO_CRITICAL                       0x0002
+#define SYS_INFO_CRITICAL_WORDS_RETURNED        _u(1)
 // 1 word: bytes: cpu_type, supported_cpu_type_bitfield
 #define SYS_INFO_CPU_INFO                       0x0004
+#define SYS_INFO_CPU_INFO_WORDS_RETURNED        _u(1)
 // 1 word: same as FLASH_DEVINFO row in OTP
 #define SYS_INFO_FLASH_DEV_INFO                 0x0008
+#define SYS_INFO_FLASH_DEV_INFO_WORDS_RETURNED  _u(1)
 // 4 words
 #define SYS_INFO_BOOT_RANDOM                    0x0010
+#define SYS_INFO_BOOT_RANDOM_WORDS_RETURNED     _u(4)
 // 2 words lsb first
 #define SYS_INFO_NONCE                          0x0020
+#define SYS_INFO_NONCE_WORDS_RETURNED           _u(2)
 // 4 words boot_info, boot_diagnostic, boot_param0, boot_param1
 #define SYS_INFO_BOOT_INFO                      0x0040
+#define SYS_INFO_BOOT_INFO_WORDS_RETURNED       _u(4)
 
 #define BOOTROM_NS_API_get_sys_info 0
 #define BOOTROM_NS_API_checked_flash_op 1

--- a/src/rp2_common/pico_bootrom/bootrom.c
+++ b/src/rp2_common/pico_bootrom/bootrom.c
@@ -85,9 +85,9 @@ void __attribute__((noreturn)) rom_reset_usb_boot_extra(int usb_activity_gpio_pi
 
 #if !PICO_RP2040
 bool rom_get_boot_random(uint32_t out[4]) {
-    uint32_t result[SYS_INFO_BOOT_RANDOM_WORDS_RETURNED + 1];
+    uint32_t result[SYS_INFO_BOOT_RANDOM_WORD_COUNT + 1];
     int words_returned = rom_get_sys_info(result, count_of(result), SYS_INFO_BOOT_RANDOM);
-    if ((words_returned - 1) == SYS_INFO_BOOT_RANDOM_WORDS_RETURNED && result[0] == SYS_INFO_BOOT_RANDOM) {
+    if (words_returned == (SYS_INFO_BOOT_RANDOM_WORD_COUNT + 1) && result[0] == SYS_INFO_BOOT_RANDOM) {
         for(uint i=0;i<4;i++) {
             out[i] = result[i+1];
         }

--- a/src/rp2_common/pico_bootrom/bootrom.c
+++ b/src/rp2_common/pico_bootrom/bootrom.c
@@ -86,8 +86,8 @@ void __attribute__((noreturn)) rom_reset_usb_boot_extra(int usb_activity_gpio_pi
 #if !PICO_RP2040
 bool rom_get_boot_random(uint32_t out[4]) {
     uint32_t result[5];
-    rom_get_sys_info_fn func = (rom_get_sys_info_fn) rom_func_lookup_inline(ROM_FUNC_GET_SYS_INFO);
-    if (5 == func(result, count_of(result), SYS_INFO_BOOT_RANDOM)) {
+    int words_returned = rom_get_sys_info(result, 5, SYS_INFO_BOOT_RANDOM);
+    if (words_returned == count_of(result) && result[0] == SYS_INFO_BOOT_RANDOM) {
         for(uint i=0;i<4;i++) {
             out[i] = result[i+1];
         }

--- a/src/rp2_common/pico_bootrom/bootrom.c
+++ b/src/rp2_common/pico_bootrom/bootrom.c
@@ -85,9 +85,9 @@ void __attribute__((noreturn)) rom_reset_usb_boot_extra(int usb_activity_gpio_pi
 
 #if !PICO_RP2040
 bool rom_get_boot_random(uint32_t out[4]) {
-    uint32_t result[5];
-    int words_returned = rom_get_sys_info(result, 5, SYS_INFO_BOOT_RANDOM);
-    if (words_returned == count_of(result) && result[0] == SYS_INFO_BOOT_RANDOM) {
+    uint32_t result[SYS_INFO_BOOT_RANDOM_WORDS_RETURNED + 1];
+    int words_returned = rom_get_sys_info(result, count_of(result), SYS_INFO_BOOT_RANDOM);
+    if ((words_returned - 1) == SYS_INFO_BOOT_RANDOM_WORDS_RETURNED && result[0] == SYS_INFO_BOOT_RANDOM) {
         for(uint i=0;i<4;i++) {
             out[i] = result[i+1];
         }

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -1109,9 +1109,9 @@ typedef struct {
 } boot_info_t;
 
 static inline int rom_get_boot_info(boot_info_t *info) {
-    uint32_t result[5];
-    int words_returned = rom_get_sys_info(result, 5, SYS_INFO_BOOT_INFO);
-    if (words_returned == (sizeof(result)/sizeof(result[0])) && result[0] == SYS_INFO_BOOT_INFO) {
+    uint32_t result[SYS_INFO_BOOT_INFO_WORDS_RETURNED + 1];
+    int words_returned = rom_get_sys_info(result, count_of(result), SYS_INFO_BOOT_INFO);
+    if ((words_returned - 1) == SYS_INFO_BOOT_INFO_WORDS_RETURNED && result[0] == SYS_INFO_BOOT_INFO) {
         memcpy(info, &result[1], sizeof(boot_info_t));
         return true;
     } else {
@@ -1120,9 +1120,9 @@ static inline int rom_get_boot_info(boot_info_t *info) {
 }
 
 static inline int rom_get_last_boot_type_with_chained_flag(void) {
-    uint32_t result[5];
-    int words_returned = rom_get_sys_info(result, 5, SYS_INFO_BOOT_INFO);
-    if (words_returned == count_of(result) && result[0] == SYS_INFO_BOOT_INFO) {
+    uint32_t result[SYS_INFO_BOOT_INFO_WORDS_RETURNED + 1];
+    int words_returned = rom_get_sys_info(result, count_of(result), SYS_INFO_BOOT_INFO);
+    if ((words_returned - 1) == SYS_INFO_BOOT_INFO_WORDS_RETURNED && result[0] == SYS_INFO_BOOT_INFO) {
         // todo use struct
         return (int)((result[1] & 0xff00u) >> 8);
     } else {

--- a/src/rp2_common/pico_bootrom/include/pico/bootrom.h
+++ b/src/rp2_common/pico_bootrom/include/pico/bootrom.h
@@ -1109,9 +1109,9 @@ typedef struct {
 } boot_info_t;
 
 static inline int rom_get_boot_info(boot_info_t *info) {
-    uint32_t result[SYS_INFO_BOOT_INFO_WORDS_RETURNED + 1];
+    uint32_t result[SYS_INFO_BOOT_INFO_WORD_COUNT + 1];
     int words_returned = rom_get_sys_info(result, count_of(result), SYS_INFO_BOOT_INFO);
-    if ((words_returned - 1) == SYS_INFO_BOOT_INFO_WORDS_RETURNED && result[0] == SYS_INFO_BOOT_INFO) {
+    if (words_returned == (SYS_INFO_BOOT_INFO_WORD_COUNT + 1) && result[0] == SYS_INFO_BOOT_INFO) {
         memcpy(info, &result[1], sizeof(boot_info_t));
         return true;
     } else {
@@ -1120,9 +1120,9 @@ static inline int rom_get_boot_info(boot_info_t *info) {
 }
 
 static inline int rom_get_last_boot_type_with_chained_flag(void) {
-    uint32_t result[SYS_INFO_BOOT_INFO_WORDS_RETURNED + 1];
+    uint32_t result[SYS_INFO_BOOT_INFO_WORD_COUNT + 1];
     int words_returned = rom_get_sys_info(result, count_of(result), SYS_INFO_BOOT_INFO);
-    if ((words_returned - 1) == SYS_INFO_BOOT_INFO_WORDS_RETURNED && result[0] == SYS_INFO_BOOT_INFO) {
+    if (words_returned == (SYS_INFO_BOOT_INFO_WORD_COUNT + 1) && result[0] == SYS_INFO_BOOT_INFO) {
         // todo use struct
         return (int)((result[1] & 0xff00u) >> 8);
     } else {

--- a/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
+++ b/src/rp2_common/pico_stdio_usb/stdio_usb_descriptors.c
@@ -167,7 +167,7 @@ const uint16_t *tud_descriptor_string_cb(uint8_t index, __unused uint16_t langid
         desc_str[1] = 0x0409; // supported language is English
         len = 1;
     } else {
-        if (index >= sizeof(usbd_desc_str) / sizeof(usbd_desc_str[0])) {
+        if (index >= count_of(usbd_desc_str)) {
             return NULL;
         }
         const char *str = usbd_desc_str[index];

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -45,12 +45,12 @@ static void __attribute__((PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES)) _retrieve_uniq
 #else
     #if PICO_UNIQUE_BOARD_ID_SIZE_BYTES <= SYS_INFO_DEVICE_ID_SIZE_BYTES
         union {
-            uint32_t words[SYS_INFO_CHIP_INFO_WORDS_RETURNED + 1];
-            uint8_t bytes[(SYS_INFO_CHIP_INFO_WORDS_RETURNED + 1) * 4];
+            uint32_t words[SYS_INFO_CHIP_INFO_WORD_COUNT + 1];
+            uint8_t bytes[(SYS_INFO_CHIP_INFO_WORD_COUNT + 1) * 4];
         } out;
         int words_returned = rom_get_sys_info(out.words, count_of(out.words), SYS_INFO_CHIP_INFO);
-        assert(words_returned == SYS_INFO_CHIP_INFO_WORDS_RETURNED + 1);
-        if ((words_returned - 1) == SYS_INFO_CHIP_INFO_WORDS_RETURNED && out.words[0] == SYS_INFO_CHIP_INFO) {
+        assert(words_returned == SYS_INFO_CHIP_INFO_WORD_COUNT + 1);
+        if (words_returned == (SYS_INFO_CHIP_INFO_WORD_COUNT + 1) && out.words[0] == SYS_INFO_CHIP_INFO) {
             for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; i++) {
                 // The device ID is in words 3 and 4, so skip the first two words (i.e. the first 8 bytes)
                 retrieved_id.id[i] = out.bytes[PICO_UNIQUE_BOARD_ID_SIZE_BYTES - 1 + 2 * 4 - i];

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -8,7 +8,12 @@
 #include "pico/bootrom.h"
 #include "pico/unique_id.h"
 
-static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES <= FLASH_UNIQUE_ID_SIZE_BYTES, "Board ID size must at least be the size of flash ID");
+#if PICO_RP2040
+static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES <= FLASH_UNIQUE_ID_SIZE_BYTES, "Board ID size cannot be greater than the size of flash ID");
+#else
+#define SYS_INFO_DEVICE_ID_SIZE_BYTES 8
+static_assert(PICO_UNIQUE_BOARD_ID_SIZE_BYTES <= SYS_INFO_DEVICE_ID_SIZE_BYTES, "Board ID size cannot be greater than the size of device ID");
+#endif
 
 static pico_unique_board_id_t retrieved_id;
 
@@ -38,16 +43,22 @@ static void __attribute__((PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES)) _retrieve_uniq
         #error unique board ID size is greater than flash unique ID size
     #endif
 #else
-    rom_get_sys_info_fn func = (rom_get_sys_info_fn) rom_func_lookup(ROM_FUNC_GET_SYS_INFO);
-    union {
-        uint32_t words[9];
-        uint8_t bytes[9 * 4];
-    } out;
-    __unused int rc = func(out.words, 9, SYS_INFO_CHIP_INFO);
-    assert(rc == 4);
-    for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; i++) {
-        retrieved_id.id[i] = out.bytes[PICO_UNIQUE_BOARD_ID_SIZE_BYTES - 1 + 2 * 4 - i];
-    }
+    #if PICO_UNIQUE_BOARD_ID_SIZE_BYTES <= SYS_INFO_DEVICE_ID_SIZE_BYTES
+        union {
+            uint32_t words[4];
+            uint8_t bytes[4 * 4];
+        } out;
+        int words_returned = rom_get_sys_info(out.words, 4, SYS_INFO_CHIP_INFO);
+        assert(words_returned == 4);
+        if (words_returned == count_of(out.words) && out.words[0] == SYS_INFO_CHIP_INFO) {
+            for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; i++) {
+                // The device ID is in words 3 and 4, so skip the first two words (i.e. the first 8 bytes)
+                retrieved_id.id[i] = out.bytes[PICO_UNIQUE_BOARD_ID_SIZE_BYTES - 1 + 2 * 4 - i];
+            }
+        }
+    #else
+        #error unique board ID size is greater than device unique ID size
+    #endif
 #endif
 }
 

--- a/src/rp2_common/pico_unique_id/unique_id.c
+++ b/src/rp2_common/pico_unique_id/unique_id.c
@@ -45,12 +45,12 @@ static void __attribute__((PICO_UNIQUE_BOARD_ID_INIT_ATTRIBUTES)) _retrieve_uniq
 #else
     #if PICO_UNIQUE_BOARD_ID_SIZE_BYTES <= SYS_INFO_DEVICE_ID_SIZE_BYTES
         union {
-            uint32_t words[4];
-            uint8_t bytes[4 * 4];
+            uint32_t words[SYS_INFO_CHIP_INFO_WORDS_RETURNED + 1];
+            uint8_t bytes[(SYS_INFO_CHIP_INFO_WORDS_RETURNED + 1) * 4];
         } out;
-        int words_returned = rom_get_sys_info(out.words, 4, SYS_INFO_CHIP_INFO);
-        assert(words_returned == 4);
-        if (words_returned == count_of(out.words) && out.words[0] == SYS_INFO_CHIP_INFO) {
+        int words_returned = rom_get_sys_info(out.words, count_of(out.words), SYS_INFO_CHIP_INFO);
+        assert(words_returned == SYS_INFO_CHIP_INFO_WORDS_RETURNED + 1);
+        if ((words_returned - 1) == SYS_INFO_CHIP_INFO_WORDS_RETURNED && out.words[0] == SYS_INFO_CHIP_INFO) {
             for (int i = 0; i < PICO_UNIQUE_BOARD_ID_SIZE_BYTES; i++) {
                 // The device ID is in words 3 and 4, so skip the first two words (i.e. the first 8 bytes)
                 retrieved_id.id[i] = out.bytes[PICO_UNIQUE_BOARD_ID_SIZE_BYTES - 1 + 2 * 4 - i];


### PR DESCRIPTION
I copied the `rom_get_sys_info` usage-pattern from [`bootrom.h`](https://github.com/raspberrypi/pico-sdk/blob/develop/src/rp2_common/pico_bootrom/include/pico/bootrom.h#L1122).
RP2350 Datasheet says "You should always check (the first word in the returned buffer) before interpreting the buffer.", so do that too.
Also some small unique_id tidy-ups.