### PR TITLE
Fix \param names in interp_get_base and riscv_timer_set_mtimecmp

### DIFF
--- a/src/rp2_common/hardware_interp/include/hardware/interp.h
+++ b/src/rp2_common/hardware_interp/include/hardware/interp.h
@@ -358,7 +358,7 @@ static inline void interp_set_base(interp_hw_t *interp, uint index, uint32_t val
  *  \ingroup hardware_interp
  *
  * \param interp Interpolator instance, interp0 or interp1.
- * \param lane The base register index, 0 or 1 or 2
+ * \param index The base register index, 0 or 1 or 2
  * \return  The current content of the base register
  */
 static inline uint32_t interp_get_base(interp_hw_t *interp, uint index) {

--- a/src/rp2_common/hardware_riscv_platform_timer/include/hardware/riscv_platform_timer.h
+++ b/src/rp2_common/hardware_riscv_platform_timer/include/hardware/riscv_platform_timer.h
@@ -125,7 +125,7 @@ static inline uint64_t riscv_timer_get_mtimecmp(void) {
  * mtime value (stored in 32-bit mtime/mtimeh registers) is greater than or
  * equal to this core's current mtime/mtimecmph value.
  *
- * \param mtime New value to set the RISC-V platform timer to
+ * \param mtimecmp New value to set the RISC-V platform timer to
  */
 static inline void riscv_timer_set_mtimecmp(uint64_t mtimecmp) {
     // Use write procedure from RISC-V ISA manual to avoid causing a spurious


### PR DESCRIPTION
Was checking doxygen output on the interp and riscv timer headers and hit two \param names that don't match the argument below them. interp_get_base documents `lane`, which looks copied from interp_set_base just above it, and riscv_timer_set_mtimecmp documents `mtime` from its neighbour. Doxygen drops unmatched names quietly so the build stays green either way. I left the mtimecmp wording alone, it still reads as if the call sets mtime and that seemed like your call.
