### PR TITLE
temp workaround for failed build with no PICO_DEFAULT_UART

### DIFF
--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -172,7 +172,7 @@ static void replace_null_enable_values(const clock_dest_bitset_t *keep_enabled,
     }
 }
 
-static void add_library_clocks(clock_dest_bitset_t *local_keep_enabled) {
+static void add_library_clocks(__unused clock_dest_bitset_t *local_keep_enabled) {
 #if LIB_PICO_STDIO_USB || LIB_TINYUSB_HOST || LIB_TINYUSB_DEVICE
     // this is necessary to prevent dropping the connection
     #if PICO_RP2040

--- a/src/rp2_common/pico_low_power/low_power.c
+++ b/src/rp2_common/pico_low_power/low_power.c
@@ -186,7 +186,7 @@ static void add_library_clocks(clock_dest_bitset_t *local_keep_enabled) {
     #endif
 #endif
 
-#if LIB_PICO_STDIO_UART
+#if LIB_PICO_STDIO_UART && defined(PICO_DEFAULT_UART)
     // this is only needed to prevent losing stdin while sleeping
     clock_dest_bitset_add(local_keep_enabled, PICO_DEFAULT_UART ? CLK_DEST_PERI_UART1 : CLK_DEST_PERI_UART0);
     clock_dest_bitset_add(local_keep_enabled, PICO_DEFAULT_UART ? CLK_DEST_SYS_UART1 : CLK_DEST_SYS_UART0);


### PR DESCRIPTION
Fix broken build when there is no PICO_DEFAULT_UART... note this is a band-aid fix; opening .. #3172 to track 