### PR TITLE
pico_lwip: restore lwip_context on re-init

### DIFF
--- a/src/rp2_common/pico_lwip/lwip_freertos.c
+++ b/src/rp2_common/pico_lwip/lwip_freertos.c
@@ -26,9 +26,9 @@ static void tcpip_init_done(void *param) {
 
 bool lwip_freertos_init(async_context_t *context) {
     assert(!lwip_context || lwip_context == context);
+    lwip_context = context;
     static bool done_lwip_init;
     if (!done_lwip_init) {
-        lwip_context = context;
         done_lwip_init = true;
         SemaphoreHandle_t init_sem = xSemaphoreCreateBinary();
         tcpip_task_blocker = xSemaphoreCreateBinary();


### PR DESCRIPTION
lwip_freertos_deinit() clears lwip_context, but lwip_freertos_init() only assigns it inside the !done_lwip_init branch. After deinit/re-init it stays NULL and pico_lwip_custom_lock_tcpip_core() blocks forever — while the async_context worker holds the async_context lock, deadlocking the stack.

Fixes #3096 
