### PR TITLE
Install pioasm cmake files to CMAKE_INSTALL_LIBDIR

### DIFF
--- a/tools/pioasm/CMakeLists.txt
+++ b/tools/pioasm/CMakeLists.txt
@@ -69,7 +69,7 @@ if (PIOASM_FLAT_INSTALL)
     set(INSTALL_CONFIGDIR pioasm)
     set(INSTALL_BINDIR pioasm)
 else()
-    set(INSTALL_CONFIGDIR lib/cmake/pioasm)
+    set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/pioasm)
     set(INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})
 endif()
 


### PR DESCRIPTION
Fixes #3119.