### PR TITLE
pico_ubsan: report undefined behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ if (NOT TARGET _pico_sdk_inclusion_marker)
     add_subdirectory(tools)
     add_subdirectory(src)
 
+    # after src, so the pico_ubsan target exists
+    pico_apply_ubsan_options()
+
     # allow customization
     add_sub_list_dirs(PICO_SDK_POST_LIST_DIRS)
     add_sub_list_files(PICO_SDK_POST_LIST_FILES)

--- a/pico_sdk_init.cmake
+++ b/pico_sdk_init.cmake
@@ -46,6 +46,41 @@ if (NOT TARGET _pico_sdk_pre_init_marker)
             message(WARNING "pico_sdk_init() should be called after the project is created (and languages added)")
         endif()
         add_subdirectory(${PICO_SDK_PATH} pico-sdk)
+
+        pico_apply_ubsan_options()
+    endmacro()
+
+    # PICO_CMAKE_CONFIG: PICO_UBSAN_ALIGNMENT_CHECKS, Check every load and store for correct alignment at runtime, type=bool, default=0, group=build
+    # PICO_CMAKE_CONFIG: PICO_UBSAN_NULL_CHECKS, Check every load and store for a null pointer at runtime, type=bool, default=0, group=build
+    # PICO_CMAKE_CONFIG: PICO_UBSAN_RECOVER, Report and continue rather than panicking on the first failure, type=bool, default=0, group=build
+    macro(pico_apply_ubsan_options)
+        set(_pico_ubsan_checks "")
+        if (PICO_UBSAN_ALIGNMENT_CHECKS)
+            list(APPEND _pico_ubsan_checks alignment)
+        endif()
+        if (PICO_UBSAN_NULL_CHECKS)
+            list(APPEND _pico_ubsan_checks null)
+        endif()
+        if (_pico_ubsan_checks)
+            # Refuse to apply checks in release builds
+            if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+                message(FATAL_ERROR "UBSan checks are not supported with"
+                        " CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}: Use CMAKE_BUILD_TYPE=Debug, or"
+                        " drop PICO_UBSAN_ALIGNMENT_CHECKS/PICO_UBSAN_NULL_CHECKS.")
+            endif()
+            list(JOIN _pico_ubsan_checks "," _pico_ubsan_list)
+            get_property(_pico_ubsan_announced GLOBAL PROPERTY PICO_UBSAN_ANNOUNCED)
+            if (NOT _pico_ubsan_announced)
+                message("Enabling UBSan checks: ${_pico_ubsan_list}")
+                set_property(GLOBAL PROPERTY PICO_UBSAN_ANNOUNCED 1)
+            endif()
+            add_compile_options(-fsanitize=${_pico_ubsan_list})
+            if (NOT PICO_UBSAN_RECOVER)
+                # Picks the _abort handlers, which panic
+                add_compile_options(-fno-sanitize-recover=${_pico_ubsan_list})
+            endif()
+            link_libraries(pico_ubsan)
+        endif()
     endmacro()
 
     macro(add_sub_list_dirs var)

--- a/src/cmake/rp2_common.cmake
+++ b/src/cmake/rp2_common.cmake
@@ -119,6 +119,7 @@ if (NOT PICO_BARE_METAL)
     pico_add_subdirectory(rp2_common/pico_stdio_semihosting)
     pico_add_subdirectory(rp2_common/pico_stdio_uart)
     pico_add_subdirectory(rp2_common/pico_stdio_rtt)
+    pico_add_subdirectory(rp2_common/pico_ubsan)
 
     if (NOT PICO_RISCV)
          pico_add_subdirectory(rp2_common/cmsis)

--- a/src/rp2_common/pico_ubsan/CMakeLists.txt
+++ b/src/rp2_common/pico_ubsan/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (NOT TARGET pico_ubsan)
+    pico_add_library(pico_ubsan)
+
+    target_sources(pico_ubsan INTERFACE
+            ${CMAKE_CURRENT_LIST_DIR}/ubsan.c
+    )
+
+    pico_mirrored_target_link_libraries(pico_ubsan INTERFACE pico_platform_panic)
+endif()

