### PR TITLE
Add pico_clib_interface_test

### DIFF
--- a/cmake/preload/toolchains/util/pico_arm_clang_common.cmake
+++ b/cmake/preload/toolchains/util/pico_arm_clang_common.cmake
@@ -105,3 +105,8 @@ else()
     endif()
 endif()
 include(${CMAKE_CURRENT_LIST_DIR}/set_flags.cmake)
+
+# Fix for https://github.com/raspberrypi/pico-sdk/issues/3112
+#foreach(LANG IN ITEMS C CXX)
+#    set(CMAKE_${LANG}_FLAGS_INIT "${CMAKE_${LANG}_FLAGS_INIT} -ftls-model=local-exec")
+#endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ if (PICO_ON_DEVICE)
     add_subdirectory(pico_low_power_test)
     add_subdirectory(pico_async_context_test)
     add_subdirectory(pico_thread_local_test)
+    add_subdirectory(pico_clib_interface_test)
 endif()
 
 # PICO_TEST_FILE_GENERATOR: Path to the a CMake script to generate test files for ci

--- a/test/pico_clib_interface_test/CMakeLists.txt
+++ b/test/pico_clib_interface_test/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(tls_repro
+    tls_repro.c
+    )
+target_link_libraries(tls_repro
+    pico_stdlib
+    )

--- a/test/pico_clib_interface_test/tls_repro.c
+++ b/test/pico_clib_interface_test/tls_repro.c
@@ -1,0 +1,16 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "pico/stdlib.h"
+
+int main(void) {
+    stdio_init_all();
+
+    // Ordinary use of errno. Under picolibc errno is thread-local, so this is a TLS
+    // reference from a translation unit compiled by the SDK.
+    errno = 0;
+    long v = strtol("99999999999999999999", NULL, 10);
+    printf("strtol -> %ld, errno=%d (ERANGE=%d)\n", v, errno, ERANGE);
+
+    return 0;
+}


### PR DESCRIPTION
This is a very simple test that references errno.
A TLS reference from a translation unit compiled by the SDK. With ATfE-22.1.0-Linux-x86_64 it generates a linker error

unable to move location counter (0x20000318) backward to 0x20000314 for section '.tbss_space'

See https://github.com/raspberrypi/pico-sdk/issues/3112
