### PR TITLE
Fix linker script comment about placing memcpy in RAM

### DIFF
--- a/src/rp2_common/pico_standard_link/script_include/section_default_text.incl
+++ b/src/rp2_common/pico_standard_link/script_include/section_default_text.incl
@@ -31,9 +31,8 @@ SECTIONS
         KEEP (*(.embedded_block))
         __embedded_block_end = .;
         KEEP (*(.reset))
-        /* TODO revisit this now memset/memcpy/float in ROM */
-        /* bit of a hack right now to exclude all floating point and time critical (e.g. memset, memcpy) code from
-         * FLASH ... we will include any thing excluded here in .data below by default */
+        /* bit of a hack right now to exclude all floating point code from FLASH
+         * ... we will include any thing excluded here in .data below by default */
         *(.init)
         *libgcc.a:cmse_nonsecure_call.o
         INCLUDE "default_text_excludes.incl"


### PR DESCRIPTION
Follow up to #3075 fix the comment, as requested in https://github.com/raspberrypi/pico-sdk/pull/3075#issuecomment-5096419675 - now the only things excluded are `*libgcc.a:` and `*libm.a:`, both of which have been unchanged since the SDK 1.0.0 release https://github.com/raspberrypi/pico-sdk/blob/26653ea81e340cacee55025d110c3e014a252a87/src/rp2_common/pico_standard_link/memmap_default.ld#L72