### PR TITLE
Rename poorly named constants in the lock_core/spin_lock workarounds, and add some more tests

### DIFF
--- a/src/common/pico_sync/include/pico/lock_core.h
+++ b/src/common/pico_sync/include/pico/lock_core.h
@@ -45,7 +45,11 @@
 
 // PICO_CONFIG: PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND, Enable workaround to preserve low power waits in synchronization primitives where an exclusive access sets the calling core's own event, type=bool, default=1 when using software spin locks on such a platform, advanced=true, group=pico_sync
 #ifndef PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
+#ifdef PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
+#define PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
+#else
 #define PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND (PICO_USE_SW_SPIN_LOCKS && PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT)
+#endif
 #endif
 
 /** \file lock_core.h

--- a/src/common/pico_sync/include/pico/lock_core.h
+++ b/src/common/pico_sync/include/pico/lock_core.h
@@ -43,9 +43,9 @@
 #define PARAM_ASSERTIONS_ENABLED_LOCK_CORE 0
 #endif
 
-// PICO_CONFIG: PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND, Enable workaround to preserve low power waits in synchronization primitives on RP2350 when using software spin locks, type=bool, default=1 on RP2350 when using software spin locks, advanced=true, group=pico_sync
-#ifndef PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
-#define PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV
+// PICO_CONFIG: PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND, Enable workaround to preserve low power waits in synchronization primitives where an exclusive access sets the calling core's own event, type=bool, default=1 when using software spin locks on such a platform, advanced=true, group=pico_sync
+#ifndef PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
+#define PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND (PICO_USE_SW_SPIN_LOCKS && PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT)
 #endif
 
 /** \file lock_core.h
@@ -138,7 +138,7 @@ void lock_init(lock_core_t *core, uint lock_num);
  * \param save the uint32_t value that should be passed to spin_unlock when the spin lock is unlocked. (i.e. the `PRIMASK`
  *             state when the spin lock was acquire
  */
-#if !PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
+#if !PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
 #define lock_internal_spin_unlock_with_wait(lock, save) spin_unlock((lock)->spin_lock, save), __wfe()
 #else
 extern volatile uint8_t lock_internal_notify_count;
@@ -198,7 +198,7 @@ extern volatile uint8_t lock_internal_notify_count;
  * \param save the uint32_t value that should be passed to spin_unlock when the spin lock is unlocked. (i.e. the PRIMASK
  *             state when the spin lock was acquire)
  */
-#if !PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
+#if !PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
 #define lock_internal_spin_unlock_with_notify(lock, save) spin_unlock((lock)->spin_lock, save), __sev()
 #else
 // note that spin_lock_blocking() already posts an event to the current core: ldaexb/strex on Arm,
@@ -237,7 +237,7 @@ extern volatile uint8_t lock_internal_notify_count;
  * \param until the \ref absolute_time_t value
  * \return true if the timeout has been reached
  */
-#if !PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
+#if !PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
 #define lock_internal_spin_unlock_with_best_effort_wait_or_timeout(lock, save, until) ({ \
     spin_unlock((lock)->spin_lock, save);                                                \
     best_effort_wfe_or_timeout(until);                                                   \

--- a/src/common/pico_sync/lock_core.c
+++ b/src/common/pico_sync/lock_core.c
@@ -6,7 +6,7 @@
 
 #include "pico/lock_core.h"
 
-#if PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
+#if PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
 // Global rolling counter used to disambiguate ordering of SEV events. See definitions of:
 // lock_internal_spin_unlock_with_wait(), lock_internal_spin_unlock_with_notify().
 //

--- a/src/rp2350/hardware_regs/include/hardware/platform_defs.h
+++ b/src/rp2350/hardware_regs/include/hardware/platform_defs.h
@@ -124,6 +124,10 @@
 #endif
 #endif
 
+// An exclusive access pair leaves the calling core's own event register set, so a following
+// __wfe() does not block. See PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND in pico/lock_core.h.
+#define PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT 1
+
 // PICO_CONFIG: USB_CLK_HZ, USB clock frequency. Must be 48MHz for the USB interface to operate correctly, type=int, default=48000000, advanced=true, group=hardware_base
 #ifndef USB_CLK_HZ
 #ifdef USB_CLK_KHZ

--- a/src/rp2_common/hardware_sync_spin_lock/include/hardware/sync/spin_lock.h
+++ b/src/rp2_common/hardware_sync_spin_lock/include/hardware/sync/spin_lock.h
@@ -143,10 +143,6 @@ typedef SW_SPIN_LOCK_TYPE spin_lock_t;
 #endif
 
 #if PICO_USE_SW_SPIN_LOCKS
