### PR TITLE
Add powman_timer_set_1khz_tick_source_default function

### DIFF
--- a/src/rp2_common/hardware_powman/include/hardware/powman.h
+++ b/src/rp2_common/hardware_powman/include/hardware/powman.h
@@ -81,7 +81,7 @@ void powman_timer_set_1khz_tick_source_xosc(void);
  */
 void powman_timer_set_1khz_tick_source_xosc_with_hz(uint32_t xosc_freq_hz);
 
-inline void powman_timer_set_1khz_tick_source_default(void) {
+static inline void powman_timer_set_1khz_tick_source_default(void) {
 #if PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC + PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC != 1
     #error Exactly one of PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC and PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC must be specified
 #endif

--- a/src/rp2_common/hardware_powman/include/hardware/powman.h
+++ b/src/rp2_common/hardware_powman/include/hardware/powman.h
@@ -32,6 +32,16 @@ extern "C" {
 #define PICO_POWMAN_CALIBRATE_LPOSC_FROM_OTP 1
 #endif
 
+// PICO_CONFIG: PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC, Use the XOSC by default for the powman tick source, type=bool, default=1, group=hardware_powman
+#ifndef PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC
+#define PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC 1
+#endif
+
+// PICO_CONFIG: PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC, Use the LPOSC by default for the powman tick source, type=bool, default=!PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC, group=hardware_powman
+#ifndef PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC
+#define PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC !PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC
+#endif
+
 /*! \brief Get the calibrated frequency of the low power oscillator
  *  \ingroup hardware_powman
  *
@@ -70,6 +80,21 @@ void powman_timer_set_1khz_tick_source_xosc(void);
  *  \param xosc_freq_hz specify a crystal frequency
  */
 void powman_timer_set_1khz_tick_source_xosc_with_hz(uint32_t xosc_freq_hz);
+
+inline void powman_timer_set_1khz_tick_source_default(void) {
+#if PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC + PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC != 1
+    #error Exactly one of PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC and PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC must be specified
+#endif
+
+#if PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC
+    powman_timer_set_1khz_tick_source_xosc();
+#elif PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC
+    powman_timer_set_1khz_tick_source_lposc();
+#else
+    // should be caught by the #error above, but panic anyway
+    panic("Exactly one of PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC and PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC must be specified to call powman_timer_set_1khz_tick_source_default")
+#endif
+}
 
 /*! \brief Use a 1KHz external tick as the powman timer source
  *  \ingroup hardware_powman

--- a/src/rp2_common/pico_aon_timer/aon_timer.c
+++ b/src/rp2_common/pico_aon_timer/aon_timer.c
@@ -196,8 +196,7 @@ bool aon_timer_start(const struct timespec *ts) {
     rtc_init();
     return aon_timer_set_time(ts);
 #elif HAS_POWMAN_TIMER
-    // todo how best to allow different configurations; this should just be the default
-    powman_timer_set_1khz_tick_source_xosc();
+    powman_timer_set_1khz_tick_source_default();
     bool ok = aon_timer_set_time(ts);
     if (ok) {
         powman_timer_set_ms(timespec_to_ms(ts));
@@ -214,8 +213,7 @@ bool aon_timer_start_calendar(const struct tm *tm) {
     rtc_init();
     return aon_timer_set_time_calendar(tm);
 #elif HAS_POWMAN_TIMER
-    // todo how best to allow different configurations; this should just be the default
-    powman_timer_set_1khz_tick_source_xosc();
+    powman_timer_set_1khz_tick_source_default();
     bool ok = aon_timer_set_time_calendar(tm);
     if (ok) {
         powman_timer_start();

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -621,7 +621,8 @@ int low_power_dormant_until_aon_timer(absolute_time_t until,
 
 #if PICO_RP2350
     if (dormant_clock_source == DORMANT_CLOCK_SOURCE_LPOSC)
-        powman_timer_set_1khz_tick_source_xosc();
+        // Switch powman timer back to default
+        powman_timer_set_1khz_tick_source_default();
 #endif
 
     return 0;
@@ -804,8 +805,8 @@ void __weak runtime_init_low_power_reboot_check(void) {
         powman_hw->scratch[6] = 0;
         powman_hw->scratch[7] = 0;
 
-        // Switch powman timer back to xosc
-        powman_timer_set_1khz_tick_source_xosc();
+        // Switch powman timer back to default
+        powman_timer_set_1khz_tick_source_default();
     } else {
         // not a powman reboot, so clear persistent data
         reset_persistent_data();


### PR DESCRIPTION
Adds `powman_timer_set_1khz_tick_source_default` function to be used instead of `powman_timer_set_1khz_tick_source_xosc` inside the SDK, to support users turning off the XOSC

Adds `PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC` and `PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC` defines to toggle the behaviour of the function

Default `PICO_POWMAN_DEFAULT_TICK_SOURCE_LPOSC` to `!PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC` for simplicity, so you can just set `PICO_POWMAN_DEFAULT_TICK_SOURCE_XOSC=0` to use the LPOSC, but keeping separate defines in case extra default tick sources are added in future