### PR TITLE
[Bazel] Fix USB dependencies, __init__.py creation

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -6,8 +6,8 @@ package(default_visibility = ["//visibility:public"])
 py_binary(
     name = "generate_version_header",
     srcs = ["generate_version_header.py"],
-    visibility = ["//:__subpackages__"],
     legacy_create_init = False,
+    visibility = ["//:__subpackages__"],
 )
 
 # This isn't actually generated, it just uses the same name

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -7,6 +7,7 @@ py_binary(
     name = "generate_version_header",
     srcs = ["generate_version_header.py"],
     visibility = ["//:__subpackages__"],
+    legacy_create_init = False,
 )
 
 # This isn't actually generated, it just uses the same name

--- a/src/rp2040/boot_stage2/BUILD.bazel
+++ b/src/rp2040/boot_stage2/BUILD.bazel
@@ -127,6 +127,7 @@ py_binary(
     name = "pad_checksum_tool",
     srcs = ["pad_checksum_tool.py"],
     target_compatible_with = ["//bazel/constraint:host"],
+    legacy_create_init = False,
 )
 
 run_binary(

--- a/src/rp2040/boot_stage2/BUILD.bazel
+++ b/src/rp2040/boot_stage2/BUILD.bazel
@@ -126,8 +126,8 @@ copy_file(
 py_binary(
     name = "pad_checksum_tool",
     srcs = ["pad_checksum_tool.py"],
-    target_compatible_with = ["//bazel/constraint:host"],
     legacy_create_init = False,
+    target_compatible_with = ["//bazel/constraint:host"],
 )
 
 run_binary(

--- a/src/rp2350/boot_stage2/BUILD.bazel
+++ b/src/rp2350/boot_stage2/BUILD.bazel
@@ -126,8 +126,8 @@ copy_file(
 py_binary(
     name = "pad_tool",
     srcs = ["pad_tool.py"],
-    target_compatible_with = ["//bazel/constraint:host"],
     legacy_create_init = False,
+    target_compatible_with = ["//bazel/constraint:host"],
 )
 
 run_binary(

--- a/src/rp2350/boot_stage2/BUILD.bazel
+++ b/src/rp2350/boot_stage2/BUILD.bazel
@@ -127,6 +127,7 @@ py_binary(
     name = "pad_tool",
     srcs = ["pad_tool.py"],
     target_compatible_with = ["//bazel/constraint:host"],
+    legacy_create_init = False,
 )
 
 run_binary(

--- a/src/rp2_common/pico_btstack/btstack.BUILD
+++ b/src/rp2_common/pico_btstack/btstack.BUILD
@@ -327,4 +327,5 @@ py_binary(
     ],
     # TODO: Add pip pins.
     # deps = ["@python_packages//pycryptodomex"]
+    legacy_create_init = False,
 )

--- a/src/rp2_common/pico_stdio_usb/BUILD.bazel
+++ b/src/rp2_common/pico_stdio_usb/BUILD.bazel
@@ -73,7 +73,7 @@ cc_library(
         "//src/rp2_common/hardware_irq",
         "//src/rp2_common/pico_stdio:pico_stdio_headers",
         "//src/rp2_common/pico_unique_id",
-        "//src/rp2_common/pico_usb_reset_interface",
+        "//src/rp2_common/pico_usb_reset",
     ],
     # Ensure `stdio_usb_descriptors.c` isn't affected by link order.
     alwayslink = True,


### PR DESCRIPTION
The 2.3.0 release seems to depend on nonexistent target for the USB reset library. A la https://github.com/raspberrypi/picotool/pull/351, new `rules_py` warnings spam about the `py_binary` usage in the repo; these changes silence the warning.

I didn't make an issue, sorry for the hygiene.
