### PR TITLE
sha256: don't truncate the padded bit length to 32 bits

### DIFF
--- a/src/rp2_common/pico_sha256/sha256.c
+++ b/src/rp2_common/pico_sha256/sha256.c
@@ -170,7 +170,7 @@ static void write_padding(pico_sha256_state_t *state) {
     add_zero_bytes(state, padding_size_bytes - SHA256_PADDING_DATA_BYTES);
 
     // Add size in bits, big endian
-    size = __builtin_bswap64(user_data_size * 8);
+    size = __builtin_bswap64((uint64_t)user_data_size * 8);
     update_internal(state, (uint8_t*)&size, sizeof(uint64_t)); // last write
 }
 


### PR DESCRIPTION
user_data_size is size_t, so user_data_size * 8 wraps at 512 MiB and the message length appended to the final block is wrong.

Fixes #3176