### PR TITLE
Fix #3181 (Do not include <cassert>)

### DIFF
--- a/src/common/pico_base_headers/include/pico/assert.h
+++ b/src/common/pico_base_headers/include/pico/assert.h
@@ -10,13 +10,10 @@
 #include <stdbool.h>
 
 #ifdef __cplusplus
-
-#include <cassert>
-
 extern "C" {
-#else
-#include <assert.h>
 #endif
+
+#include <assert.h>
 
 // PICO_CONFIG: PARAM_ASSERTIONS_ENABLE_ALL, Global assert enable, type=bool, default=0, group=pico_base
 // PICO_CONFIG: PARAM_ASSERTIONS_DISABLE_ALL, Global assert disable, type=bool, default=0, group=pico_base


### PR DESCRIPTION
Fixes [Issue #3181](https://github.com/raspberrypi/pico-sdk/issues/3181).

This pull request removes `#include <cassert.h>`, so the only thing in the `#ifdef _cplusplus`
block is `extern C {`.

This code change removes the error I get when trying to use clangd with pico-sdk and C++.