--- a/src/rp2_common/pico_ubsan/ubsan.c
+++ b/src/rp2_common/pico_ubsan/ubsan.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Handlers for the subset of UndefinedBehaviorSanitizer enabled by
+// PICO_UBSAN_ALIGNMENT_CHECKS and PICO_UBSAN_NULL_CHECKS.
+//
+// The structure layouts below are the UBSan ABI
+
+#include <stdint.h>
+#include <stdio.h>
+#include "pico.h"
+#include "pico/platform/panic.h"
+
+// These functions must not be instrumented themselves: a check firing inside a
+// handler would call the handler again
+#define PICO_UBSAN_HANDLER __attribute__((no_sanitize("undefined")))
+
+struct source_location {
+    const char *file_name;
+    uint32_t line;
+    uint32_t column;
+};
+
+struct type_descriptor {
+    uint16_t type_kind;
+    uint16_t type_info;
+    char type_name[1];
+};
+
+struct type_mismatch_data_v1 {
+    struct source_location loc;
+    const struct type_descriptor *type;
+    unsigned char log_alignment;
+    unsigned char type_check_kind;
+};
+
+// type_check_kind values we can usefully distinguish
+#define TYPE_CHECK_KIND_LOAD    0
+#define TYPE_CHECK_KIND_STORE   1
+
+// UBSan calls one of two entry points depending on whether the check was
+// compiled as recoverable.
+//
+//   __ubsan_handle_type_mismatch_v1        must return; the program then goes
+//                                          ahead and performs the access
+//   __ubsan_handle_type_mismatch_v1_abort  must not return
+
+// PICO_CONFIG: PICO_UBSAN_MAX_REPORTS, Maximum number of reports the recoverable UBSan handler will print before falling silent, min=1, default=20, group=pico_ubsan
+#ifndef PICO_UBSAN_MAX_REPORTS
+#define PICO_UBSAN_MAX_REPORTS 20
+#endif
+
+static unsigned reports;
+
+struct mismatch {
+    const char *file;
+    unsigned line;
+    const char *type_name;
+    const char *op;
+    uintptr_t ptr;
+    unsigned alignment;
+};
+
+PICO_UBSAN_HANDLER static struct mismatch describe(void *_data, void *_ptr) {
+    struct type_mismatch_data_v1 *data = _data;
+    // Report just the file name; with the line number
+    const char *file = data->loc.file_name;
+    for (const char *s = file; *s; s++) {
+        if (*s == '/' || *s == '\\') {
+            file = s + 1;
+        }
+    }
+    struct mismatch m = {
+        .file = file,
+        .line = (unsigned)data->loc.line,
+        .type_name = data->type->type_name,
+        .op = data->type_check_kind == TYPE_CHECK_KIND_STORE ? "store" : "load",
+        .ptr = (uintptr_t)_ptr,
+        .alignment = 1u << data->log_alignment,
+    };
+    return m;
+}
+
+// Recoverable: report and return. Execution then performs the access anyway,
+// which on Arm succeeds, and on RP2350's RISC-V core will fault
+void __ubsan_handle_type_mismatch_v1(void *data, void *ptr);
+PICO_UBSAN_HANDLER void __ubsan_handle_type_mismatch_v1(void *data, void *ptr) {
+    if (++reports > PICO_UBSAN_MAX_REPORTS) {
+        if (reports == PICO_UBSAN_MAX_REPORTS + 1) {
+            printf("ubsan: further reports suppressed\n");
+        }
+        return;
+    }
+    struct mismatch m = describe(data, ptr);
+    if (!m.ptr) {
+        printf("ubsan: %s:%u null pointer access to %s\n", m.file, m.line, m.type_name);
+    } else {
+        printf("ubsan: %s:%u misaligned %s of %s at %p (needs %u)\n",
+               m.file, m.line, m.op, m.type_name, (void *)m.ptr, m.alignment);
+    }
+}
+
+// Non-recoverable, emitted under -fno-sanitize-recover. It does not return
+void __ubsan_handle_type_mismatch_v1_abort(void *data, void *ptr);
+PICO_UBSAN_HANDLER void __ubsan_handle_type_mismatch_v1_abort(void *data, void *ptr) {
+    struct mismatch m = describe(data, ptr);
+    // Break for clang which discards the return address as panic is noreturn
+    __breakpoint();
+    if (!m.ptr) {
+        panic("ubsan: %s:%u null pointer access to %s", m.file, m.line, m.type_name);
+    }
+    panic("ubsan: %s:%u misaligned %s of %s at %p (needs %u)",
+          m.file, m.line, m.op, m.type_name, (void *)m.ptr, m.alignment);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ if (PICO_ON_DEVICE)
     add_subdirectory(pico_async_context_test)
     add_subdirectory(pico_thread_local_test)
     add_subdirectory(pio_encoding_test)
+    add_subdirectory(pico_ubsan_test)
 endif()
 
 # PICO_TEST_FILE_GENERATOR: Path to the a CMake script to generate test files for ci

--- a/test/pico_ubsan_test/CMakeLists.txt
+++ b/test/pico_ubsan_test/CMakeLists.txt
@@ -1,0 +1,62 @@
+# These tests are only meaningful when the corresponding check is enabled
+if (PICO_UBSAN_ALIGNMENT_CHECKS)
+    add_executable(pico_ubsan_align_test
+            pico_ubsan_align_test.c
+            )
+
+    target_link_libraries(pico_ubsan_align_test pico_stdlib)
+
+    # The point of the test: this file contains a misaligned access and still
+    # builds clean under the same warnings kitchen_sink uses, because the
+    # pointer is laundered through void *. Only the runtime check finds it.
+    target_compile_options(pico_ubsan_align_test PRIVATE
+            -Wall
+            -Wextra
+            -Wcast-align
+            -Werror
+            )
+
+    # The panic is the pass condition, so tell ci what success looks like.
+    set_target_properties(pico_ubsan_align_test PROPERTIES
+            PICO_TEST_SUCCESS_STRING "misaligned load"
+            PICO_TEST_FAILURE_STRING "FAILED"
+            )
+
+    # so the test can tell whether reaching the end is expected
+    target_compile_definitions(pico_ubsan_align_test PRIVATE
+            PICO_UBSAN_RECOVER=$<BOOL:${PICO_UBSAN_RECOVER}>
+            )
+
+    pico_add_extra_outputs(pico_ubsan_align_test)
+else()
+    message("Skipping pico_ubsan_align_test as PICO_UBSAN_ALIGNMENT_CHECKS is not set")
+endif()
+
+if (PICO_UBSAN_NULL_CHECKS)
+    add_executable(pico_ubsan_null_test
+            pico_ubsan_null_test.c
+            )
+
+    target_link_libraries(pico_ubsan_null_test pico_stdlib)
+
+    target_compile_options(pico_ubsan_null_test PRIVATE
+            -Wall
+            -Wextra
+            -Werror
+            )
+
+    # The panic is the pass condition, so tell ci what success looks like.
+    set_target_properties(pico_ubsan_null_test PROPERTIES
+            PICO_TEST_SUCCESS_STRING "null pointer access"
+            PICO_TEST_FAILURE_STRING "FAILED"
+            )
+
+    # so the test can tell whether reaching the end is expected
+    target_compile_definitions(pico_ubsan_null_test PRIVATE
+            PICO_UBSAN_RECOVER=$<BOOL:${PICO_UBSAN_RECOVER}>
+            )
+
+    pico_add_extra_outputs(pico_ubsan_null_test)
+else()
+    message("Skipping pico_ubsan_null_test as PICO_UBSAN_NULL_CHECKS is not set")
+endif()

--- a/test/pico_ubsan_test/pico_ubsan_align_test.c
+++ b/test/pico_ubsan_test/pico_ubsan_align_test.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Checks that PICO_UBSAN_ALIGNMENT_CHECKS catches a misaligned access that
+// the compiler's static checks cannot see.
+//
+// RP2350's RISC-V cores fault on any misaligned load or store, where the Arm
+// cores handle it in hardware. An unaligned access therefore hangs on RISC-V
+// and passes silently on Arm.
+
+#include <stdio.h>
+#include <stdint.h>
+#include "pico/stdlib.h"
+
+static uint8_t buf[16] __attribute__((aligned(4)));
+
+// volatile so the compiler cannot fold the accesses below into constants.
+static volatile int offset;
+static volatile uint32_t sink;
+
+int main(void) {
+    stdio_init_all();
+
+    for (int i = 0; i < 16; i++) {
+        buf[i] = (uint8_t)i;
+    }
+
+    printf("pico_ubsan_align_test\n");
+
+    // A correctly aligned access through the same code path must not trip the
+    // check
+    offset = 4;
+    void *aligned = &buf[offset];
+    sink = *(uint32_t *)aligned;
+    printf("aligned load at offset 4 returned 0x%08x\n", (unsigned)sink);
+
+    // The real test. buf is 4-byte aligned, so offset 1 is not.
+    offset = 1;
+    void *misaligned = &buf[offset];
+    printf("loading 4 bytes from %p -- expecting a ubsan panic now\n", misaligned);
+    sink = *(uint32_t *)misaligned;
+
+#if PICO_UBSAN_RECOVER
+    // The recoverable handler reports and returns. On Arm the access then
+    // succeeds and we reach here; on RISC-V it faults first, so this line is
+    // only expected on Arm.
+    printf("load returned 0x%08x and execution continued, as expected with"
+           " PICO_UBSAN_RECOVER\n", (unsigned)sink);
+#else
+    printf("FAILED: the misaligned load was not detected (returned 0x%08x)\n", (unsigned)sink);
+#endif
+    while (true) {
+        tight_loop_contents();
+    }
+}

--- a/test/pico_ubsan_test/pico_ubsan_null_test.c
+++ b/test/pico_ubsan_test/pico_ubsan_null_test.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Checks that PICO_UBSAN_NULL_CHECKS catches a null pointer read.
+
+#include <stdio.h>
+#include <stdint.h>
+#include "pico/stdlib.h"
+
+static volatile uint32_t value = 0x12345678;
+
+// volatile, so the compiler cannot see that this is null and fold the access
+// away or treat the path as unreachable.
+static uint32_t *volatile ptr;
+
+int main(void) {
+    stdio_init_all();
+    printf("pico_ubsan_null_test\n");
+
+    // A non-null load through the same code path must not trip the check.
+    ptr = (uint32_t *)&value;
+    uint32_t ok = *ptr;
+    printf("non-null load returned 0x%08x\n", (unsigned)ok);
+
+    ptr = NULL;
+    printf("loading through a null pointer -- expecting a ubsan panic now\n");
+    stdio_flush();
+    uint32_t bad = *ptr;
+
+#if PICO_UBSAN_RECOVER
+    // The recoverable handler reports and returns, so getting here is expected.
+    printf("load returned 0x%08x and execution continued, as expected with"
+           " PICO_UBSAN_RECOVER\n", (unsigned)bad);
+#else
+    printf("FAILED: the null load was not detected (returned 0x%08x)\n", (unsigned)bad);
+#endif
+    while (true) {
+        tight_loop_contents();
+    }
+}


### PR DESCRIPTION
The recent RISC-V alignment issue made me wonder if we should have a way to check code for this sort of problem. -fsanitize achives this.

RP2350's RISC-V cores fault on a misaligned load or store where the Arm cores handle it in hardware, so code that works on Arm can hang on RISC-V.

Also reading from address zero is bad as it does not fault, it returns bootrom contents and execution continues.

Add UBSan handlers and two CMake flags to enable the corresponding checks across a build:

PICO_UBSAN_ALIGNMENT_CHECKS
PICO_UBSAN_NULL_CHECKS
PICO_UBSAN_RECOVER - report and continue rather than panicking

Debug only. Costs roughly 10% of code size, so it is a development aid, off by default.

