### PR TITLE
Fix pio_encoding_test on RP2040

### DIFF
--- a/test/pio_encoding_test/pio_encoding_test.c
+++ b/test/pio_encoding_test/pio_encoding_test.c
@@ -24,8 +24,8 @@ int main() {
     PICOTEST_CHECK(0xa0e1 == encodings_program_instructions[encodings_offset_mov_osr_x], "mov osr, x");
     PICOTEST_CHECK(0xa0e1 == pio_encode_mov(pio_osr, pio_x), "pio_encode_mov(pio_osr, pio_x)");
     PICOTEST_CHECK(0xa061 == encodings_program_instructions[encodings_offset_mov_pindirs_x], "mov pindirs, x");
-    PICOTEST_CHECK(0xa061 == pio_encode_mov(pio_pindirs, pio_x), "pio_encode_mov(pio_pindirs, pio_x)");
 #if PICO_PIO_VERSION > 0
+    PICOTEST_CHECK(0xa061 == pio_encode_mov(pio_pindirs, pio_x), "pio_encode_mov(pio_pindirs, pio_x)");
     PICOTEST_CHECK(0xa061 == pio_encode_mov(pio_pindirs_mov, pio_x), "pio_encode_mov(pio_pindirs_mov, pio_x)");
 #endif
     PICOTEST_CHECK(0xa081 == encodings_program_instructions[encodings_offset_mov_exec_x], "mov exec, x");


### PR DESCRIPTION
PIO version 0 does not support `mov pindirs`, so put that inside the `#if` so the test works on RP2040

Decisions about how `pio_encode_mov` etc should behave for PIO version 0 can come separately, but this PR at least fixes the test on RP2040