### PR TITLE
Return from pico_unaligned_string_test

### DIFF
--- a/test/pico_unaligned_string_test/pico_unaligned_string_test.c
+++ b/test/pico_unaligned_string_test/pico_unaligned_string_test.c
@@ -286,7 +286,5 @@ int main(void) {
         printf("all functions handled every alignment correctly\n");
         printf("PASSED\n");
     }
-    while (true) {
-        tight_loop_contents();
-    }
+    return 0;
 }


### PR DESCRIPTION
All tests should end with the normal exit (which is a breakpoint) for the CI to work correctly, but this ended in an infinite loop instead so failed CI

Fix is to `return 0;` instead