### PR TITLE
riscv: restore sp correctly in __unhandled_exception

### DIFF
--- a/src/rp2_common/hardware_exception/exception_table_riscv.S
+++ b/src/rp2_common/hardware_exception/exception_table_riscv.S
@@ -117,7 +117,7 @@ __unhandled_exception:
     // Restore original registers and stack pointer so debugger can backtrace
     csrr ra, mscratch
     lw t6, 60(sp)
-    addi sp, sp, -64
+    addi sp, sp, 64
     // Second symbol here just to make it clearer in the debugger why you got
     // here; the entry point can appear labelled with the name of any one of the
     // unhandled exceptions, which is less clear.


### PR DESCRIPTION
The exception prologue does `addi sp, sp, -64` before saving registers, and the normal return path undoes it with `addi sp, sp, 64`. __unhandled_exception instead applied -64 a second time, leaving sp 128 bytes below the foreground stack pointer rather than restored.

That defeats the stated purpose of the surrounding instructions ("Restore original registers and stack pointer so debugger can backtrace"). Taking a misaligned load four frames deep and halting the core, gdb gives:

Fixes #3137
