### PR TITLE
Pass -mstrict-align to Risc-V builds by default

### DIFF
--- a/cmake/preload/toolchains/pico_riscv_gcc.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc.cmake
@@ -4,14 +4,14 @@ set(PICO_DEFAULT_GCC_TRIPLE riscv32-pico-elf riscv32-unknown-elf riscv32-corev-e
 
 # PICO_CMAKE_CONFIG: PICO_NO_STRICT_ALIGN, Disable -mstrict-align for Risc-V, type=bool, default=0, group=build, docref=cmake-toolchain-config
 if (NOT PICO_NO_STRICT_ALIGN)
-    set(PICO_COMMON_LANG_FLAGS_EXTRA "${PICO_COMMON_LANG_FLAGS_EXTRA} -mstrict-align")
+    set(PICO_RISCV_LANG_FLAGS_EXTRA "${PICO_RISCV_LANG_FLAGS_EXTRA} -mstrict-align")
 endif()
 
 # ordered list of preferred flags to support
 set(PICO_COMMON_LANG_FLAGS_LIST
-        " -mcpu=hazard3-rp2350"
-        " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32"
-        " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32")
+        " -mcpu=hazard3-rp2350 ${PICO_RISCV_LANG_FLAGS_EXTRA}"
+        " -march=rv32ima_zicsr_zifencei_zba_zbb_zbs_zbkb_zca_zcb_zcmp -mabi=ilp32 ${PICO_RISCV_LANG_FLAGS_EXTRA}"
+        " -march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32 ${PICO_RISCV_LANG_FLAGS_EXTRA}")
 
 # C file used to test the flags listed above. There needs to be an equal number
 # of entries in PICO_COMMON_LANG_FLAGS_LIST and PICO_COMMON_LANG_FLAGS_TEST_FILES.

--- a/cmake/preload/toolchains/pico_riscv_gcc.cmake
+++ b/cmake/preload/toolchains/pico_riscv_gcc.cmake
@@ -2,6 +2,11 @@ set(CMAKE_SYSTEM_PROCESSOR hazard3)
 
 set(PICO_DEFAULT_GCC_TRIPLE riscv32-pico-elf riscv32-unknown-elf riscv32-corev-elf riscv-none-elf)
 
+# PICO_CMAKE_CONFIG: PICO_NO_STRICT_ALIGN, Disable -mstrict-align for Risc-V, type=bool, default=0, group=build, docref=cmake-toolchain-config
+if (NOT PICO_NO_STRICT_ALIGN)
+    set(PICO_COMMON_LANG_FLAGS_EXTRA "${PICO_COMMON_LANG_FLAGS_EXTRA} -mstrict-align")
+endif()
+
 # ordered list of preferred flags to support
 set(PICO_COMMON_LANG_FLAGS_LIST
         " -mcpu=hazard3-rp2350"

--- a/cmake/preload/toolchains/util/pico_gcc_common.cmake
+++ b/cmake/preload/toolchains/util/pico_gcc_common.cmake
@@ -24,10 +24,6 @@ set(ENV{_SAVED_PICO_GCC_TRIPLE} "${PICO_GCC_TRIPLE}")
 # Find GCC
 pico_find_compiler_with_triples(PICO_COMPILER_CC "${PICO_GCC_TRIPLE}" gcc)
 pico_choose_compiler_flags(${PICO_COMPILER_CC} PICO_COMMON_LANG_FLAGS PICO_COMMON_LANG_FLAGS_LIST PICO_COMMON_LANG_FLAGS_TEST_FILES)
-if (${PICO_COMMON_LANG_FLAGS_EXTRA})
-    # Extra flags to be added after pico_choose_compiler_flags
-    set(PICO_COMMON_LANG_FLAGS "${PICO_COMMON_LANG_FLAGS} ${PICO_COMMON_LANG_FLAGS_EXTRA}")
-endif()
 pico_find_compiler_with_triples(PICO_COMPILER_CXX "${PICO_GCC_TRIPLE}" g++)
 set(PICO_COMPILER_ASM "${PICO_COMPILER_CC}" CACHE INTERNAL "")
 pico_find_compiler_with_triples(PICO_OBJCOPY "${PICO_GCC_TRIPLE}" objcopy)

--- a/cmake/preload/toolchains/util/pico_gcc_common.cmake
+++ b/cmake/preload/toolchains/util/pico_gcc_common.cmake
@@ -24,6 +24,10 @@ set(ENV{_SAVED_PICO_GCC_TRIPLE} "${PICO_GCC_TRIPLE}")
 # Find GCC
 pico_find_compiler_with_triples(PICO_COMPILER_CC "${PICO_GCC_TRIPLE}" gcc)
 pico_choose_compiler_flags(${PICO_COMPILER_CC} PICO_COMMON_LANG_FLAGS PICO_COMMON_LANG_FLAGS_LIST PICO_COMMON_LANG_FLAGS_TEST_FILES)
+if (${PICO_COMMON_LANG_FLAGS_EXTRA})
+    # Extra flags to be added after pico_choose_compiler_flags
+    set(PICO_COMMON_LANG_FLAGS "${PICO_COMMON_LANG_FLAGS} ${PICO_COMMON_LANG_FLAGS_EXTRA}")
+endif()
 pico_find_compiler_with_triples(PICO_COMPILER_CXX "${PICO_GCC_TRIPLE}" g++)
 set(PICO_COMPILER_ASM "${PICO_COMPILER_CC}" CACHE INTERNAL "")
 pico_find_compiler_with_triples(PICO_OBJCOPY "${PICO_GCC_TRIPLE}" objcopy)


### PR DESCRIPTION
GCC shouldn't generate misaligned code anyway, as it is marked as slow by the default tune, but add this to ensure __riscv_misaligned_avoid is set in builds as well

Adds new PICO_COMMON_LANG_FLAGS_EXTRA which can be used to append extra flags after pico_choose_compiler_flags chooses from PICO_COMMON_LANG_FLAGS_LIST
