### PR TITLE
Add support for configuring XOSC FREQ_RANGE

### DIFF
--- a/src/rp2040/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2040/hardware_regs/include/hardware/platform_defs.h
@@ -56,7 +56,7 @@
 #define FPGA_CLK_REF_HZ (12 * MHZ)
 #endif
 
-// PICO_CONFIG: XOSC_HZ, Crystal oscillator frequency in Hz, type=int, default=12000000, advanced=true, group=hardware_base
+// PICO_CONFIG: XOSC_HZ, Crystal oscillator frequency in Hz, type=int, min=1000000, max=50000000, default=12000000, advanced=true, group=hardware_base
 // NOTE:  The system and USB clocks are generated from the frequency using two PLLs.
 // If you override this define, or SYS_CLK_HZ/USB_CLK_HZ below, you will *also* need to add your own adjusted PLL set-up defines to
 // override the defaults which live in src/rp2_common/hardware_clocks/include/hardware/clocks.h

--- a/src/rp2350/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2350/hardware_regs/include/hardware/platform_defs.h
@@ -93,7 +93,7 @@
 #define LPOSC_MAX_EXPECTED_HZ _u(40000)
 #endif
 
-// PICO_CONFIG: XOSC_HZ, Crystal oscillator frequency in Hz, type=int, default=12000000, advanced=true, group=hardware_base
+// PICO_CONFIG: XOSC_HZ, Crystal oscillator frequency in Hz, type=int, min=1000000, max=50000000, default=12000000, advanced=true, group=hardware_base
 // NOTE:  The system and USB clocks are generated from the frequency using two PLLs.
 // If you override this define, or SYS_CLK_HZ/USB_CLK_HZ below, you will *also* need to add your own adjusted PLL set-up defines to
 // override the defaults which live in src/rp2_common/hardware_clocks/include/hardware/clocks.h

--- a/src/rp2_common/hardware_xosc/include/hardware/xosc.h
+++ b/src/rp2_common/hardware_xosc/include/hardware/xosc.h
@@ -10,6 +10,9 @@
 #include "pico.h"
 #include "hardware/structs/xosc.h"
 
+// For frequency related definitions etc
+#include "hardware/clocks.h"
+
 
 // Allow lengthening startup delay to accommodate slow-starting oscillators
 
@@ -18,12 +21,12 @@
 #define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 6
 #endif
 
-// PICO_CONFIG: PICO_XOSC_FREQ_RANGE_MAX, The maximum frequency in MHz for the XOSC to support (not required when using CMOS clock input instead of XOSC) - defining this variable is not supported on RP2040 as it only has one range, type=int, min=1, max=100, default=XOSC_HZ/1000000, group=hardware_xosc
+// PICO_CONFIG: PICO_XOSC_FREQ_RANGE_MAX, The maximum frequency in MHz for the XOSC to support (not required when using CMOS clock input instead of XOSC) - defining this variable is not supported on RP2040 as it only has one range, type=int, min=1, max=100, default=XOSC_HZ/MHZ, group=hardware_xosc
 #if PICO_RP2040
 #define PICO_XOSC_FREQ_RANGE_MAX 15
 #else
 #ifndef PICO_XOSC_FREQ_RANGE_MAX
-#define PICO_XOSC_FREQ_RANGE_MAX (XOSC_HZ / 1000000)
+#define PICO_XOSC_FREQ_RANGE_MAX (XOSC_HZ / MHZ)
 #endif
 #endif
 

--- a/src/rp2_common/hardware_xosc/include/hardware/xosc.h
+++ b/src/rp2_common/hardware_xosc/include/hardware/xosc.h
@@ -18,6 +18,15 @@
 #define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 6
 #endif
 
+// PICO_CONFIG: PICO_XOSC_FREQ_RANGE_MAX, The maximum frequency in MHz for the XOSC to support (not required when using CMOS clock input instead of XOSC) - defining this variable is not supported on RP2040 as it only has one range, type=int, min=1, max=100, default=XOSC_HZ/1000000, group=hardware_xosc
+#if PICO_RP2040
+#define PICO_XOSC_FREQ_RANGE_MAX 15
+#else
+#ifndef PICO_XOSC_FREQ_RANGE_MAX
+#define PICO_XOSC_FREQ_RANGE_MAX (XOSC_HZ / 1000000)
+#endif
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/rp2_common/hardware_xosc/xosc.c
+++ b/src/rp2_common/hardware_xosc/xosc.c
@@ -27,8 +27,17 @@
 #endif
 
 void xosc_init(void) {
-    // Assumes 1-15 MHz input, checked above.
+#if PICO_RP2040 || PICO_XOSC_FREQ_RANGE_MAX <= 15 // RP2040 only has this range
     xosc_hw->ctrl = XOSC_CTRL_FREQ_RANGE_VALUE_1_15MHZ;
+#elif PICO_XOSC_FREQ_RANGE_MAX <= 30
+    xosc_hw->ctrl = XOSC_CTRL_FREQ_RANGE_VALUE_10_30MHZ;
+#elif PICO_XOSC_FREQ_RANGE_MAX <= 60
+    xosc_hw->ctrl = XOSC_CTRL_FREQ_RANGE_VALUE_25_60MHZ;
+#elif PICO_XOSC_FREQ_RANGE_MAX <= 100
+    xosc_hw->ctrl = XOSC_CTRL_FREQ_RANGE_VALUE_40_100MHZ;
+#else
+    #error PICO_XOSC_FREQ_RANGE_MAX is too large, maximum is 100
+#endif
 
     // Set xosc startup delay
     xosc_hw->startup = STARTUP_DELAY;


### PR DESCRIPTION
Add PICO_XOSC_FREQ_RANGE_MAX config for non-RP2040 chips - defaults to XOSC_HZ / 1000000, but can be configured higher (e.g. to select the 40-100MHz range for a 50MHz crystal)

RP2040 only has one range, so this config is not defined for RP2040, as CMOS clock inputs >15MHz are still supported despite being out of the XOSC FREQ_RANGE value

Fixes #3074