-#if PICO_RP2350
-// Indicates that taking and releasing a software spin lock sets the calling core's own event flag,
-#define PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV 1
-#endif
 
 #ifndef SW_SPIN_LOCK_INSTANCE
 #define SW_SPIN_LOCK_INSTANCE(lock_num) ({             \

--- a/test/hardware_sync_spin_lock_test/hardware_sync_spin_lock_test.c
+++ b/test/hardware_sync_spin_lock_test/hardware_sync_spin_lock_test.c
@@ -191,7 +191,13 @@ static const test_t tests[] = {
 };
 
 // ---------------------------------------------------------------------------
-// Verify the PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV setting
+#if PICO_USE_SW_SPIN_LOCKS && PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT
+#define SEV_PROBE_EXPECT_OWN_EVENT 1
+#else
+#define SEV_PROBE_EXPECT_OWN_EVENT 0
+#endif
+
+// Verify the PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT setting
 //
 // Clear the event flag, do a lock/unlock pair, then __wfe() and see whether it returned of its
 // own accord or only once core 1's backstop arrived. A control pass with the lock/unlock
@@ -202,12 +208,8 @@ static const test_t tests[] = {
 // code against the same fabric.
 // ---------------------------------------------------------------------------
 
-#ifndef PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV
-#define PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV 0
-#endif
-
 // long enough that core 0 is certainly parked in its __wfe() before this expires
-static const uint SEV_PROBE_BACKSTOP_CYCLES = 2000000;
+static const uint SEV_PROBE_BACKSTOP_CYCLES = 200000;
 static const uint SEV_PROBE_ROUNDS = 5;
 #define SEV_PROBE_LOCK_NUM 0
 
@@ -251,7 +253,9 @@ static bool sev_probe_run(void) {
 	uint control_blocked = 0;
 	uint probe_blocked = 0;
 	for (uint i = 0; i < SEV_PROBE_ROUNDS; ++i) {
+		printf("  round %u: control...\n", i);
 		control_blocked += sev_probe_wfe_blocked(false);
+		printf("  round %u: probe...\n", i);
 		probe_blocked += sev_probe_wfe_blocked(true);
 	}
 	printf("control (no lock/unlock): blocked %u/%u\n", control_blocked, SEV_PROBE_ROUNDS);
@@ -275,12 +279,117 @@ static bool sev_probe_run(void) {
 	}
 	printf("observed: spin lock lock/unlock %s the calling core's event flag\n",
 		observed ? "DOES set" : "does NOT set");
-	if (observed != (bool)PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV) {
-		printf("Failed: PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV is %d but hardware says %d.\n"
+	if (observed != (bool)SEV_PROBE_EXPECT_OWN_EVENT) {
+		printf("Failed: PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT is %d but hardware says %d.\n"
 			"The lock_core wait/notify primitives in pico/lock_core.h rely on this.\n",
-			PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV, observed);
+			SEV_PROBE_EXPECT_OWN_EVENT, observed);
 		return false;
 	}
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// Remote spin lock traffic probe
+//
+// The probe above asks whether THIS core's own lock/unlock sets its own event. It cannot see
+// the other question the lock_core wait primitives depend on: whether ANOTHER core's ordinary
+// spin lock traffic sets this core's event. If it does, a core sitting in the usual
+// "check condition, WFE" loop is woken by unrelated lock activity elsewhere and cannot stay
+// asleep - and two cores both in wait loops can hold each other awake indefinitely.
+//
+// Measured the same way: core 1 does N lock/unlock pairs on a DIFFERENT lock (so this is about
+// remote traffic, not contention), then flags and SEVs as a backstop. If core 0's __wfe()
+// returns while the flag is still clear, remote traffic woke it.
+//
+// Note core 0 takes and releases a lock of its own before waiting, so this measures the pattern
+// the wait primitives actually use. What comes out is therefore a property of pattern AND
+// hardware together: a negative result means only that remote traffic cannot reach a core that
+// waits this way, not that the part has no cross-core wake path. Where a core's own exclusive
+// store clears its own reservation, it holds none by the time it waits, and the path - which is
+// still there - has nothing to act on.
+//
+// Reported, not asserted: what the right expectation is per platform is exactly what this is
+// here to establish.
+// ---------------------------------------------------------------------------
+
+#ifndef SEV_PROBE_SKIP_REMOTE
+#define SEV_PROBE_SKIP_REMOTE 0
+#endif
+
+#define SEV_PROBE_REMOTE_LOCK_NUM 1
+static const uint SEV_PROBE_REMOTE_PAIRS = 2000;
+
+// runs on core 1
+void sev_probe_remote_traffic(void) {
+	// let core 0 reach its __wfe() first
+	busy_wait_at_least_cycles(SEV_PROBE_BACKSTOP_CYCLES / 4);
+	spin_lock_t *lock = spin_lock_instance(SEV_PROBE_REMOTE_LOCK_NUM);
+	for (uint i = 0; i < SEV_PROBE_REMOTE_PAIRS; i++) {
+		uint32_t save = spin_lock_blocking(lock);
+		spin_unlock(lock, save);
+	}
+	sev_probe_backstop_fired = true;
+	__mem_fence_release();
+	__sev();
+}
+
+// runs on core 1: the control, same shape with no lock traffic
+void sev_probe_remote_quiet(void) {
+	busy_wait_at_least_cycles(SEV_PROBE_BACKSTOP_CYCLES / 4);
+	busy_wait_at_least_cycles(SEV_PROBE_BACKSTOP_CYCLES);
+	sev_probe_backstop_fired = true;
+	__mem_fence_release();
+	__sev();
+}
+
+static bool sev_probe_remote_blocked(bool with_traffic) {
+	sev_probe_backstop_fired = false;
+	__mem_fence_release();
+	multicore_fifo_push_blocking((uintptr_t)(with_traffic ? sev_probe_remote_traffic
+	                                                     : sev_probe_remote_quiet));
+	// Take and release a lock of our own before waiting, exactly as every lock_core wait does.
+	// This matters: a cross-PE store can only clear a reservation we actually hold, and whether
+	// our own exclusive store left one behind is the implementation-defined part.
+	spin_lock_t *own = spin_lock_instance(SEV_PROBE_LOCK_NUM);
+	uint32_t save = spin_lock_blocking(own);
+	spin_unlock(own, save);
+
+	// clear our event flag, including any self-ping from the pair above
+	__sev();
+	__wfe();
+
+	__wfe();
+	__mem_fence_acquire();
+	bool blocked = sev_probe_backstop_fired;
+	(void)multicore_fifo_pop_blocking();
+	return blocked;
+}
+
+static bool sev_probe_remote_run(void) {
+	spin_lock_init(SEV_PROBE_LOCK_NUM);
+	spin_lock_init(SEV_PROBE_REMOTE_LOCK_NUM);
+	uint control_blocked = 0, traffic_blocked = 0;
+	for (uint i = 0; i < SEV_PROBE_ROUNDS; ++i) {
+		printf("  round %u: control...\n", i);
+		control_blocked += sev_probe_remote_blocked(false);
+		printf("  round %u: traffic...\n", i);
+		traffic_blocked += sev_probe_remote_blocked(true);
+	}
+	printf("control (core 1 quiet):        blocked %u/%u\n", control_blocked, SEV_PROBE_ROUNDS);
+	printf("probe   (core 1 lock traffic): blocked %u/%u\n", traffic_blocked, SEV_PROBE_ROUNDS);
+	if (control_blocked != SEV_PROBE_ROUNDS) {
+		printf("INCONCLUSIVE: a bare __wfe() did not always block even with core 1 quiet.\n");
+		return true;
+	}
+	const bool woken = traffic_blocked != SEV_PROBE_ROUNDS;
+	printf("observed: after using a spin lock itself, this core %s woken by another core's\n"
+		"  spin lock traffic, so a lock_core wait loop %s stay asleep while another core\n"
+		"  uses spin locks\n",
+		woken ? "IS" : "is NOT", woken ? "CANNOT" : "can");
+	printf("  note this is the composite of the access pattern and the hardware, not a\n"
+		"  statement about the part: a cross-core wake path may exist and simply not be\n"
+		"  reachable this way, e.g. where a core's own exclusive store has already cleared\n"
+		"  its reservation by the time it waits\n");
 	return true;
 }
 
@@ -298,7 +407,7 @@ int main() {
 	multicore_launch_core1(core1_main);
 	uint failed = 0;
 
-	printf(">>> Starting test: PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV probe (core 0)\n");
+	printf(">>> Starting test: PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT probe (core 0)\n");
 	spin_locks_reset();
 	if (sev_probe_run()) {
 		printf("OK.\n");
@@ -306,7 +415,19 @@ int main() {
 		printf("Failed.\n");
 		++failed;
 	}
-	printf(">>> Finished test: PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV probe\n");
+	printf(">>> Finished test: PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT probe\n");
+
+#if !SEV_PROBE_SKIP_REMOTE
+	printf(">>> Starting test: remote spin lock traffic probe (core 0)\n");
+	spin_locks_reset();
+	if (sev_probe_remote_run()) {
+		printf("OK.\n");
+	} else {
+		printf("Failed.\n");
+		++failed;
+	}
+	printf(">>> Finished test: remote spin lock traffic probe\n");
+#endif
 
 	for (int i = 0; i < count_of(tests); ++i) {
 		const test_t *t = &tests[i];

--- a/test/sync_interop_test/CMakeLists.txt
+++ b/test/sync_interop_test/CMakeLists.txt
@@ -31,7 +31,7 @@ function(add_interop_variant NAME)
 endfunction()
 
 # Every variant is built twice, following the pico_time_test/_sw convention. This matters a
-# great deal here: PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND only exists under software spin
+# great deal here: PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND only exists under software spin
 # locks (a hardware unlock is a plain SIO write and does not set the event), so a run that
 # does not pin this is testing whichever implementation the platform defaulted to.
 # Software spin locks need Armv8-M or RISC-V atomics, so there is no _sw twin on RP2040 -

--- a/test/sync_interop_test/interop_harness.c
+++ b/test/sync_interop_test/interop_harness.c
@@ -167,7 +167,25 @@ int harness_yield_pct(uint32_t spinner_delta, uint32_t window_ms) {
  * Hence the calibration runs on the agent core too, not here.
  */
 
-#ifdef __riscv
+/* Set where the part has no usable cycle counter at all. On RISC-V the counters are optional:
+ * an implementation may omit mcycle and mcountinhibit entirely, in which case both reading and
+ * enabling raise an illegal instruction (mcause 2), and there is no way to probe for them that
+ * does not itself fault. Nothing's verdict depends on the counter - it feeds D0's calibration
+ * and the occupancy figures - so its absence is reported, not failed. */
+#ifndef INTEROP_NO_CYCLE_COUNTER
+#define INTEROP_NO_CYCLE_COUNTER 0
+#endif
+
+#if INTEROP_NO_CYCLE_COUNTER
+#define HARNESS_HAS_CYCLE_COUNTER 0
+#define HARNESS_CYCLE_BITS 32
+uint32_t harness_cycles(void) { return 0; }
+static void cycles_enable(void) {}
+static uint32_t cycle_delta(uint32_t before, uint32_t after) { (void)before; (void)after; return 0; }
+uint32_t harness_sleep_counter(void) { return 0; }
+bool harness_sleep_counter_present(void) { return false; }
+
+#elif defined(__riscv)
 #define HARNESS_HAS_CYCLE_COUNTER 1
 #define HARNESS_CYCLE_BITS 32
 uint32_t harness_cycles(void) {
@@ -178,7 +196,9 @@ uint32_t harness_cycles(void) {
 static void cycles_enable(void) {
     /* mcycle does NOT run by default on Hazard3: RVCSR_MCOUNTINHIBIT resets to 0x5, i.e. the
      * CY (cycle) and IR (instret) inhibit bits are both set. Clear CY so mcycle advances,
-     * otherwise every reading is 0 and the calibration correctly declares it unusable. */
+     * otherwise every reading is 0 and the calibration correctly declares it unusable.
+     *
+     * Where this CSR is not implemented, use INTEROP_NO_CYCLE_COUNTER above. */
     __asm volatile ("csrci %0, %1" :: "i" (RVCSR_MCOUNTINHIBIT_OFFSET),
                                       "i" (RVCSR_MCOUNTINHIBIT_CY_BITS));
 }
@@ -282,6 +302,7 @@ void harness_set_agent_calibration(const harness_cal_t *cal) {
 }
 
 bool harness_agent_calibrated(void) { return agent_cal_valid; }
+bool harness_cycle_counter_present(void) { return HARNESS_HAS_CYCLE_COUNTER; }
 
 uint32_t harness_agent_dwt_ctrl(void) { return agent_cal.dwt_ctrl; }
 uint32_t harness_agent_demcr(void)    { return agent_cal.demcr; }

--- a/test/sync_interop_test/interop_harness.h
+++ b/test/sync_interop_test/interop_harness.h
@@ -101,6 +101,8 @@ uint32_t harness_cycles(void);
 /* 1 only where a DWT sleep counter exists at all; 0 elsewhere, where
  * harness_sleep_counter() is a constant 0. Should agree with the expectation above. */
 bool     harness_sleep_counter_present(void);
+/* false where the part has no usable cycle counter, so D0 reports rather than fails */
+bool     harness_cycle_counter_present(void);
 uint32_t harness_sleep_counter(void);
 /* 8-bit wrapping delta between two harness_sleep_counter() reads */
 uint32_t harness_sleep_delta(uint32_t before, uint32_t after);

--- a/test/sync_interop_test/interop_platform.c
+++ b/test/sync_interop_test/interop_platform.c
@@ -90,6 +90,13 @@ uint32_t counted_mutex_enter_block_until(mutex_t *mtx, absolute_time_t until,
     return interop_wakeups[get_core_num()];
 }
 
+uint32_t counted_sem_acquire_block_until(semaphore_t *sem, absolute_time_t until,
+                                                bool *acquired) {
+    interop_count_reset();
+    *acquired = sem_acquire_block_until(sem, until);
+    return interop_wakeups[get_core_num()];
+}
+
 #if INTEROP_HAS_SDK_CORE
 
 static struct {
@@ -129,6 +136,8 @@ static int64_t agent_stolen_far_alarm(__unused alarm_id_t id, __unused void *ud)
 
 static volatile bool agent_known_sleep_fired;
 
+static semaphore_t agent_done_sem;
+
 static int64_t agent_burst_alarm(__unused alarm_id_t id, __unused void *ud) {
     return 0;   /* never reached; the burst is cancelled long before it is due */
 }
@@ -140,6 +149,7 @@ static int64_t agent_known_sleep_alarm(__unused alarm_id_t id, __unused void *ud
 }
 
 static void sdk_core_agent(void) {
+    sem_init(&agent_done_sem, 0, 1);
     harness_cycles_enable_this_core();
     for (;;) {
         while (!agent.cmd) {
@@ -311,6 +321,15 @@ static void sdk_core_agent(void) {
                 result = (n == arg);
                 break;
             }
+            case AGENT_SEM_TIMED_COUNTED: {
+                /* A semaphore nobody ever releases, so this waits the deadline out. Local, so
+                 * it cannot be disturbed by the semaphore ops the other cases use. */
+                semaphore_t s;
+                sem_init(&s, 0, 1);
+                agent.wait_count = counted_sem_acquire_block_until(
+                        &s, make_timeout_time_ms(arg), &result);
+                break;
+            }
             case AGENT_SLEEP_MS:
                 sleep_ms(arg);
                 result = true;
@@ -410,6 +429,7 @@ static void sdk_core_agent(void) {
         agent.bool_result = result;
         agent.cmd = AGENT_IDLE;
         agent.done = true;
+        sem_release(&agent_done_sem);
         __sev();
     }
 }
@@ -427,6 +447,19 @@ void agent_start(uint32_t cmd, uint32_t arg) {
     __compiler_memory_barrier();
     agent.cmd = cmd;
     __sev();
+}
+
+/* Waits for the agent by blocking on a lock_core primitive rather than polling, so this core
+ * sits in a wait loop of its own while the agent works. That is pico_sync_test's arrangement
+ * and it is the one environment this suite otherwise never creates: with software spin locks
+ * each core's lock traffic can raise an event on the other, so two cores in wait loops can keep
+ * each other awake. Reset first, because the polling agent_wait() leaves permits behind. */
+bool agent_wait_blocking(uint32_t timeout_ms) {
+    return sem_acquire_block_until(&agent_done_sem, make_timeout_time_ms(timeout_ms));
+}
+
+void agent_wait_blocking_arm(void) {
+    sem_reset(&agent_done_sem, 0);
 }
 
 bool agent_wait(uint32_t timeout_ms) {

--- a/test/sync_interop_test/interop_platform.h
+++ b/test/sync_interop_test/interop_platform.h
@@ -97,6 +97,10 @@ void plat_hold_for_ms(uint32_t ms);
 uint32_t counted_mutex_enter_blocking(mutex_t *mtx);
 uint32_t counted_mutex_enter_block_until(mutex_t *mtx, absolute_time_t until, bool *acquired);
 
+/* The same for a semaphore with no permits available, which is a different call site in
+ * pico_sync even though it uses the same lock_core macro. */
+uint32_t counted_sem_acquire_block_until(semaphore_t *sem, absolute_time_t until, bool *acquired);
+
 /*
  * The same loop, but using the BARE `spin_unlock(); __wfe()` pattern instead of
  * lock_internal_spin_unlock_with_wait(). This is what the FreeRTOS ports hard-code on their
@@ -147,6 +151,8 @@ enum {
     AGENT_CANCEL_BURST,               /* add arg alarms and cancel them all as fast as possible,
                                        * so that several are marked before the pool's core gets
                                        * to scan them */
+    AGENT_SEM_TIMED_COUNTED,          /* timed acquire on a semaphore with no permits, so it
+                                       * waits the whole deadline out; arg = ms */
 };
 
 /* How many alarms AGENT_CANCEL_BURST adds and cancels per round, and how many rounds D2.15
@@ -186,6 +192,10 @@ enum {
 void     plat_sdk_core_hold_for_ms(uint32_t ms);
 void     agent_start(uint32_t cmd, uint32_t arg);
 bool     agent_wait(uint32_t timeout_ms);
+/* Wait for the agent by blocking on a semaphore instead of polling, so this core is itself in a
+ * lock_core wait while the agent runs. Call agent_wait_blocking_arm() before agent_start(). */
+void     agent_wait_blocking_arm(void);
+bool     agent_wait_blocking(uint32_t timeout_ms);
 bool     agent_run(uint32_t cmd, uint32_t arg, uint32_t timeout_ms);
 bool     agent_result(void);
 uint32_t agent_elapsed_us(void);

--- a/test/sync_interop_test/sync_interop_test.c
+++ b/test/sync_interop_test/sync_interop_test.c
@@ -90,16 +90,16 @@
 #define BUSY_POLL_VERDICT RESULT_FAIL
 
 /*
- * These must be resolved in the preprocessor, not in C: PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
- * is #defined *to* PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV, which is simply undefined when using
+ * These must be resolved in the preprocessor, not in C: PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
+ * is #defined *to* PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT, which is simply undefined when using
  * hardware spin locks. #if treats that as 0; C code would see an undeclared identifier.
  */
-#if PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV
+#if PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT
 #define INTEROP_UNLOCK_SEVS 1
 #else
 #define INTEROP_UNLOCK_SEVS 0
 #endif
-#if PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND
+#if PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
 #define INTEROP_WORKAROUND 1
 #else
 #define INTEROP_WORKAROUND 0
@@ -519,6 +519,13 @@ static void d0_counter_selftest(void) {
         return;
     }
 
+    if (!harness_cycle_counter_present()) {
+        /* Not a failure: the part has no usable cycle counter, so there is nothing to
+         * calibrate. Occupancy figures are simply absent from the other cases. */
+        harness_record("D0", RESULT_SKIP, "no cycle counter on this platform");
+        return;
+    }
+
     /* 1. the cycle counter must actually count, at roughly clk_sys */
     uint32_t expected = (uint32_t)(clock_get_hz(clk_sys) / 1000000u);
     uint32_t actual = harness_cal_cycles_per_us();
@@ -608,7 +615,7 @@ static void d1_9_bare_wfe_pattern(void) {
                        expect_poll ? "busy-polls" : "blocks", waits, sc_note);
     } else {
         harness_record("D1.9", RESULT_FAIL,
-                       "bare pattern %s (%u iterations) but PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV"
+                       "bare pattern %s (%u iterations) but PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT"
                        " predicts it would %s", polled ? "busy-polled" : "blocked", waits,
                        expect_poll ? "busy-poll" : "block");
     }
@@ -826,7 +833,7 @@ static void d2_13_sustained_interference(void) {
      * Every fire wakes the waiter, so one iteration per fire is the floor for any
      * implementation. What differs is whether the waiter must also re-add its own alarm each
      * time coverage lapses: on a build where a spin unlock sets the calling core's own event
-     * (PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV), the __wfe() after an add is eaten immediately, so an
+     * (PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT), the __wfe() after an add is eaten immediately, so an
      * add costs an EXTRA pass that does not sleep. So ~1x fires means the waiter kept its own
      * coverage; ~2x means it is re-adding on every lapse.
      *
@@ -1555,6 +1562,10 @@ static void d2_3_contended_times_out(void) {
                        lat.early);
     } else if (lat.max_us > 5000) {
         harness_record("D2.3", RESULT_FAIL, "timeout overshot by %lldus", (long long)lat.max_us);
+    } else if (worst_waits == 0) {
+        harness_record("D2.3", RESULT_FAIL,
+                       "no waits recorded - it never blocked, or the wakeup hook is not"
+                       " reaching pico_sync");
     } else if (worst_waits > MAX_BLOCKING_WAITS) {
         harness_record("D2.3", BUSY_POLL_VERDICT,
                        "timeout accurate (max %lldus) but busy-polled: %u wait iterations",
@@ -1669,6 +1680,10 @@ static void d2_7_sdk_core_timed(void) {
     } else if (us < (uint32_t)TIMEOUT_MS * 1000) {
         harness_record("D2.7", RESULT_FAIL, "timed out EARLY after %uus (deadline %dms)",
                        us, TIMEOUT_MS);
+    } else if (waits == 0) {
+        harness_record("D2.7", RESULT_FAIL,
+                       "no waits recorded - it never blocked, or the wakeup hook is not"
+                       " reaching pico_sync");
     } else if (waits > MAX_BLOCKING_WAITS) {
         harness_record("D2.7", BUSY_POLL_VERDICT,
                        "timed out at %uus but busy-polled: %u wait iterations", us, waits);
@@ -1677,6 +1692,80 @@ static void d2_7_sdk_core_timed(void) {
         if (occ >= 0) snprintf(occ_note, sizeof(occ_note), ", %d%% occupancy", occ);
         harness_record("D2.7", RESULT_PASS, "timed out at %uus, %u wait iterations%s",
                        us, waits, occ_note);
+    }
+#endif
+}
+
+/* D2.16 - a timed acquire on a semaphore with no permits, on the bare-SDK core.
+ *
+ * D2.7 is the same experiment on a mutex. Both reach the same lock_core macro, but they are
+ * different call sites in pico_sync, and sem_acquire_block_until() alone carries the `waited`
+ * flag and lock_internal_spin_unlock_maybe_notify(). This is the shape pico_sync_test's
+ * "wait loop with timeout" section uses, which this suite otherwise never exercised.
+ */
+static void d2_16_sdk_core_sem_timed(void) {
+#if !INTEROP_HAS_SDK_CORE
+    harness_record("D2.16", RESULT_SKIP, "no bare-SDK core in this configuration");
+#else
+    if (!agent_run(AGENT_SEM_TIMED_COUNTED, TIMEOUT_MS, TIMEOUT_MS * 4)) {
+        harness_record("D2.16", RESULT_FAIL, "timed acquire on the other core never returned");
+        return;
+    }
+    const uint32_t us = agent_elapsed_us();
+    const uint32_t waits = agent_wait_count();
+    if (agent_result()) {
+        harness_record("D2.16", RESULT_FAIL, "acquired a semaphore that has no permits");
+    } else if (us < (uint32_t)TIMEOUT_MS * 1000) {
+        harness_record("D2.16", RESULT_FAIL, "timed out EARLY after %uus (deadline %dms)",
+                       us, TIMEOUT_MS);
+    } else if (waits == 0) {
+        harness_record("D2.16", RESULT_FAIL,
+                       "no waits recorded - it never blocked, or the wakeup hook is not"
+                       " reaching pico_sync");
+    } else if (waits > MAX_BLOCKING_WAITS) {
+        harness_record("D2.16", BUSY_POLL_VERDICT,
+                       "timed out at %uus but busy-polled: %u wait iterations", us, waits);
+    } else {
+        harness_record("D2.16", RESULT_PASS, "timed out at %uus, %u wait iterations", us, waits);
+    }
+#endif
+}
+
+/* D2.17 - the agent does D2.16's timed wait while THIS core is blocked in a lock_core wait of
+ * its own, rather than polling. That is pico_sync_test's arrangement, and the one environment
+ * this suite otherwise never creates: every other case leaves the test core spinning on a plain
+ * flag, so only one core is ever in a wait loop. With software spin locks two cores in wait
+ * loops can keep each other awake, which is invisible to every other case here.
+ */
+static void d2_17_both_cores_waiting(void) {
+#if !INTEROP_HAS_SDK_CORE
+    harness_record("D2.17", RESULT_SKIP, "no bare-SDK core in this configuration");
+#else
+    agent_wait_blocking_arm();
+    agent_start(AGENT_SEM_TIMED_COUNTED, TIMEOUT_MS);
+    if (!agent_wait_blocking(TIMEOUT_MS * 4)) {
+        harness_record("D2.17", RESULT_FAIL, "agent never finished while this core blocked");
+        return;
+    }
+    const uint32_t us = agent_elapsed_us();
+    const uint32_t waits = agent_wait_count();
+    if (agent_result()) {
+        harness_record("D2.17", RESULT_FAIL, "acquired a semaphore that has no permits");
+    } else if (us < (uint32_t)TIMEOUT_MS * 1000) {
+        harness_record("D2.17", RESULT_FAIL, "timed out EARLY after %uus (deadline %dms)",
+                       us, TIMEOUT_MS);
+    } else if (waits == 0) {
+        harness_record("D2.17", RESULT_FAIL,
+                       "no waits recorded - it never blocked, or the wakeup hook is not"
+                       " reaching pico_sync");
+    } else if (waits > MAX_BLOCKING_WAITS) {
+        harness_record("D2.17", BUSY_POLL_VERDICT,
+                       "timed out at %uus but busy-polled while this core also waited:"
+                       " %u wait iterations", us, waits);
+    } else {
+        harness_record("D2.17", RESULT_PASS,
+                       "timed out at %uus, %u wait iterations with both cores waiting",
+                       us, waits);
     }
 #endif
 }
@@ -1801,6 +1890,8 @@ static void test_body(void) {
     d2_13_sustained_interference();
     d2_14_far_alarm_only();
     d2_15_cancel_burst();
+    d2_16_sdk_core_sem_timed();
+    d2_17_both_cores_waiting();
 
     printf("\n--- D3: sleep_ms / sleep_until (ms-scale, concurrent, cross-core) ---\n");
     d3_1_sleep_accuracy_ms();

--- a/test/sync_interop_test/sync_interop_test.c
+++ b/test/sync_interop_test/sync_interop_test.c
@@ -89,15 +89,12 @@
  */
 #define BUSY_POLL_VERDICT RESULT_FAIL
 
-/*
- * These must be resolved in the preprocessor, not in C: PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
- * is #defined *to* PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT, which is simply undefined when using
- * hardware spin locks. #if treats that as 0; C code would see an undeclared identifier.
- */
-#if PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT
-#define INTEROP_UNLOCK_SEVS 1
+/* Resolved in the preprocessor as these macros are undefined on platforms without the behaviour.
+ * Only a software spin lock unlocks with an exclusive access, so both terms are needed. */
+#if PICO_USE_SW_SPIN_LOCKS && PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT
+#define INTEROP_SPIN_UNLOCK_SETS_OWN_EVENT 1
 #else
-#define INTEROP_UNLOCK_SEVS 0
+#define INTEROP_SPIN_UNLOCK_SETS_OWN_EVENT 0
 #endif
 #if PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND
 #define INTEROP_WORKAROUND 1
@@ -604,7 +601,7 @@ static void d1_9_bare_wfe_pattern(void) {
                  agent_inline_sleep_delta());
     }
 
-    const bool expect_poll = INTEROP_UNLOCK_SEVS;
+    const bool expect_poll = INTEROP_SPIN_UNLOCK_SETS_OWN_EVENT;
     if (polled == expect_poll) {
         /* PASS either way: this case is a control, and confirming its prediction is a
          * success whichever way the prediction went. It is not an expected *failure* - the
@@ -615,7 +612,7 @@ static void d1_9_bare_wfe_pattern(void) {
                        expect_poll ? "busy-polls" : "blocks", waits, sc_note);
     } else {
         harness_record("D1.9", RESULT_FAIL,
-                       "bare pattern %s (%u iterations) but PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT"
+                       "bare pattern %s (%u iterations) but this spin lock configuration"
                        " predicts it would %s", polled ? "busy-polled" : "blocked", waits,
                        expect_poll ? "busy-poll" : "block");
     }
@@ -1828,9 +1825,9 @@ static void test_body(void) {
 #endif
     printf("platform: %s\n", PICO_PLATFORM_STRING);
     printf("config: %s\n", plat_config_name());
-    printf("spin locks: %s, unlock %s the event\n",
+    printf("spin locks: %s, unlock %s the calling core's own event\n",
            PICO_USE_SW_SPIN_LOCKS ? "software" : "hardware",
-           INTEROP_UNLOCK_SEVS ? "sets" : "does not set");
+           INTEROP_SPIN_UNLOCK_SETS_OWN_EVENT ? "sets" : "does not set");
     if (INTEROP_LOCK_MACROS_OVERRIDDEN) {
         /* Say this plainly: it means the SDK's WFE machinery, workaround and all, is not the
          * code under test here - the RTOS port's event-group implementation is. */


### PR DESCRIPTION
* Rename `PICO_SPIN_LOCK_UNLOCK_CAUSES_SEV` to `PICO_EXCLUSIVE_ACCESS_SETS_OWN_EVENT`
* Rename `PICO_SYNC_RP2350_SPIN_LOCK_WORKAROUND` to `PICO_SYNC_EXCLUSIVE_ACCESS_EVENT_WORKAROUND`
* Add some more sync tests
